### PR TITLE
NVDIMM support

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -51,9 +51,9 @@ gi.require_version("BlockDev", "2.0")
 from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 if arch.is_s390():
-    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390", "nvdimm"))
 else:
-    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvdimm"))
 
 _requested_plugins = blockdev.plugin_specs_from_names(_REQUESTED_PLUGIN_NAMES)
 try:

--- a/blivet/devices/__init__.py
+++ b/blivet/devices/__init__.py
@@ -22,7 +22,7 @@
 from .lib import device_path_to_name, device_name_to_disk_by_path, ParentList
 from .device import Device
 from .storage import StorageDevice
-from .disk import DiskDevice, DiskFile, DMRaidArrayDevice, MultipathDevice, iScsiDiskDevice, FcoeDiskDevice, DASDDevice, ZFCPDiskDevice
+from .disk import DiskDevice, DiskFile, DMRaidArrayDevice, MultipathDevice, iScsiDiskDevice, FcoeDiskDevice, DASDDevice, ZFCPDiskDevice, NVDIMMNamespaceDevice
 from .partition import PartitionDevice
 from .dm import DMDevice, DMLinearDevice, DMCryptDevice, DM_MAJORS
 from .luks import LUKSDevice

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -63,7 +63,7 @@ class DiskDevice(StorageDevice):
     def __init__(self, name, fmt=None,
                  size=None, major=None, minor=None, sysfs_path='',
                  parents=None, serial=None, vendor="", model="", bus="", wwn=None,
-                 exists=True):
+                 uuid=None, exists=True):
         """
             :param name: the device name (generally a device node's basename)
             :type name: str
@@ -96,7 +96,7 @@ class DiskDevice(StorageDevice):
                                major=major, minor=minor, exists=exists,
                                sysfs_path=sysfs_path, parents=parents,
                                serial=serial, model=model,
-                               vendor=vendor, bus=bus)
+                               vendor=vendor, bus=bus, uuid=uuid)
 
         self.wwn = wwn or None
 
@@ -660,3 +660,50 @@ class DASDDevice(DiskDevice):
                                             ":".join(opts))])
         else:
             return set(["rd.dasd=%s" % self.busid])
+
+
+class NVDIMMNamespaceDevice(DiskDevice):
+
+    """ Non-volatile memory namespace """
+    _type = "nvdimm"
+
+    def __init__(self, device, **kwargs):
+        """
+            :param name: the device name (generally a device node's basename)
+            :type name: str
+            :keyword exists: does this device exist?
+            :type exists: bool
+            :keyword size: the device's size
+            :type size: :class:`~.size.Size`
+            :keyword parents: a list of parent devices
+            :type parents: list of :class:`StorageDevice`
+            :keyword format: this device's formatting
+            :type format: :class:`~.formats.DeviceFormat` or a subclass of it
+            :keyword mode: mode of the namespace
+            :type mode: str
+            :keyword devname: name of the namespace (e.g. 'namespace0.0')
+            :type devname: str
+            :keyword sector_size: sector size of the namespace in sector mode
+            :type sector_size: str
+        """
+        self.mode = kwargs.pop("mode")
+        self.devname = kwargs.pop("devname")
+        self.sector_size = kwargs.pop("sector_size")
+
+        DiskDevice.__init__(self, device, **kwargs)
+
+    def __repr__(self):
+        s = DiskDevice.__repr__(self)
+        s += ("  mode = %(mode)s  devname = %(devname)s" %
+              {"mode": self.mode,
+               "devname": self.devname})
+        if self.sector_size:
+            s += ("  sector size = %(sector_size)s" % {"sector_size": self.sector_size})
+        return s
+
+    @property
+    def description(self):
+        return "NVDIMM namespace %(devname)s in %(mode)s mode exported as %(path)s" \
+               % {'devname': self.devname,
+                  'mode': self.mode,
+                  'path': self.path}

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -692,6 +692,10 @@ class NVDIMMNamespaceDevice(DiskDevice):
 
         DiskDevice.__init__(self, device, **kwargs)
 
+        self._clear_local_tags()
+        self.tags.add(Tags.local)
+        self.tags.add(Tags.nvdimm)
+
     def __repr__(self):
         s = DiskDevice.__repr__(self)
         s += ("  mode = %(mode)s  devname = %(devname)s" %

--- a/blivet/devices/lib.py
+++ b/blivet/devices/lib.py
@@ -31,6 +31,7 @@ LINUX_SECTOR_SIZE = Size(512)
 class Tags(str, Enum):
     """Tags that describe various classes of disk."""
     local = 'local'
+    nvdimm = 'nvdimm'
     remote = 'remote'
     removable = 'removable'
     ssd = 'ssd'

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -6,7 +6,7 @@ from .formatpopulator import FormatPopulator
 
 from .btrfs import BTRFSFormatPopulator
 from .boot import AppleBootFormatPopulator, EFIFormatPopulator, MacEFIFormatPopulator
-from .disk import DiskDevicePopulator, iScsiDevicePopulator, FCoEDevicePopulator, MDBiosRaidDevicePopulator, DASDDevicePopulator, ZFCPDevicePopulator
+from .disk import DiskDevicePopulator, iScsiDevicePopulator, FCoEDevicePopulator, MDBiosRaidDevicePopulator, DASDDevicePopulator, ZFCPDevicePopulator, NVDIMMNamespaceDevicePopulator
 from .disklabel import DiskLabelFormatPopulator
 from .dm import DMDevicePopulator
 from .dmraid import DMRaidFormatPopulator

--- a/blivet/static_data/__init__.py
+++ b/blivet/static_data/__init__.py
@@ -1,3 +1,4 @@
 from .lvm_info import lvs_info, pvs_info
 from .luks_data import luks_data
 from .mpath_info import mpath_members
+from .nvdimm import nvdimm

--- a/blivet/static_data/nvdimm.py
+++ b/blivet/static_data/nvdimm.py
@@ -1,0 +1,152 @@
+#
+# nvdimm.py - nvdimm class
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import gi
+gi.require_version("BlockDev", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import BlockDev
+from gi.repository import GLib
+
+from .. import util
+
+import logging
+log = logging.getLogger("blivet")
+
+
+class NVDIMMDependencyGuard(util.DependencyGuard):
+    error_msg = "libblockdev NVDIMM functionality not available"
+
+    def _check_avail(self):
+        try:
+            BlockDev.nvdimm_is_tech_avail(BlockDev.NVDIMMTech.NVDIMM_TECH_NAMESPACE,
+                                          BlockDev.NVDIMMTechMode.RECONFIGURE |
+                                          BlockDev.NVDIMMTechMode.QUERY |
+                                          BlockDev.NVDIMMTechMode.ACTIVATE_DEACTIVATE)
+        except GLib.GError:
+            return False
+        return True
+
+blockdev_nvdimm_required = NVDIMMDependencyGuard()
+
+
+class NVDIMM(object):
+    """ NVDIMM utility class.
+
+        .. warning::
+            Since this is a singleton class, calling deepcopy() on the instance
+            just returns ``self`` with no copy being created.
+    """
+
+    def __init__(self):
+        self._namespaces = None
+
+    # So that users can write nvdimm() to get the singleton instance
+    def __call__(self):
+        return self
+
+    def __deepcopy__(self, memo_dict):
+        # pylint: disable=unused-argument
+        return self
+
+    @property
+    def namespaces(self):
+        """ Dict of all NVDIMM namespaces, including dax and disabled namespaces
+        """
+        if not self._namespaces:
+            self.update_namespaces_info()
+
+        return self._namespaces
+
+    @blockdev_nvdimm_required(critical=True, eval_mode=util.EvalMode.onetime)
+    def update_namespaces_info(self):
+        """ Update information about the namespaces
+        """
+        namespaces = BlockDev.nvdimm_list_namespaces(idle=True)
+
+        self._namespaces = dict((namespace.dev, namespace) for namespace in namespaces)
+
+    def get_namespace_info(self, device):
+        """ Get namespace information for a device
+            :param str device: device name (e.g. 'pmem0') or path
+        """
+        for info in self.namespaces.values():
+            if info.blockdev == device or \
+               (device.startswith("/dev/") and info.blockdev == device[5:]):
+                return info
+
+    @blockdev_nvdimm_required(critical=True, eval_mode=util.EvalMode.onetime)
+    def enable_namespace(self, namespace):
+        """ Enable a namespace
+            :param str namespace: devname of the namespace (e.g. 'namespace0.0')
+        """
+
+        if namespace not in self.namespaces.keys():
+            raise ValueError("Namespace '%s' doesn't exist." % namespace)
+
+        BlockDev.nvdimm_namespace_enable(namespace)
+
+        # and update our namespaces info "cache"
+        self.update_namespaces_info()
+
+    @blockdev_nvdimm_required(critical=True, eval_mode=util.EvalMode.onetime)
+    def reconfigure_namespace(self, namespace, mode, **kwargs):
+        """ Change mode of the namespace
+            :param str namespace: devname of the namespace (e.g. 'namespace0.0')
+            :param str mode: new mode of the namespace (one of 'sector', 'memory', 'dax')
+            :keyword int sector_size: sector size when reconfiguring to the 'sector' mode
+            :keyword str map_location: map location when reconfiguring to the 'memory'
+                                       mode (one of 'mem', 'dev')
+
+            .. note::
+                This doesn't change state of the devicetree. It is necessary to
+                run reset() or populate() to make these changes visible.
+        """
+
+        if namespace not in self.namespaces.keys():
+            raise ValueError("Namespace '%s' doesn't exist." % namespace)
+
+        info = self.namespaces[namespace]
+
+        sector_size = kwargs.get("sector_size", None)
+        map_location = kwargs.get("map_location", None)
+
+        if sector_size and mode != "sector":
+            raise ValueError("Sector size cannot be set for selected mode '%s'." % mode)
+
+        if map_location and mode != "memory":
+            raise ValueError("Map location cannot be set for selected mode '%s'." % mode)
+
+        mode_t = BlockDev.nvdimm_namespace_get_mode_from_str(mode)
+
+        if sector_size:
+            extra = {"-l": str(sector_size)}
+        elif map_location:
+            extra = {"-M": map_location}
+        else:
+            extra = None
+
+        BlockDev.nvdimm_namespace_reconfigure(namespace, mode_t, info.enabled, extra)
+
+        # and update our namespaces info "cache"
+        self.update_namespaces_info()
+
+
+# Create nvdimm singleton
+nvdimm = NVDIMM()
+""" An instance of :class:`NVDIMM` """

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -914,3 +914,12 @@ def device_get_fcoe_identifier(info):
     if device_is_fcoe(info) and len(path_components) >= 4 and \
        path_components[2] == 'fc':
         return path_components[3]
+
+
+def device_is_nvdimm_namespace(info):
+    if info.get("DEVTYPE") != "disk":
+        return False
+
+    devname = info.get("DEVNAME", "")
+    ninfo = blockdev.nvdimm_namespace_get_devname(devname)
+    return ninfo is not None

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -10,14 +10,14 @@ from gi.repository import BlockDev as blockdev
 
 from blivet.devices import DiskDevice, DMDevice, FileDevice, LoopDevice
 from blivet.devices import MDRaidArrayDevice, MultipathDevice, OpticalDevice
-from blivet.devices import PartitionDevice, StorageDevice
+from blivet.devices import PartitionDevice, StorageDevice, NVDIMMNamespaceDevice
 from blivet.devicetree import DeviceTree
 from blivet.formats import get_device_format_class, get_format, DeviceFormat
 from blivet.formats.disklabel import DiskLabel
 from blivet.populator.helpers import DiskDevicePopulator, DMDevicePopulator, LoopDevicePopulator
 from blivet.populator.helpers import LVMDevicePopulator, MDDevicePopulator, MultipathDevicePopulator
 from blivet.populator.helpers import OpticalDevicePopulator, PartitionDevicePopulator
-from blivet.populator.helpers import LVMFormatPopulator, MDFormatPopulator
+from blivet.populator.helpers import LVMFormatPopulator, MDFormatPopulator, NVDIMMNamespaceDevicePopulator
 from blivet.populator.helpers import get_format_helper, get_device_helper
 from blivet.populator.helpers.boot import AppleBootFormatPopulator, EFIFormatPopulator, MacEFIFormatPopulator
 from blivet.populator.helpers.formatpopulator import FormatPopulator
@@ -508,6 +508,71 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertTrue(device.is_disk)
         self.assertEqual(device.wwn, data["ID_WWN"])
         self.assertEqual(device.name, device_name)
+        self.assertTrue(device in devicetree.devices)
+
+
+class NVDIMMNamespaceDevicePopulatorTestCase(PopulatorHelperTestCase):
+    helper_class = NVDIMMNamespaceDevicePopulator
+
+    @patch("os.path.join")
+    @patch("blivet.udev.device_is_cdrom", return_value=False)
+    @patch("blivet.udev.device_is_dm", return_value=False)
+    @patch("blivet.udev.device_is_loop", return_value=False)
+    @patch("blivet.udev.device_is_md", return_value=False)
+    @patch("blivet.udev.device_is_partition", return_value=False)
+    @patch("blivet.udev.device_is_disk", return_value=True)
+    @patch("blivet.udev.device_is_nvdimm_namespace", return_value=True)
+    def test_match(self, *args):
+        """Test matching of NVDIMM namespace device populator."""
+        device_is_nvdimm_namespace = args[0]
+        self.assertTrue(self.helper_class.match(None))
+        device_is_nvdimm_namespace.return_value = False
+        self.assertFalse(self.helper_class.match(None))
+
+    @patch("os.path.join")
+    @patch("blivet.udev.device_is_cdrom", return_value=False)
+    @patch("blivet.udev.device_is_dm", return_value=False)
+    @patch("blivet.udev.device_is_loop", return_value=False)
+    @patch("blivet.udev.device_is_md", return_value=False)
+    @patch("blivet.udev.device_is_partition", return_value=False)
+    @patch("blivet.udev.device_is_disk", return_value=True)
+    @patch("blivet.udev.device_is_nvdimm_namespace", return_value=True)
+    def test_get_helper(self, *args):
+        """Test get_device_helper for NVDIMM namespaces."""
+        device_is_nvdimm_namespace = args[0]
+        data = {}
+        self.assertEqual(get_device_helper(data), self.helper_class)
+
+        # verify that setting one of the required True return values to False prevents success
+        device_is_nvdimm_namespace.return_value = False
+        self.assertNotEqual(get_device_helper(data), self.helper_class)
+        device_is_nvdimm_namespace.return_value = True
+
+    @patch("blivet.udev.device_get_name")
+    def test_run(self, *args):
+        """Test disk device populator."""
+        device_get_name = args[0]
+
+        devicetree = DeviceTree()
+
+        # set up some fake udev data to verify handling of specific entries
+        data = {'SYS_PATH': 'dummy', 'DEVNAME': 'dummy'}
+
+        device_name = "nop"
+        device_get_name.return_value = device_name
+        helper = self.helper_class(devicetree, data)
+
+        nvdimm_data = Mock(mode=blockdev.NVDIMMNamespaceMode.SECTOR, devname='dummy',
+                           uuid='test-uuid', sector_size=512)
+
+        with patch("blivet.static_data.nvdimm.get_namespace_info", return_value=nvdimm_data):
+            device = helper.run()
+        self.assertIsInstance(device, NVDIMMNamespaceDevice)
+        self.assertTrue(device.exists)
+        self.assertTrue(device.is_disk)
+        self.assertEqual(device.mode, 'sector')
+        self.assertEqual(device.uuid, 'test-uuid')
+        self.assertTrue(device.sector_size, 512)
         self.assertTrue(device in devicetree.devices)
 
 


### PR DESCRIPTION
Basic support for nvdimm devices:

- `NVDIMMNamespaceDevice` -- new "disk type" for NVDIMM namespaces that are recognized by udev as disks -- namespaces in *sector*, *memory* or *raw* mode
  ```
  NVDIMMNamespaceDevice instance (0x7fc4646340b8) --
  name = pmem0s  status = True  id = 268
  children = []
  parents = []
  uuid = 5c75b9c7-a74d-43c7-b260-c5b00415015f  size = 1015.91 MiB
  format = existing gpt disklabel
  major = 0  minor = 0  exists = True  protected = False
  sysfs path = /sys/devices/platform/e820_pmem/ndbus0/region0/btt0.0/block/pmem0s
  target size = 1015.91 MiB  path = /dev/pmem0s
  format args = []  original_format = disklabel  removable = False  wwn = None  mode = sector  devname = namespace0.0  sector size = 512
  ```
- `NVDIMM` singleton for managing NVDIMM devices
  - we need to be able to list and manage "non-block" namespaces (in *dax* mode or disabled) -- this will work similarly to iscsi devices in Anaconda -- simple dialog (kickstart command) allowing to enable or reconfigure namespaces and Anaconda will run `populate()` after the change