### PR TITLE
Add a call to wipefs before mkswap

### DIFF
--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -167,6 +167,7 @@ class SwapSpace(DeviceFormat):
     def _create(self, **kwargs):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
+        blockdev.swap.wipefs(self.device)
         blockdev.swap.mkswap(self.device, label=self.label)
 
 register_device_format(SwapSpace)


### PR DESCRIPTION
Mkswap leaves the FS signatures at the end of the partition around which
confuses a ton of tools. We should wipe that out first.

Depends on https://github.com/rhinstaller/libblockdev/pull/163

NOTE: not tested yet, sending for comments.