### PR TITLE
devicetree.names is now a property

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -952,13 +952,11 @@ class DeviceFactory(object):
         _blivet_copy = self.storage.copy()
         self.__devices = _blivet_copy.devicetree._devices
         self.__actions = _blivet_copy.devicetree._actions
-        self.__names = _blivet_copy.devicetree.names
         self.__roots = _blivet_copy.roots
 
     def _revert_devicetree(self):
         self.storage.devicetree._devices = self.__devices
         self.storage.devicetree._actions = self.__actions
-        self.storage.devicetree.names = self.__names
         self.storage.roots = self.__roots
 
 

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -123,9 +123,6 @@ class LVMFormatPopulator(FormatPopulator):
         lv_info = dict((k, v) for (k, v) in iter(lvs_info.cache.items())
                        if v.vg_name == vg_name)
 
-        # FIXME: This should account for added/removed LVs.
-        self._devicetree.names.extend(n for n in lv_info.keys() if n not in self._devicetree.names)
-
         for lv_device in vg_device.lvs[:]:
             if lv_device.name not in lv_info:
                 log.info("lv %s was removed", lv_device.name)

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -1,6 +1,6 @@
 import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import Mock, patch, sentinel  # pylint: disable=no-name-in-module,import-error
+from six.moves.mock import Mock, patch, PropertyMock, sentinel  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 
@@ -15,6 +15,7 @@ from blivet.devices.lib import Tags
 from blivet.devicetree import DeviceTree
 from blivet.formats import get_format
 from blivet.size import Size
+from blivet.static_data.lvm_info import lvs_info, LVsInfo
 
 """
     TODO:
@@ -59,14 +60,41 @@ class DeviceTreeTestCase(unittest.TestCase):
 
         self.assertEqual(dt.resolve_device(dev3.name), dev3)
 
+    def test_device_name(self):
+        # check that devicetree.names property contains all device's names
+
+        # mock lvs_info to avoid blockdev call allowing run as non-root
+        with patch.object(LVsInfo, 'cache', new_callable=PropertyMock) as mock_lvs_cache:
+            mock_lvs_cache.return_value = {"sdmock": "dummy"}
+
+            tree = DeviceTree()
+            dev_names = ["sda", "sdb", "sdc"]
+
+            for dev_name in dev_names:
+                dev = DiskDevice(dev_name)
+                tree._add_device(dev)
+                self.assertTrue(dev in tree.devices)
+
+            # frobnicate a bit with the hidden status of the devices:
+            # * hide sda
+            # * hide and unhide again sdb
+            # * leave sdc unchanged
+            tree.hide(tree.get_device_by_name("sda"))
+            tree.hide(tree.get_device_by_name("sdb"))
+            tree.unhide(tree.get_device_by_name("sdb", hidden=True))
+
+            # some lvs names may be already present in the system (mocked)
+            lv_info = list(lvs_info.cache.keys())
+
+            # all devices should still be present in the tree.names
+            self.assertEqual(sorted(tree.names), sorted(lv_info + dev_names))
+
     def test_reset(self):
         dt = DeviceTree()
         names = ["fakedev1", "fakedev2"]
         for name in names:
             device = Mock(name=name, spec=StorageDevice, parents=[], exists=True)
             dt._devices.append(device)
-
-        dt.names = names[:]
 
         dt.actions._actions.append(Mock(name="fake action"))
 


### PR DESCRIPTION
- removed devicetree.names list
- introduced property with the same name and function
- devicetree.names are now obtained directly from devices
- added a test to check the proper behavior