### PR TITLE
Dasd is a valid label type on s390x (#1538550)

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -226,7 +226,7 @@ class DiskLabel(DeviceFormat):
         elif arch.is_efi() and not arch.is_aarch64():
             label_types = ["gpt"]
         elif arch.is_s390():
-            label_types = ["msdos"]  # since 'dasd' is only for DASD, it isn't listed here
+            label_types = ["msdos", "dasd"]
 
         return label_types
 

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -84,7 +84,7 @@ class DiskLabelTestCase(unittest.TestCase):
         arch.is_efi.return_value = False
 
         arch.is_s390.return_value = True
-        self.assertEqual(disklabel_class.get_platform_label_types(), ["msdos"])
+        self.assertEqual(disklabel_class.get_platform_label_types(), ["msdos", "dasd"])
         arch.is_s390.return_value = False
 
     def test_label_type_size_check(self):


### PR DESCRIPTION
Add the dasd label type to the list of valid label types for s390x.
This bug was introduced in the commit ebd43b6.

Resolves: rhbz#1538550