### PR TITLE
Make use of the new info provided for LVs

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -942,38 +942,18 @@ class LVMInternalLVtype(Enum):
     unknown = 99
 
     @classmethod
-    def get_type(cls, lv_attr, lv_name):  # pylint: disable=unused-argument
-        attr_letters = {cls.data: ("T", "C"),
-                        cls.meta: ("e",),
-                        cls.log: ("l", "L"),
-                        cls.image: ("i",),
-                        cls.origin: ("o",),
-                        cls.cache_pool: ("C",)}
-
-        if lv_attr[0] == "C":
-            # cache pools and internal data LV of cache pools need a more complicated check
-            if lv_attr[6] == "C":
-                # target type == cache -> cache pool
-                return cls.cache_pool
-            else:
-                return cls.data
-
-        if lv_attr[0] == "r":
-            # internal LV which is at the same time a RAID LV
-            if lv_attr[6] == "C":
-                # part of the cache -> cache origin
-                # (cache pool cannot be a RAID LV, cache pool's data LV would
-                # have lv_attr[0] == "C", metadata LV would have
-                # lv_attr[0] == "e" even if they were RAID LVs)
-                return cls.origin
-            elif lv_attr[6] == "r":
-                # a data LV (metadata LV would have lv_attr[0] == "e")
-                return cls.data
-
-        for lv_type, letters in attr_letters.items():
-            if lv_attr[0] in letters:
-                return lv_type
-
+    def get_type(cls, lv_roles):
+        type_roles = {
+            cls.data: ["data"],
+            cls.meta: ["metadata"],
+            cls.log: ["log"],
+            cls.image: ["image"],
+            cls.origin: ["origin"],
+            cls.cache_pool: ["cache", "pool"]
+        }
+        for int_type, roles in type_roles.items():
+            if all(role in lv_roles for role in roles):
+                return int_type
         return cls.unknown
 
 

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -339,7 +339,7 @@ class LVMFormatPopulator(FormatPopulator):
 
         # assign parents to internal LVs (and vice versa)
         for lv in orphan_lvs.values():
-            parent_lv = lvm.determine_parent_lv(vg_name, lv, all_lvs)
+            parent_lv = lvm.determine_parent_lv(lv, all_lvs, lv_info)
             if parent_lv:
                 lv.parent_lv = parent_lv
             else:

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -288,7 +288,7 @@ class LVMFormatPopulator(FormatPopulator):
             lv_size = Size(lv.size)
             seg_type = lv.segtype
 
-            lv_type = LVMInternalLVtype.get_type(lv_attr, lv_name)
+            lv_type = LVMInternalLVtype.get_type(lv.roles.split(","))
             if lv_type is LVMInternalLVtype.unknown:
                 raise DeviceTreeError("Internal LVs of type '%s' are not supported" % lv_attr[0])
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,7 +21,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 1.4
+%define libblockdevver 1.7
 %define libbytesizever 0.3
 %define pyudevver 0.18
 


### PR DESCRIPTION
To speed things up by not doing extra calls to libblockdev and to make things more reliable by using better source of information.
