### PR TITLE
No longer skip test w/o selinux; mocked

### DIFF
--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -13,8 +13,6 @@ class SELinuxContextTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-        if not blivet.flags.selinux:
-            self.skipTest("SELinux disabled.")
         self.installer_mode = blivet.flags.installer_mode
         super(SELinuxContextTestCase, self).setUp()
 


### PR DESCRIPTION
Rather than skiping the test, parts of it that need selinux were mocked