### PR TITLE
Fixed create_device fail behavior

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -36,7 +36,7 @@ from .deviceaction import ActionDestroyFormat, ActionResizeDevice, ActionResizeF
 from .devicelibs.edd import get_edd_dict
 from .devicelibs.btrfs import MAIN_VOLUME_ID
 from .devicelibs.crypto import LUKS_METADATA_SIZE
-from .errors import StorageError
+from .errors import StorageError, DependencyError
 from .size import Size
 from .devicetree import DeviceTree
 from .formats import get_default_filesystem_type
@@ -786,12 +786,20 @@ class Blivet(object):
             :type device: :class:`~.devices.StorageDevice`
             :rtype: None
         """
-        self.devicetree.actions.add(ActionCreateDevice(device))
+        action_create_dev = ActionCreateDevice(device)
+        self.devicetree.actions.add(action_create_dev)
 
         is_snapshot = isinstance(device, LVMLogicalVolumeDevice) and device.is_snapshot_lv
 
         if device.format.type and not device.format_immutable and not is_snapshot:
-            self.devicetree.actions.add(ActionCreateFormat(device))
+            action_create_fmt = None
+            try:
+                action_create_fmt = ActionCreateFormat(device)
+            except (ValueError, DependencyError) as e:
+                # revert devicetree changes done so far
+                self.devicetree.actions.remove(action_create_dev)
+                raise e
+            self.devicetree.actions.add(action_create_fmt)
 
     def destroy_device(self, device):
         """ Schedule destruction of a device.

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -24,6 +24,7 @@ from six import add_metaclass
 
 from . import util
 from . import udev
+from .errors import DependencyError
 from .util import get_current_entropy
 from .devices import StorageDevice
 from .devices import PartitionDevice, LVMLogicalVolumeDevice
@@ -162,7 +163,7 @@ class DeviceAction(util.ObjectID):
         unavailable_dependencies = device.unavailable_dependencies
         if unavailable_dependencies:
             dependencies_str = ", ".join(str(d) for d in unavailable_dependencies)
-            raise ValueError("device type %s requires unavailable_dependencies: %s" % (device.type, dependencies_str))
+            raise DependencyError("device type %s requires unavailable_dependencies: %s" % (device.type, dependencies_str))
 
         self.device = device
         self.container = getattr(self.device, "container", None)


### PR DESCRIPTION
 - when `create_device` raises an exception during the format creation, previously
created device is now cleaned from the devicetree; the exception is then reraised
 - this prevents having the device with the same name already in the devicetree
when retrying the `create_device` command
 - changed dependency related exception in `DeviceAction.__init__` from `ValueError`
to `DependencyError` and updated the rest of code and the tests accordingly