### PR TITLE
Added min size for file systems

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1968,7 +1968,8 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def max_size(self):
         """ The maximum size this lv can be. """
-        max_lv = self.size + self.vg.free_space
+        max_lv = (self.vg.align(self.size, roundup=True) +
+                  self.vg.align(self.vg.free_space, roundup=False))
         max_format = self.format.max_size
         return min(max_lv, max_format) if max_format else max_lv
 

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -71,6 +71,7 @@ class FS(DeviceFormat):
     _uuidfs = None                       # functionality for UUIDs
     _fsck_class = fsck.UnimplementedFSCK
     _mkfs_class = fsmkfs.UnimplementedFSMkfs
+    _min_size = Size("2 MiB")            # default minimal size
     _mount_class = fsmount.FSMount
     _readlabel_class = fsreadlabel.UnimplementedFSReadLabel
     _sync_class = fssync.UnimplementedFSSync
@@ -1256,6 +1257,7 @@ class NoDevFS(FS):
     _type = "nodev"
     _mount_class = fsmount.NoDevFSMount
     _selinux_supported = False
+    _min_size = Size(0)
 
     def __init__(self, **kwargs):
         FS.__init__(self, **kwargs)

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -301,7 +301,7 @@ class DeviceActionTestCase(StorageTestCase):
                                name="sdc1", size=Size("100 GiB"),
                                parents=[sdc], exists=True)
 
-        sdc1_format = self.new_format("ext2", device=sdc1.path, mountpoint="/")
+        sdc1_format = self.new_format("ext2", device=sdc1.path, mountpoint="/", size=Size("100 GiB"))
         create_sdc1_format = ActionCreateFormat(sdc1, sdc1_format)
         create_sdc1_format.apply()
         with self.assertRaises(blivet.errors.DeviceTreeError):

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -33,6 +33,7 @@ from blivet.devicelibs import mdraid
 from blivet.size import Size
 
 from blivet.formats import get_format
+from blivet.formats.fs import FS
 
 BTRFS_MIN_MEMBER_SIZE = get_format("btrfs").min_size
 
@@ -599,7 +600,8 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
             "media_present": xform(self.assertTrue),
             "metadata_level": lambda d, a: self.assertFalse(hasattr(d, a)),
             "type": xform(lambda x, m: self.assertEqual(x, "btrfs", m)),
-            "vol_id": xform(lambda x, m: self.assertEqual(x, btrfs.MAIN_VOLUME_ID, m))}
+            "vol_id": xform(lambda x, m: self.assertEqual(x, btrfs.MAIN_VOLUME_ID, m))
+        }
         self._state_functions.update(state_functions)
 
     def setUp(self):
@@ -759,6 +761,8 @@ class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
             "parents": xform(lambda x, m: self.assertEqual(len(x), 1, m) and
                              self.assertIsInstance(x, ParentList) and
                              self.assertIsInstance(x[0], LVMVolumeGroupDevice)),
+            "size": xform(lambda x, m: self.assertEqual(x, FS._min_size, m)),
+            "target_size": xform(lambda x, m: self.assertEqual(x, FS._min_size, m))
         }
 
         self._state_functions.update(state_functions)

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -87,13 +87,16 @@ class LVMDeviceTest(unittest.TestCase):
         vg = LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
 
         cache_req = LVMCacheRequest(Size("512 MiB"), [pv2], "writethrough")
-        lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
+        lv = LVMLogicalVolumeDevice("testlv",
+                                    parents=[vg],
                                     fmt=blivet.formats.get_format("xfs"),
-                                    exists=False, cache_request=cache_req)
+                                    size=Size(blivet.formats.get_format("xfs").min_size),
+                                    exists=False,
+                                    cache_request=cache_req)
 
         # the cache reserves space for its metadata from the requested size, but
         # it may require (and does in this case) a pmspare LV to be allocated
-        self.assertEqual(lv.vg_space_used, Size("504 MiB"))
+        self.assertEqual(lv.vg_space_used, Size("508 MiB"))
 
         # check that the LV behaves like a cached LV
         self.assertTrue(lv.cached)

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -34,7 +34,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         dev1_label = "dev1_label"
         dev1_uuid = "1234-56-7890"
         fmt1 = get_format("ext4", label=dev1_label, uuid=dev1_uuid)
-        dev1 = StorageDevice("dev1", exists=True, fmt=fmt1)
+        dev1 = StorageDevice("dev1", exists=True, fmt=fmt1, size=fmt1.min_size)
         dt._add_device(dev1)
 
         dev2_label = "dev2_label"

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -87,6 +87,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
 
         # sizes
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))
@@ -98,6 +99,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         an_fs = self._fs_class(size=NEW_SIZE)
 
         # sizes
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, NEW_SIZE)
         self.assertEqual(an_fs.current_size, Size(0))
@@ -114,6 +116,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertTrue(an_fs.exists)
         self.assertIsNone(an_fs.do_check())
 
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -87,9 +87,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
 
         # sizes
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
-
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))
@@ -101,9 +98,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         an_fs = self._fs_class(size=NEW_SIZE)
 
         # sizes
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
-
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, NEW_SIZE)
         self.assertEqual(an_fs.current_size, Size(0))
@@ -119,9 +113,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
         self.assertTrue(an_fs.exists)
         self.assertIsNone(an_fs.do_check())
-
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
 
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))


### PR DESCRIPTION
- added default minimal file system size into FS class (2 MiB)
- overriden in certain subclasses (e.g. NoDevFS)
- updated tests behavior to reflect the changes
    
Resolves: #1554519
