### PR TITLE
Weak dependencies for libblockdev plugins

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -75,7 +75,19 @@ Requires: parted >= %{partedver}
 Requires: python3-pyparted >= %{pypartedver}
 Requires: libselinux-python3
 Requires: python3-blockdev >= %{libblockdevver}
-Requires: libblockdev-plugins-all >= %{libblockdevver}
+Recommends: libblockdev-btrfs >= %{libblockdevver}
+Recommends: libblockdev-crypto >= %{libblockdevver}
+Recommends: libblockdev-dm >= %{libblockdevver}
+Recommends: libblockdev-fs >= %{libblockdevver}
+Recommends: libblockdev-kbd >= %{libblockdevver}
+Recommends: libblockdev-loop >= %{libblockdevver}
+Recommends: libblockdev-lvm >= %{libblockdevver}
+Recommends: libblockdev-mdraid >= %{libblockdevver}
+Recommends: libblockdev-mpath >= %{libblockdevver}
+Recommends: libblockdev-nvdimm >= %{libblockdevver}
+Recommends: libblockdev-part >= %{libblockdevver}
+Recommends: libblockdev-swap >= %{libblockdevver}
+Recommends: libblockdev-s390 >= %{libblockdevver}
 Requires: python3-bytesize >= %{libbytesizever}
 Requires: util-linux >= %{utillinuxver}
 Requires: lsof
@@ -120,7 +132,19 @@ Requires: parted >= %{partedver}
 Requires: pyparted >= %{pypartedver}
 Requires: libselinux-python
 Requires: python-blockdev >= %{libblockdevver}
-Requires: libblockdev-plugins-all >= %{libblockdevver}
+Recommends: libblockdev-btrfs >= %{libblockdevver}
+Recommends: libblockdev-crypto >= %{libblockdevver}
+Recommends: libblockdev-dm >= %{libblockdevver}
+Recommends: libblockdev-fs >= %{libblockdevver}
+Recommends: libblockdev-kbd >= %{libblockdevver}
+Recommends: libblockdev-loop >= %{libblockdevver}
+Recommends: libblockdev-lvm >= %{libblockdevver}
+Recommends: libblockdev-mdraid >= %{libblockdevver}
+Recommends: libblockdev-mpath >= %{libblockdevver}
+Recommends: libblockdev-nvdimm >= %{libblockdevver}
+Recommends: libblockdev-part >= %{libblockdevver}
+Recommends: libblockdev-swap >= %{libblockdevver}
+Recommends: libblockdev-s390 >= %{libblockdevver}
 Requires: python-bytesize >= %{libbytesizever}
 Requires: util-linux >= %{utillinuxver}
 Requires: lsof

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -1,6 +1,12 @@
 # vim:set fileencoding=utf-8
 from unittest.mock import patch, PropertyMock
 import unittest
+import os
+import six
+import blivet
+import gi
+gi.require_version("BlockDev", "2.0")
+from gi.repository import BlockDev as blockdev
 
 from blivet.deviceaction import ActionCreateDevice
 from blivet.deviceaction import ActionDestroyDevice
@@ -20,6 +26,8 @@ from blivet.formats import get_format
 from blivet.size import Size
 
 from blivet.tasks import availability
+
+from blivet.util import create_sparse_tempfile
 
 
 class DeviceDependenciesTestCase(unittest.TestCase):
@@ -129,3 +137,123 @@ class MockingDeviceDependenciesTestCase2(unittest.TestCase):
         self.assertFalse(fmt.supported)
         self.assertFalse(fmt.formattable)
         self.assertFalse(fmt.destroyable)
