### PR TITLE
Followup for #651

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -577,7 +577,7 @@ class MDRaidArrayDevice(ContainerDevice):
 
             try:
                 pv_info = lvm.pvinfo(device=self.path)[self.path]
-            except errors.LVMError as e:
+            except (errors.LVMError, KeyError) as e:
                 return
 
             vg_uuid = None


### PR DESCRIPTION
Apparently you get `KeyError` instead of `blivet.errors.LVMError` when the new md array doesn't have lvm metadata on it.