### PR TITLE
Consider non-efi AARCH64 machine to behave like am ARM machine

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -468,6 +468,8 @@ def get_platform():
             return omapARM()
         else:
             return ARM()
+    elif arch.is_aarch64():
+        return ARM()
     else:
         raise SystemError("Could not determine system architecture.")
 


### PR DESCRIPTION
If an non-efi AARCH64 machine le booted, the system architecture fails to be determined.

Consider a non-efi AARCH64 to be like a non-efi ARM machine.