### PR TITLE
Remove stale lvm metadata found on new md arrays.

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -376,13 +376,24 @@ def vgcreate(vg_name, pv_list, pe_size):
     except LVMError as msg:
         raise LVMError("vgcreate failed for %s: %s" % (vg_name, msg))
 
-def vgremove(vg_name):
-    args = ["vgremove", "--force", vg_name]
+def vgremove(vg_name, vg_uuid=None):
+    """ Remove volume group metadata/signature from disk.
+
+        Optional keyword argument vg_uuid allows for precise specification of
+        volume group in the face of the potential for multiple distinct volume
+        groups with the same name. If vg_uuid is passed it will be used instead
+        of vg_name.
+    """
+    args = ["vgremove", "--force"]
+    if vg_uuid:
+        args.extend(["--select", "vg_uuid=%s" % vg_uuid])
+    else:
+        args.append(vg_name)
 
     try:
         lvm(args)
     except LVMError as msg:
-        raise LVMError("vgremove failed for %s: %s" % (vg_name, msg))
+        raise LVMError("vgremove failed for %s: %s" % (vg_name if not vg_uuid else vg_uuid, msg))
 
 def vgactivate(vg_name):
     args = ["vgchange", "-a", "y", vg_name]

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -21,11 +21,13 @@
 
 import os
 
+from ..devicelibs import lvm
 from ..devicelibs import mdraid, raid
 
 from .. import errors
 from .. import util
 from ..flags import flags
+from ..formats import getFormat
 from ..storage_log import log_method_call
 from .. import udev
 from ..i18n import P_
@@ -554,6 +556,42 @@ class MDRaidArrayDevice(ContainerDevice):
         if getattr(self.format, "mountpoint", None) == "/boot/efi":
             self.metadataVersion = "1.0"
 
+    def _removeStaleLVM(self):
+        """ Remove any stale LVM metadata that pre-existed in a new array's on-disk footprint.
+
+            XXX This should only be run from _postCreate.
+        """
+        import time
+        log.debug("waiting 5s for activation of stale lvm on new md array %s", self.path)
+        time.sleep(5)
+        udev.settle()
+        info = udev.get_device(self.sysfsPath)
+        fmt = getFormat(udev.device_get_format(info), device=self.path, exists=True)
+        if fmt.type != "lvmpv":
+            return
+
+        try:
+            pv_info = lvm.pvinfo(device=self.path)[self.path]
+        except errors.LVMError as e:
+            return
+
+        vg_name = None
+        vg_uuid = None
+        try:
+            vg_name = udev.device_get_vg_name(pv_info)
+            vg_uuid = udev.device_get_vg_uuid(pv_info)
+        except KeyError:
+            return
+
+        if vg_name and vg_uuid:
+            log.info("removing stale LVM metadata found on %s", self.name)
+            try:
+                lvm.vgremove(vg_name, vg_uuid=vg_uuid)
+            except errors.LVMError as e:
+                log.error("Failed to remove stale volume group from newly-created md array %s: %s",
+                          self.path, str(e))
+                raise
+
     def _postCreate(self):
         # this is critical since our status method requires a valid sysfs path
         self.exists = True  # this is needed to run updateSysfsPath
@@ -566,6 +604,8 @@ class MDRaidArrayDevice(ContainerDevice):
         self.uuid = info.get("UUID")
         for member in self.devices:
             member.format.mdUuid = self.uuid
+
+        self._removeStaleLVM()
 
     def _create(self):
         """ Create the device. """


### PR DESCRIPTION
Multiple subsequent installations with the same layout (lvm-on-raid1) with lazy cleanup in between can lead to a situation in which stale lvm metadata is found by udev/lvmetad/pvscan immediately after creation of a new md array. The same udev/lvmetad/pvscan machinery activates this lvm, which trips blivet since it is unaware of the newly-activated devices.

There will also be a version of this for newer branches once the fix is confirmed by reporters.