### PR TITLE
Try to wait after stopping an MD array

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -494,6 +494,9 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         # give valid results
         self.sysfs_path = ''
 
+        # make sure the /dev/mdXXX path is removed after stopping the array
+        udev.settle()
+
     def teardown(self, recursive=None):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,


### PR DESCRIPTION
Sometimes after running 'mdadm --stop' it takes some time before
the device in /dev disappears. udev settle should fix this.

Resolves: rhbz#1563631

----

This happens when we try to remove an mdraid array in Anaconda. We first need to wipe filesystem from the array -- so we need to start it, run wipefs and stop it after that. Second step is to remove the array itself -- the code checks if the `/dev/mdXXX` exists and if it exists we try to stop it first. The problem is that it takes some time before the device file disappears after the first stop and sometimes it disappears after we run the check in blivet but before libblockdev tries to stop it again, so the `blockdev.md.deactivate(self.path)` call fails. Running `udev.settle()` should prevent this.