### PR TITLE
Use addCleanup for test cleanup instead of clening in tearDown

### DIFF
--- a/tests/clearpart_test.py
+++ b/tests/clearpart_test.py
@@ -17,6 +17,10 @@ class ClearPartTestCase(unittest.TestCase):
 
     def setUp(self):
         flags.testing = True
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
+        flags.testing = False
 
     def test_should_clear(self):
         """ Test the Blivet.should_clear method. """
@@ -193,9 +197,6 @@ class ClearPartTestCase(unittest.TestCase):
         # clearpart type list
         #
         # TODO
-
-    def tearDown(self):
-        flags.testing = False
 
     def test_initialize_disk(self):
         """

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -74,12 +74,13 @@ class EddTestCase(unittest.TestCase):
                                  side_effect=self._edd_logger.error)
         edd.log = newlog
 
-    def tearDown(self):
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
         edd.log = self._edd_logger
         edd.log.setLevel(self._edd_logger_level)
         edd.log.removeHandler(self.log_handler)
         edd.testdata_log.removeHandler(self.td_log_handler)
-        super(EddTestCase, self).tearDown()
 
     def check_logs(self, debugs=None, infos=None, warnings=None, errors=None):
         def check(left, right_object):

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -55,6 +55,8 @@ class MockingDeviceDependenciesTestCase1(unittest.TestCase):
         self.dm_method = availability.BLOCKDEV_DM_PLUGIN._method
         self.cache_availability = availability.CACHE_AVAILABILITY
 
+        self.addCleanup(self._clean_up)
+
     def test_availability_mdraidplugin(self):
 
         availability.CACHE_AVAILABILITY = False
@@ -84,7 +86,7 @@ class MockingDeviceDependenciesTestCase1(unittest.TestCase):
         with self.assertRaises(ValueError):
             ActionDestroyFormat(self.dev)
 
-    def tearDown(self):
+    def _clean_up(self):
         availability.BLOCKDEV_MDRAID_PLUGIN._method = self.mdraid_method
         availability.BLOCKDEV_DM_PLUGIN._method = self.dm_method
 

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -154,6 +154,8 @@ class MDRaidArrayDeviceTestCase(DeviceStateTestCase):
         self.get_superblock_size = MDRaidArrayDevice.get_superblock_size
         MDRaidArrayDevice.get_superblock_size = lambda a, s: Size(0)
 
+        self.addCleanup(self._clean_up)
+
         parents = [
             DiskDevice("name1", fmt=get_format("mdmember"))
         ]
@@ -358,7 +360,7 @@ class MDRaidArrayDeviceTestCase(DeviceStateTestCase):
             uuid='Just-pretending'
         )
 
-    def tearDown(self):
+    def _clean_up(self):
         mdraid.MD_CHUNK_SIZE = self.md_chunk_size
         MDRaidArrayDevice.get_superblock_size = self.get_superblock_size
 

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -399,20 +399,6 @@ class BlivetResetTestCase(ImageBackedTestCase):
         self.device_attr_dicts = []
         self.collect_expected_data()
 
-    def tearDown(self):
-        """ Clean up after testing is complete. """
-        super(BlivetResetTestCase, self).tearDown()
-
-        # XXX The only reason for this may be lvmetad
-        for disk in self.blivet.disks:
-            self.blivet.recursive_remove(disk)
-
-        try:
-            self.blivet.do_it()
-        except Exception:
-            self.blivet.reset()
-            raise
-
     def skip_attr(self, device, attr):
         """ Return True if attr should not be checked for device. """
         # pylint: disable=unused-argument

--- a/tests/formats_test/fs_test.py
+++ b/tests/formats_test/fs_test.py
@@ -144,6 +144,7 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.mountpoint = tempfile.mkdtemp()
         self.an_fs.mountpoint = self.mountpoint
         self.an_fs.mount()
+        self.addCleanup(self._clean_up)
 
     def test_resize(self):
         self.an_fs.update_size_info()
@@ -160,7 +161,7 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
         with self.assertRaises(ValueError):
             self.an_fs.target_size = newsize
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             self.an_fs.unmount()
         except Exception:  # pylint: disable=broad-except

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -20,6 +20,7 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         # create and open the luks format
         self.fmt.create()
         self.fmt.setup()
+        self.addCleanup(self._luks_close)
 
         # without update_size_info size should be 0
         self.assertEqual(self.fmt.current_size, Size(0))
@@ -34,6 +35,7 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         # create and open the luks format
         self.fmt.create()
         self.fmt.setup()
+        self.addCleanup(self._luks_close)
 
         # get current size to make format resizable
         self.assertFalse(self.fmt.resizable)
@@ -49,9 +51,8 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.fmt.update_size_info()
         self.assertEqual(self.fmt.current_size, new_size)
 
-    def tearDown(self):
+    def _luks_close(self):
         self.fmt.teardown()
-        super(LUKSTestCase, self).tearDown()
 
 
 class LUKSNodevTestCase(unittest.TestCase):

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -14,7 +14,10 @@ class SELinuxContextTestCase(unittest.TestCase):
 
     def setUp(self):
         self.installer_mode = blivet.flags.installer_mode
-        super(SELinuxContextTestCase, self).setUp()
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
+        blivet.flags.installer_mode = self.installer_mode
 
     @patch("blivet.util.mount", return_value=0)
     @patch.object(fs.FS, "_pre_setup", return_value=True)
@@ -48,7 +51,3 @@ class SELinuxContextTestCase(unittest.TestCase):
     def test_mount_selinux_xfs(self):
         """ Test of correct selinux context parameter value when mounting XFS"""
         self.exec_mount_selinux_format(fs.XFS)
-
-    def tearDown(self):
-        super(SELinuxContextTestCase, self).tearDown()
-        blivet.flags.installer_mode = self.installer_mode

--- a/tests/imagebackedtestcase.py
+++ b/tests/imagebackedtestcase.py
@@ -102,6 +102,17 @@ class ImageBackedTestCase(unittest.TestCase):
 
     def _clean_up(self):
         """ Clean up any resources that may have been set up for a test. """
+
+        # XXX The only reason for this may be lvmetad
+        for disk in self.blivet.disks:
+            self.blivet.recursive_remove(disk)
+
+        try:
+            self.blivet.do_it()
+        except Exception:
+            self.blivet.reset()
+            raise
+
         self.blivet.reset()
         self.blivet.devicetree.teardown_disk_images()
         for fn in self.blivet.config.disk_images.values():

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -52,6 +52,7 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
 
         # at this point the DMLinearDevice has correct size
         self.blivet.setup_disk_images()
+        self.addCleanup(self._clean_up)
 
         # emulates setting the anaconda flags which later update
         # blivet flags as the first thing to do in storage_initialize
@@ -65,7 +66,7 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         with patch('blivet.osinstall.flags'):
             storage_initialize(self.blivet, ksdata, [])
 
-    def tearDown(self):
+    def _clean_up(self):
         self.blivet.reset()
         self.blivet.devicetree.teardown_disk_images()
         for fn in self.blivet.config.disk_images.values():

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -232,8 +232,9 @@ class TranslationTestCase(unittest.TestCase):
 
     def setUp(self):
         self.saved_lang = os.environ.get('LANG', None)
+        self.addCleanup(self._clean_up)
 
-    def tearDown(self):
+    def _clean_up(self):
         os.environ['LANG'] = self.saved_lang
         locale.setlocale(locale.LC_ALL, '')
 

--- a/tests/storagetestcase.py
+++ b/tests/storagetestcase.py
@@ -52,6 +52,8 @@ class StorageTestCase(unittest.TestCase):
         blivet.devices.PartitionDevice.max_size = StorageDevice.max_size
         blivet.devices.PartitionDevice.min_size = StorageDevice.min_size
 
+        self.addCleanup(self._clean_up)
+
         def partition_probe(device):
             if isinstance(device._parted_partition, Mock):
                 # don't clobber a Mock we already set up here
@@ -74,7 +76,7 @@ class StorageTestCase(unittest.TestCase):
         self.get_active_mounts = blivet.formats.fs.mounts_cache._get_active_mounts
         blivet.formats.fs.mounts_cache._get_active_mounts = Mock()
 
-    def tearDown(self):
+    def _clean_up(self):
         blivet.devices.StorageDevice.status = self.storage_status
         blivet.devices.DMDevice.status = self.dm_status
         blivet.devices.LUKSDevice.status = self.luks_status


### PR DESCRIPTION
In some cases when a test crashes, the tearDown method is not
executed, using addCleanup method fixes this.