### PR TITLE
Fixups for missing dependency tests.

### DIFF
--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -62,9 +62,23 @@ class ExternalResource(object):
             :returns: [] if the resource is available
             :rtype: list of str
         """
-        if self._availability_errors is None or not CACHE_AVAILABILITY:
-            self._availability_errors = self._method.availability_errors(self)
-        return self._availability_errors[:]
+        _errors = list()
+
+        # Prepare error cache and return value based on current caching setting.
+        if CACHE_AVAILABILITY:
+            _errors = self._availability_errors
+        else:
+            self._availability_errors = None
+
+        # Check for errors if necessary.
+        if self._availability_errors is None:
+            _errors = self._method.availability_errors(self)
+
+        # Update error cache if necessary.
+        if CACHE_AVAILABILITY and self._availability_errors is None:
+            self._availability_errors = _errors[:]
+
+        return _errors
 
     @property
     def available(self):

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -146,10 +146,11 @@ class MissingWeakDependenciesTestCase(unittest.TestCase):
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.disk1_file = create_sparse_tempfile("disk1", Size("2GiB"))
+        self.plugins = blockdev.plugin_specs_from_names(blockdev.get_available_plugin_names())
 
     def _clean_up(self):
         # reload all libblockdev plugins
-        blockdev.try_reinit(require_plugins=None, reload=False)
+        self.load_all_plugins()
 
         for disk in self.bvt.disks:
             self.bvt.recursive_remove(disk)
@@ -160,7 +161,7 @@ class MissingWeakDependenciesTestCase(unittest.TestCase):
                 os.unlink(fn)
 
     def load_all_plugins(self):
-        result, plugins = blockdev.try_reinit(require_plugins=None, reload=False)
+        result, plugins = blockdev.try_reinit(require_plugins=self.plugins, reload=True)
         if not result:
             self.fail("Could not reload libblockdev plugins")
         return plugins

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -159,6 +159,7 @@ class MissingWeakDependenciesTestCase(unittest.TestCase):
         for fn in self.bvt.disk_images.values():
             if os.path.exists(fn):
                 os.unlink(fn)
+        availability.CACHE_AVAILABILITY = True
 
     def load_all_plugins(self):
         result, plugins = blockdev.try_reinit(require_plugins=self.plugins, reload=True)


### PR DESCRIPTION
These changes fix the partitioning test error and allow running (most of) these tests as non-root.

This is an alternative to #691.