### PR TITLE
Use Ansible playbook to install test dependencies

### DIFF
--- a/install-test-dependencies.yml
+++ b/install-test-dependencies.yml
@@ -1,0 +1,73 @@
+# this is a simple ansible playbook for installing packages needed by blivet
+# test suite
+# you can this by using 'make install-requires' or manually using
+# 'ansible-playbook -K -i "localhost," -c local install-test-dependencies.yml'
+
+---
+- hosts: all
+  vars:
+    python: python3
+
+  become: true
+
+  tasks:
+  - name: Install common test dependencies
+    package: name={{item}} state=installed
+    with_items:
+      - anaconda-core
+      - dosfstools
+      - e2fsprogs
+      - xfsprogs
+      - hfsplus-tools
+      - zanata-python-client
+
+  - name: Install Python 3 test dependencies
+    package: name={{item}} state=installed
+    with_items:
+      - python3-mock
+      - python3-coverage
+      - python3-pocketlint
+      - python3-bugzilla
+      - python3-pep8
+      - python3-six
+      - python3-kickstart
+      - python3-pyudev
+      - python3-pyparted
+      - libselinux-python3
+      - python3-blockdev
+      - python3-bytesize
+    when: python == "python3"
+
+  - name: Install Python 2 test dependencies (Fedora)
+    package: name={{item}} state=installed
+    with_items:
+      - python2-mock
+      - python2-coverage
+      - python2-pocketlint
+      - python2-bugzilla
+      - python-pep8
+      - python2-six
+      - pykickstart
+      - python2-pyudev
+      - pyparted
+      - libselinux-python
+      - python2-blockdev
+      - python-bytesize
+    when: python == "python2" and ansible_distribution == "Fedora"
+
+  - name: Install Python 2 test dependencies (CentOS)
+    package: name={{item}} state=installed
+    with_items:
+      - python-mock
+      - python-coverage
+      - python-pocketlint
+      - python-bugzilla
+      - python-pep8
+      - python-six
+      - pykickstart
+      - python-pyudev
+      - pyparted
+      - libselinux-python
+      - python-blockdev
+      - python-bytesize
+    when: python == "python2" and ansible_distribution == "CentOS"


### PR DESCRIPTION
List of dependencies moved from Makefile to a ansible playbook.
"install-requires" target now uses Ansible to install dependencies
instead of yum/dnf.

------
Moving list of dependencies to a playbook also allows it to be somewhat distribution independent and makes it easier to maintain lists of packages with different names for different distributions.

I've also decided to remove the "check-requires" target -- it isn't possible to check if a package is installed with Ansible (it is possible to run "install-requires" instead, it will skip packages that are already installed, but it needs root privilegies). I think we can simply assume that user will run "install-requires" before running the tests and we don't need to check for every run.