### PR TITLE
Update the upstream git URL

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -6,7 +6,7 @@ Contributor's Guide
 
 Where the Code Lives
 ---------------------
-The upstream git repo is on `GitHub <https://github.com/rhinstaller/blivet>`_.
+The upstream git repo is on `GitHub <https://github.com/storaged-project/blivet>`_.
 
 Branching Model
 ----------------

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -1,6 +1,6 @@
 Summary:  A python module for system storage configuration
 Name: python-blivet
-Url: http://fedoraproject.org/wiki/blivet
+Url: https://www-rhstorage.rhcloud.com/projects/blivet
 Version: 2.0.2
 
 #%%global prerelease .b1
@@ -11,7 +11,7 @@ License: LGPLv2+
 Group: System Environment/Libraries
 %global realname blivet
 %global realversion %{version}%{?prerelease}
-Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}.tar.gz
+Source0: http://github.com/storaged-project/blivet/archive/%{realname}-%{realversion}.tar.gz
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,6 @@ setup(name='blivet', version='2.0.2',
       cmdclass={"sdist": blivet_sdist},
       description='Python module for system storage configuration',
       author='David Lehman', author_email='dlehman@redhat.com',
-      url='http://github.com/rhinstaller/blivet',
+      url='http://github.com/storaged-project/blivet',
       data_files=data_files,
       packages=['blivet', 'blivet.devices', 'blivet.devicelibs', 'blivet.events', 'blivet.formats', 'blivet.populator', 'blivet.static_data', 'blivet.tasks', 'blivet.populator.helpers'])


### PR DESCRIPTION
blivet has been moved under the storaged-project organization at
GitHub.

Also update the URL of the project pages.