### PR TITLE
edd_test: don't run on non-x86

### DIFF
--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -28,6 +28,8 @@ class FakeEddEntry(edd.EddEntry):
     def __repr__(self):
         return "<FakeEddEntry%s>" % (self._fmt(' ', ''),)
 
+@unittest.skipUnless(os.uname().machine in ['i386','i686','x86_64'],
+                     reason='incompatible arch')
 class EddTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwds):


### PR DESCRIPTION
Since this doesn't make any sense on non-x86 machines anyway, and
apparently I've got some endian bugs in it (which don't really
matter...), just don't run the edd tests on non-x86.

Signed-off-by: Peter Jones pjones@redhat.com
