### PR TITLE
Skip tests when SELinux is disabled

### DIFF
--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -13,6 +13,8 @@ class SELinuxContextTestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        if not blivet.flags.selinux:
+            self.skipTest("SELinux disabled.")
         self.installer_mode = blivet.flags.installer_mode
         super(SELinuxContextTestCase, self).setUp()
 


### PR DESCRIPTION
SELinux tests no longer fail when SeLinux is disabled.
Instead they are skipped.