### PR TITLE
Ignore eMMC HW level partitions

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -654,6 +654,10 @@ class DeviceTree(object):
         if name.startswith("mtd"):
             return True
 
+        # These eMMC HW-level partitions aren't intended for generic user data
+        if re.match("mmcblk\d+(boot\d+|rpmb)", name):
+            return True
+
         if name.startswith("loop"):
             # ignore loop devices unless they're backed by a file
             return (not loop.get_backing_file(name))


### PR DESCRIPTION
eMMC devices often have dedicated HW-level partitions intended for
storing bootloader and other system-level data. These partitions aren't
intended to store generic end-user data or filesystems. Besides, they are
typically tiny (e.g. 512KB-4MB). These show up as separate block devices
under Linux, with names such as mmcblk0boot0, mmcblk0boot1, and
mmcblk0rpmb.

Blivet usually ends up ignoring the boot[01] devices, since the kernel
markes them as r/o by default, although the user can make them r/w by
writing to a sysfs file.

The RPMB device is not r/o by default, and so is not ignored. This leads
to it showing up as a potential install target in Anaconda.

Explicitly ignore all of these devices so that users aren't tempted to
use them.
