### PR TITLE
Add some reasonable default value for LANG variable in size_test

### DIFF
--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -231,7 +231,7 @@ class TranslationTestCase(unittest.TestCase):
         super(TranslationTestCase, self).__init__(methodName=methodName)
 
     def setUp(self):
-        self.saved_lang = os.environ.get('LANG', None)
+        self.saved_lang = os.environ.get('LANG', 'en_US.UTF-8')
         self.addCleanup(self._clean_up)
 
     def _clean_up(self):


### PR DESCRIPTION
LANG variable is sometimes not set in our testing environment so
we need to set some reasonable default value to make the cleanup
work.