### PR TITLE
Use libblockdev runtime dependency checks

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -57,6 +57,9 @@ else:
 
 _requested_plugins = blockdev.plugin_specs_from_names(_REQUESTED_PLUGIN_NAMES)
 try:
+    # do not check for dependencies during libblockdev initializtion, do runtime
+    # checks instead
+    blockdev.switch_init_checks(False)
     succ_, avail_plugs = blockdev.try_reinit(require_plugins=_requested_plugins, reload=False, log_func=log_bd_message)
 except GLib.GError as err:
     raise RuntimeError("Failed to intialize the libblockdev library: %s" % err)


### PR DESCRIPTION
By default libblockdev will fail to load a plugin during its
initialization if one (or more) of the plugin runtime dependencies
is missing. For example if the "swaplabel" utility is missing,
loading of the swap module will fail.
This commit disables dependency checks during init -- in the same
situation swap plugin will load and only calling "swap_set_label"
would fail (because the utility it uses is missing).
Specification of all required "technologies" and "modes" is added
to the "tasks" module so checking for external tools availability
still checks if libblockdev supports everything we need.