### PR TITLE
Improved non-unique UUID handling

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -206,6 +206,13 @@ class UnusableConfigurationError(StorageError):
         self.dev_name = dev_name
 
 
+class DuplicateUUIDError(UnusableConfigurationError, ValueError):
+    suggestion = N_("This is usually caused by cloning the device image resulting "
+                    "in duplication of the UUID value which should be unique. "
+                    "In that case you can either disconnect one of the devices or "
+                    "reformat it.")
+
+
 class DiskLabelScanError(UnusableConfigurationError):
     suggestion = N_("For some reason we were unable to locate a disklabel on a "
                     "disk that the kernel is reporting partitions on. It is "

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -5,7 +5,7 @@ import six
 import unittest
 
 from blivet.actionlist import ActionList
-from blivet.errors import DeviceTreeError
+from blivet.errors import DeviceTreeError, DuplicateUUIDError
 from blivet.devicelibs import lvm
 from blivet.devices import DiskDevice
 from blivet.devices import LVMVolumeGroupDevice
@@ -117,7 +117,11 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertTrue(dev1.add_hook.called)  # pylint: disable=no-member
 
         # adding an already-added device fails
-        six.assertRaisesRegex(self, ValueError, "already in tree", dt._add_device, dev1)
+        six.assertRaisesRegex(self, DeviceTreeError, "Trying to add already existing device.", dt._add_device, dev1)
+
+        # adding a device with the same UUID
+        dev_clone = StorageDevice("dev_clone", exists=False, uuid=sentinel.dev1_uuid, parents=[])
+        six.assertRaisesRegex(self, DuplicateUUIDError, "Duplicate UUID.*", dt._add_device, dev_clone)
 
         dev2 = StorageDevice("dev2", exists=False, parents=[])
         dev3 = StorageDevice("dev3", exists=False, parents=[dev1, dev2])


### PR DESCRIPTION
When trying to add a non-unique UUID device blivet now
produce more user friendly exception

Changed and added tests accordingly