### PR TITLE
1.20 fedora updates

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -73,7 +73,7 @@ log_bd_message = lambda level, msg: program_log.info(msg)
 
 import gi
 gi.require_version("GLib", "2.0")
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 # initialize the libblockdev library
 from gi.repository import GLib

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -36,7 +36,7 @@ from .partitioning import doPartitioning
 from .size import Size
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -26,7 +26,7 @@ import re
 from collections import namedtuple
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -24,7 +24,7 @@ import copy
 import tempfile
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/loop.py
+++ b/blivet/devices/loop.py
@@ -20,7 +20,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -29,7 +29,7 @@ import os
 import time
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -23,7 +23,7 @@ import os
 import six
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 
@@ -494,7 +494,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         log_method_call(self, self.name)
         # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays
         if getattr(self.format, "mountpoint", None) == "/boot/efi":
-            self.metadataVersion = "1.0"
+            self.metadataVersion = "2.0"
 
     def _postCreate(self):
         # this is critical since our status method requires a valid sysfs path

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -24,7 +24,7 @@ import parted
 import _ped
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -24,7 +24,7 @@ import os
 import re
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -22,7 +22,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -27,7 +27,7 @@ from . import DeviceFormat, register_device_format
 from ..size import Size
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -26,7 +26,7 @@ import stat
 import time
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -136,8 +136,6 @@ def getNextPartitionType(disk, no_primary=None):
     part_type = None
     extended = disk.getExtendedPartition()
     supports_extended = disk.supportsFeature(parted.DISK_TYPE_EXTENDED)
-    logical_count = len(disk.getLogicalPartitions())
-    max_logicals = disk.getMaxLogicalPartitions()
     primary_count = disk.primaryPartitionCount
 
     if primary_count < disk.maxPrimaryPartitionCount:
@@ -153,17 +151,17 @@ def getNextPartitionType(disk, no_primary=None):
                 # there is an extended and a free primary
                 if not no_primary:
                     part_type = parted.PARTITION_NORMAL
-                elif logical_count < max_logicals:
-                    # we have an extended with logical slots, so use one.
+                else:
+                    # we have an extended, so use it.
                     part_type = parted.PARTITION_LOGICAL
         else:
             # there are two or more primary slots left. use one unless we're
             # not supposed to make primaries.
             if not no_primary:
                 part_type = parted.PARTITION_NORMAL
-            elif extended and logical_count < max_logicals:
+            elif extended:
                 part_type = parted.PARTITION_LOGICAL
-    elif extended and logical_count < max_logicals:
+    elif extended:
         part_type = parted.PARTITION_LOGICAL
 
     return part_type

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 import functools
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -28,7 +28,7 @@ import copy
 import parted
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -26,7 +26,7 @@ import hawkey
 from six import add_metaclass
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from functools import wraps
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -27,7 +27,7 @@ from .i18n import _
 from .util import stringize, unicodeize
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -4,7 +4,7 @@ import os
 import unittest
 import parted
 
-from unittest.mock import patch
+from mock import patch
 
 from blivet.devices import DiskFile
 from blivet.devices import PartitionDevice

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -32,9 +32,9 @@ from blivet.flags import flags
 # disklabel-type-specific constants
 # keys: disklabel type string
 # values: 3-tuple of (max_primary_count, supports_extended, max_logical_count)
-disklabel_types = {'dos': (4, True, 11),
-                   'gpt': (128, False, 0),
-                   'mac': (62, False, 0)}
+disklabel_types = {'dos': (4, True),
+                   'gpt': (128, False),
+                   'mac': (62, False)}
 
 class PartitioningTestCase(unittest.TestCase):
     def getDisk(self, disk_type, primary_count=0,
@@ -44,7 +44,7 @@ class PartitioningTestCase(unittest.TestCase):
 
         disk.type = disk_type
         label_type_info = disklabel_types[disk_type]
-        (max_primaries, supports_extended, max_logicals) = label_type_info
+        (max_primaries, supports_extended) = label_type_info
 
         # primary partitions
         disk.primaryPartitionCount = primary_count
@@ -55,8 +55,7 @@ class PartitioningTestCase(unittest.TestCase):
         disk.getExtendedPartition = Mock(return_value=has_extended)
 
         # logical partitions
-        disk.getMaxLogicalPartitions = Mock(return_value=max_logicals)
-        disk.getLogicalPartitions = Mock(return_value=[0]*logical_count)
+        disk.getLogicalPartitions = Mock(return_value=[0] * logical_count)
 
         return disk
 
@@ -90,7 +89,7 @@ class PartitioningTestCase(unittest.TestCase):
         # four primaries and an extended, no available logical -> None
         disk = self.getDisk(disk_type="dos", primary_count=4, has_extended=True,
                             logical_count=11)
-        self.assertEqual(getNextPartitionType(disk), None)
+        self.assertEqual(getNextPartitionType(disk), parted.PARTITION_LOGICAL)
 
         # four primaries and no extended -> None
         disk = self.getDisk(disk_type="dos", primary_count=4,
@@ -106,7 +105,7 @@ class PartitioningTestCase(unittest.TestCase):
         # -> None
         disk = self.getDisk(disk_type="dos", primary_count=3, has_extended=True,
                             logical_count=11)
-        self.assertEqual(getNextPartitionType(disk, no_primary=True), None)
+        self.assertEqual(getNextPartitionType(disk, no_primary=True), parted.PARTITION_LOGICAL)
 
         #
         # GPT


### PR DESCRIPTION
python2-blivet1 has fallen into disrepair on Fedora since at least F25 due to various changes to dependencies. This should resolve everything. It was tested manually on F27.