### PR TITLE
Do not use package version to check version of installed tools

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -47,7 +47,6 @@ Requires: libblockdev-plugins-all >= %{libblockdevver}
 Requires: python3-bytesize >= %{libbytesizever}
 Requires: util-linux >= %{utillinuxver}
 Requires: lsof
-Requires: python3-hawkey
 Requires: python3-gobject-base
 Requires: systemd-udev
 Obsoletes: blivet-data < 1:2.0.3

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -10,7 +10,7 @@ class BlivetLintConfig(PocketLintConfig):
     def __init__(self):
         PocketLintConfig.__init__(self)
 
-        self.falsePositives = [FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
+        self.falsePositives = [FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|Utils|G)Error$"),
                                FalsePositive(r"Instance of 'int' has no .* member"),
                                FalsePositive(r"Method 'do_task' is abstract in class 'Task' but is not overridden"),
                                FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),


### PR DESCRIPTION
Just run the tool with "--version" (or similar) option to get its
version. Querying RPM database to get version of installed package
makes blivet impossible to use on other distributions than Fedora.