### PR TITLE
Make sure /boot/efi is metadata 1.0 if it's on mdraid.

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -212,6 +212,7 @@ class EFI(Platform):
     _boot_stage1_device_types = ["partition", "mdarray"]
     _boot_stage1_mountpoints = ["/boot/efi"]
     _boot_stage1_raid_levels = [devicelibs.raid.RAID1]
+    _boot_stage1_raid_metadata = ["1.0"]
     _boot_efi_description = N_("EFI System Partition")
     _boot_descriptions = {"partition": _boot_efi_description,
                           "mdarray": Platform._boot_raid_description}


### PR DESCRIPTION
This makes sure the metadata is at the end of the filesystem, so a naive
codebase that doesn't know about RAID can still successfully read the
filesystem.

Note that we're not protecting against any type of writes from UEFI or
other OSes.  Don't do that.

In general:
1) grub running from uefi should know about raid and try to access ESP
   as a raid volume
2) if you're dual booting with some other linux, it's going to know about
   raid metadata, and we're fine
3) if you're dual booting with windows or macos, ESP won't be raid if it
   already exists
4) if it doesn't already exist and you create it as mdraid and try to
   share, it with windows or macos, you're going to have quite a bad
   day sometime down the road.  Don't do that.  But also: that's something
   the user has done in another OS after requesting for us to do something
   that doesn't work with that.  That's not our problem.

Note that it's probably still better to make /boot/efi use dmraid disks
than to do any of this.

Resolves: rhbz#788313
Signed-off-by: Peter Jones pjones@redhat.com
