### PR TITLE
The key size of LUKS should be 0 by default

### DIFF
--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -96,7 +96,7 @@ class LUKS(DeviceFormat):
         self._resize = self._resize_class(self)
 
         self.cipher = kwargs.get("cipher")
-        self.key_size = kwargs.get("key_size")
+        self.key_size = kwargs.get("key_size") or 0
         self.map_name = kwargs.get("name")
 
         if not self.exists and not self.cipher:


### PR DESCRIPTION
If the cipher is specified, then the key size is None by default
and liblockdev fails to create the format, because it expects 0 by
default. Because of that, Anaconda fails to do the partitioning
if the kickstart option --cipher is specified.