+
+
+class MissingWeakDependenciesTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.addCleanup(self._clean_up)
+        self.disk1_file = create_sparse_tempfile("disk1", Size("2GiB"))
+
+    def _clean_up(self):
+        # reload all libblockdev plugins
+        blockdev.try_reinit(require_plugins=None, reload=False)
+
+        for disk in self.bvt.disks:
+            self.bvt.recursive_remove(disk)
+
+        self.bvt.devicetree.teardown_disk_images()
+        for fn in self.bvt.disk_images.values():
+            if os.path.exists(fn):
+                os.unlink(fn)
+
+    def load_all_plugins(self):
+        result, plugins = blockdev.try_reinit(require_plugins=None, reload=False)
+        if not result:
+            self.fail("Could not reload libblockdev plugins")
+        return plugins
+
+    def unload_all_plugins(self):
+        result, _ = blockdev.try_reinit(require_plugins=[], reload=True)
+        if not result:
+            self.fail("Could not reload libblockdev plugins")
+
+    def test_weak_dependencies(self):
+        self.bvt = blivet.Blivet()  # pylint: disable=attribute-defined-outside-init
+        availability.CACHE_AVAILABILITY = False
+
+        # reinitialize blockdev without the plugins
+        # TODO: uncomment (workaround (1/2) for blivet.reset fail)
+        # self.unload_all_plugins()
+        self.bvt.disk_images["disk1"] = self.disk1_file
+        self.bvt.exclusive_disks = self.bvt.disk_images["disk1"]
+        try:
+            self.bvt.reset()
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+        # TODO: remove line (workaround (2/2) for blivet.reset fail)
+        self.unload_all_plugins()
+
+        disk1 = self.bvt.devicetree.get_device_by_name("disk1")
+
+        with six.assertRaisesRegex(self, ValueError, "requires unavailable_dependencies"):
+            self.bvt.initialize_disk(disk1)
+
+        pv = self.bvt.new_partition(size=Size("8GiB"), fmt_type="lvmpv")
+        pv_fail = self.bvt.new_partition(size=Size("8GiB"), fmt_type="lvmpv")
+        btrfs = self.bvt.new_partition(size=Size("1GiB"), fmt_type="btrfs")
+        raid1 = self.bvt.new_partition(size=Size("1GiB"), fmt_type="mdmember")
+        raid2 = self.bvt.new_partition(size=Size("1GiB"), fmt_type="mdmember")
+
+        with six.assertRaisesRegex(self, ValueError, "resource to create this format.*unavailable"):
+            self.bvt.create_device(pv_fail)
+
+        # to be able to test functions like destroy_device it is necessary to have some
+        # testing devices actually created - hence loading libblockdev plugins...
+        self.load_all_plugins()
+        self.bvt.create_device(pv)
+        self.bvt.create_device(btrfs)
+        # ... and unloading again when tests can continue
+        self.unload_all_plugins()
+
+        try:
+            vg = self.bvt.new_vg(parents=[pv])
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+
+        self.load_all_plugins()
+        self.bvt.create_device(vg)
+        self.unload_all_plugins()
+
+        try:
+            lv1 = self.bvt.new_lv(fmt_type="ext4", size=Size("1GiB"), parents=[vg])
+            lv2 = self.bvt.new_lv(fmt_type="ext4", size=Size("1GiB"), parents=[vg])
+            lv3 = self.bvt.new_lv(fmt_type="luks", size=Size("1GiB"), parents=[vg])
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+
+        self.load_all_plugins()
+        self.bvt.create_device(lv1)
+        self.bvt.create_device(lv2)
+        self.bvt.create_device(lv3)
+        self.unload_all_plugins()
+
+        try:
+            pool = self.bvt.new_lv_from_lvs(vg, name='pool', seg_type="thin-pool", from_lvs=[lv1, lv2])
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+
+        self.load_all_plugins()
+        self.bvt.create_device(pool)
+        self.unload_all_plugins()
+
+        with six.assertRaisesRegex(self, ValueError, "requires unavailable_dependencies"):
+            self.bvt.destroy_device(pool)
+
+        try:
+            self.bvt.new_btrfs(parents=[btrfs])
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+
+        with six.assertRaisesRegex(self, ValueError, "device cannot be resized"):
+            self.bvt.resize_device(lv3, Size("2GiB"))
+
+        try:
+            self.bvt.new_tmp_fs(fmt=disk1.format, size=Size("500MiB"))
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")
+
+        try:
+            self.bvt.new_mdarray(level='raid0', parents=[raid1, raid2])
+        except blockdev.BlockDevNotImplementedError:  # pylint: disable=catching-non-exception
+            self.fail("Improper handling of missing libblockdev plugin")


### PR DESCRIPTION
- libblockdev plugins now use only weak dependencies
- added libblockdev plugins dependency tests to verify that:
    - destroy|create|resize_device fails (properly) w/o necessary plugin
    - no BlockDevNotImplementedError is raised in case of missing plugin
        (due to confusing nature of this exception - it does not inform
         about a missing dependency)
