### PR TITLE
Find and remove stale LVM metadata immediately after creating md array.

### DIFF
--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -382,6 +382,8 @@ class MDRaidArrayDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
         self.patchers["md"] = patch("blivet.devices.md.blockdev.md")
         self.patchers["is_disk"] = patch.object(self.device_class, "is_disk",
                                                 new=PropertyMock(return_value=False))
+        self.patchers["pvs_info"] = patch("blivet.devices.md.pvs_info")
+        self.patchers["lvm"] = patch("blivet.devices.md.blockdev.lvm")
 
     @property
     def teardown_method_mock(self):


### PR DESCRIPTION
This is a port of #651 to active development branches.