### PR TITLE
Don't use a 'wwn' kwarg for MDBiosRaidArrayDevice (#1557957)

### DIFF
--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -172,6 +172,7 @@ class MDBiosRaidDevicePopulator(DiskDevicePopulator):
         del kwargs["serial"]
         del kwargs["vendor"]
         del kwargs["bus"]
+        del kwargs["wwn"]
         return kwargs
 
 


### PR DESCRIPTION
MDBiosRaidArrayDevice's parent class doesn't take a 'wwn' kwarg,
so the populator for it shouldn't pass one.

For more details, see comment 15 on the bug.

Resolves: rhbz#1557957

Signed-off-by: Adam Williamson <awilliam@redhat.com>