### PR TITLE
Account for pmspare/mlog volumes after growing a thin pool.

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -625,7 +625,7 @@ class LVMLogicalVolumeDevice(DMDevice):
         if self.cached:
             cache_size = self.cache.size
         return (self.vg.align(self.size, roundup=True) * self.copies
-                + self.logSize + self.metaDataSize + cache_size)
+                + self.logSize + 2 * self.metaDataSize + cache_size)
 
     def _setFormat(self, fmt):
         super(LVMLogicalVolumeDevice, self)._setFormat(fmt)

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1800,7 +1800,7 @@ class VGChunk(Chunk):
                              "LVRequest"))
 
         if req.device.metaDataSize:
-            self.pool -= int(self.vg.align(req.device.metaDataSize, roundup=True) / self.vg.peSize)
+            self.pool -= 2 * int(self.vg.align(req.device.metaDataSize, roundup=True) / self.vg.peSize)
 
         if req.device.cached:
             # cached LV -> reserve space for the cache


### PR DESCRIPTION
Growable non-autopart (kickstart) thin pools don't get vg space for pmspare/mlog volumes. I have verified the fix after reproducing the original issue.