### PR TITLE
Remove build requires for pocketlint

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -12,7 +12,6 @@ Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
 %define pykickstartver 1.99.22
-%define pocketlintver 0.4
 %define partedver 1.8.1
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
@@ -22,7 +21,6 @@ Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
 BuildArch: noarch
 BuildRequires: gettext
 BuildRequires: python2-devel python2-setuptools
-BuildRequires: python3-pocketlint >= %{pocketlintver}
 BuildRequires: python3-devel python3-setuptools
 
 Requires: python


### PR DESCRIPTION
Listing python3-pocketlint as a BuildRequires is
redundant as it is used during the rpm build.
