### PR TITLE
Replace deprecated iscsi_firmware dracut option

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -450,7 +450,7 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
 
     def dracut_setup_args(self):
         if self.ibft:
-            return set(["iscsi_firmware"])
+            return set(["rd.iscsi.firmware"])
 
         # qla4xxx partial offload
         if self.node is None:


### PR DESCRIPTION
The supported option is rd.iscsi.firmware

Resolves: rhbz#1566133