### PR TITLE
Do not use rpm to check for Zanata client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all:
 	$(MAKE) -C po
 
 po-pull:
-	rpm -q zanata-python-client &>/dev/null || ( echo "need to run: $(PKG_INSTALL) install zanata-python-client"; exit 1 )
+	@which zanata >/dev/null 2>&1 || ( echo "You need to install Zanata client to download translation files"; exit 1 )
 	zanata pull $(ZANATA_PULL_ARGS)
 
 po-empty:


### PR DESCRIPTION
`zanata-python-client` package was renamed to `python2-zanata-client` so the `rpm -q` no longer works (`rpm -qa` works but I think it's better to check for the command than the package).