### PR TITLE
Remove dependency on pocketlint

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -27,7 +27,7 @@ MOFILES		= $(patsubst %.po,%.mo,$(POFILES))
 PYSRC		= $(wildcard ../blivet/*.py ../blivet/*/*.py)
 SRCFILES 	= $(PYSRC)
 
-all::  update-po $(MOFILES)
+all::  refresh-po $(MOFILES)
 
 $(POTFILE): $(SRCFILES)
 	$(XGETTEXT) -L Python --keyword=_ --keyword=N_ --keyword=P_:1,2 $(SRCFILES)
@@ -65,5 +65,3 @@ install: $(MOFILES)
 	$(MSGFMT) -o $@ $<
 
 .PHONY: missing depend
-
-

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -56,7 +56,6 @@ Summary: A python3 package for examining and modifying storage configuration.
 %{?python_provide:%python_provide python3-%{realname}}
 
 BuildRequires: gettext
-BuildRequires: python3-pocketlint >= %{pocketlintver}
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 
@@ -89,7 +88,6 @@ Summary: A python2 package for examining and modifying storage configuration.
 %{?python_provide:%python_provide python2-%{realname}}
 
 BuildRequires: gettext
-BuildRequires: python2-pocketlint >= %{pocketlintver}
 BuildRequires: python2-devel
 
 %if %{is_rhel}

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -126,7 +126,7 @@ The python2-%{realname} is a python2 package for examining and modifying storage
 configuration.
 
 %prep
-%autosetup -n %{realname}-%{realversion}
+%autosetup -n %{realname}-%{realversion} -p1
 
 %build
 make PYTHON=%{__python2}


### PR DESCRIPTION
It is not needed during build. This was already removed on
2.1-devel but not completely removed on 3.0-devel.

----

We had the dependency multiple times on 3.0-devel and I didn't notice that when merging #633