### PR TITLE
LUKS2 support

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -327,7 +327,7 @@ class DeviceFactory(object):
             setattr(self, setting, value)
 
         self.fstype = None  # not included in default_settings b/c of special handling below
-        self.min_luks_entropy = luks_data.min_entropy
+        self.min_luks_entropy = kwargs.get("min_luks_entropy") or luks_data.min_entropy
 
         # If a device was passed, update the defaults based on it.
         self.device = kwargs.get("device")

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -673,6 +673,7 @@ class DeviceFactory(object):
         if self.encrypted:
             fstype = "luks"
             mountpoint = None
+            fmt_args["min_luks_entropy"] = self.min_luks_entropy
         else:
             fstype = self.fstype
             mountpoint = self.mountpoint
@@ -725,7 +726,6 @@ class DeviceFactory(object):
 
             fmt = get_format(self.fstype,
                              mountpoint=self.mountpoint,
-                             min_luks_entropy=self.min_luks_entropy,
                              **fmt_args)
             luks_device = LUKSDevice("luks-" + device.name,
                                      parents=[device], fmt=fmt)

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -20,6 +20,11 @@
 #            Martin Sivak <msivak@redhat.com>
 #
 
+import gi
+gi.require_version("BlockDev", "2.0")
+
+from gi.repository import BlockDev
+
 from ..size import Size
 from ..tasks import availability
 
@@ -28,3 +33,7 @@ MIN_CREATE_ENTROPY = 256  # bits
 SECTOR_SIZE = Size("512 B")
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_CRYPTO_PLUGIN]
+
+LUKS_VERSIONS = {"luks1": BlockDev.CryptoLUKSVersion.LUKS1,
+                 "luks2": BlockDev.CryptoLUKSVersion.LUKS2}
+DEFAULT_LUKS_VERSION = "luks1"

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -25,8 +25,12 @@ gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev
 
-from ..size import Size
+from ..size import Size, ROUND_DOWN
 from ..tasks import availability
+from ..util import total_memory, available_memory
+
+import logging
+log = logging.getLogger("blivet")
 
 LUKS_METADATA_SIZE = Size("2 MiB")
 MIN_CREATE_ENTROPY = 256  # bits
@@ -37,3 +41,26 @@ EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_CRYPTO_PLUGIN]
 LUKS_VERSIONS = {"luks1": BlockDev.CryptoLUKSVersion.LUKS1,
                  "luks2": BlockDev.CryptoLUKSVersion.LUKS2}
 DEFAULT_LUKS_VERSION = "luks1"
+
+
+def calculate_luks2_max_memory():
+    """ Calculates maximum RAM that will be used during LUKS format.
+        The calculation is based on currenly available (free) memory.
+        This value will be used for the 'max_memory_kb' option for the
+        'argon2' key derivation function.
+    """
+    free_mem = available_memory()
+    total_mem = total_memory()
+
+    # we want to always use at least 128 MiB
+    if free_mem < Size("128 MiB"):
+        log.warning("Less than 128 MiB RAM is currently free, LUKS2 format may fail.")
+        return Size("128 MiB")
+
+    # upper limit from cryptsetup is max(half RAM, 1 GiB)
+    elif free_mem >= Size("1 GiB") or free_mem >= (total_mem / 2):
+        return None
+
+    # free rounded to multiple of 128 MiB
+    else:
+        return free_mem.round_to_nearest(Size("128 MiB"), ROUND_DOWN)

--- a/blivet/devices/__init__.py
+++ b/blivet/devices/__init__.py
@@ -24,8 +24,8 @@ from .device import Device
 from .storage import StorageDevice
 from .disk import DiskDevice, DiskFile, DMRaidArrayDevice, MultipathDevice, iScsiDiskDevice, FcoeDiskDevice, DASDDevice, ZFCPDiskDevice, NVDIMMNamespaceDevice
 from .partition import PartitionDevice
-from .dm import DMDevice, DMLinearDevice, DMCryptDevice, DM_MAJORS
-from .luks import LUKSDevice
+from .dm import DMDevice, DMLinearDevice, DMCryptDevice, DMIntegrityDevice, DM_MAJORS
+from .luks import LUKSDevice, IntegrityDevice
 from .lvm import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
 from .md import MDBiosRaidArrayDevice, MDContainerDevice, MDRaidArrayDevice, MD_MAJORS
 from .btrfs import BTRFSDevice, BTRFSVolumeDevice, BTRFSSubVolumeDevice, BTRFSSnapShotDevice

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -251,3 +251,30 @@ class DMCryptDevice(DMDevice):
         DMDevice.__init__(self, name, fmt=fmt, size=size,
                           parents=parents, sysfs_path=sysfs_path,
                           exists=exists, target="crypt")
+
+
+class DMIntegrityDevice(DMDevice):
+
+    """ A dm-integrity device """
+    _type = "dm-integrity"
+    _encrypted = True
+
+    def __init__(self, name, fmt=None, size=None, uuid=None,
+                 exists=False, sysfs_path='', parents=None):
+        """
+            :param name: the device name (generally a device node's basename)
+            :type name: str
+            :keyword exists: does this device exist?
+            :type exists: bool
+            :keyword size: the device's size
+            :type size: :class:`~.size.Size`
+            :keyword parents: a list of parent devices
+            :type parents: list of :class:`StorageDevice`
+            :keyword fmt: this device's formatting
+            :type fmt: :class:`~.formats.DeviceFormat` or a subclass of it
+            :keyword sysfs_path: sysfs device path
+            :type sysfs_path: str
+        """
+        DMDevice.__init__(self, name, fmt=fmt, size=size,
+                          parents=parents, sysfs_path=sysfs_path,
+                          exists=exists, target="integrity")

--- a/blivet/devices/luks.py
+++ b/blivet/devices/luks.py
@@ -30,7 +30,7 @@ import logging
 log = logging.getLogger("blivet")
 
 from .storage import StorageDevice
-from .dm import DMCryptDevice
+from .dm import DMCryptDevice, DMIntegrityDevice
 
 
 class LUKSDevice(DMCryptDevice):
@@ -140,3 +140,34 @@ class LUKSDevice(DMCryptDevice):
         self.slave.populate_ksdata(data)
         data.encrypted = True
         super(LUKSDevice, self).populate_ksdata(data)
+
+
+class IntegrityDevice(DMIntegrityDevice):
+
+    """ A mapped integrity device. """
+    _type = "integrity/dm-crypt"
+    _resizable = True
+    _packages = ["cryptsetup"]
+    _external_dependencies = [availability.BLOCKDEV_CRYPTO_PLUGIN]
+
+    def __init__(self, name, fmt=None, size=None, uuid=None,
+                 exists=False, sysfs_path='', parents=None):
+        """
+            :param name: the device name (generally a device node's basename)
+            :type name: str
+            :keyword exists: does this device exist?
+            :type exists: bool
+            :keyword size: the device's size
+            :type size: :class:`~.size.Size`
+            :keyword parents: a list of parent devices
+            :type parents: list of :class:`StorageDevice`
+            :keyword fmt: this device's formatting
+            :type fmt: :class:`~.formats.DeviceFormat` or a subclass of it
+            :keyword sysfs_path: sysfs device path
+            :type sysfs_path: str
+            :keyword uuid: the device UUID
+            :type uuid: str
+        """
+        DMIntegrityDevice.__init__(self, name, fmt=fmt, size=size,
+                                   parents=parents, sysfs_path=sysfs_path,
+                                   uuid=None, exists=exists)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -241,6 +241,12 @@ class LUKS(DeviceFormat):
         log.debug("unmapping %s", self.map_name)
         blockdev.crypto.luks_close(self.map_name)
 
+    def _pre_resize(self):
+        if self.luks_version == "luks2" and not self.has_key:
+            raise LUKSError("Passphrase or key needs to be set before resizing LUKS2 format.")
+
+        super(LUKS, self)._pre_resize()
+
     def _pre_create(self, **kwargs):
         super(LUKS, self)._pre_create(**kwargs)
         self.map_name = None

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -40,6 +40,16 @@ import logging
 log = logging.getLogger("blivet")
 
 
+class LUKS2PBKDFArgs(object):
+    """ PBKDF arguments for LUKS 2 format """
+
+    def __init__(self, type=None, max_memory_kb=0, iterations=0, time_ms=0):  # pylint: disable=redefined-builtin
+        self.type = type
+        self.max_memory_kb = max_memory_kb
+        self.iterations = iterations
+        self.time_ms = time_ms
+
+
 class LUKS(DeviceFormat):
 
     """ LUKS """
@@ -82,6 +92,9 @@ class LUKS(DeviceFormat):
             :type min_luks_entropy: int
             :keyword luks_version: luks format version ("luks1" or "luks2")
             :type luks_version: str
+            :keyword pbkdf_args: optional arguments for LUKS2 key derivation function
+                                 (for non-existent format only)
+            :type pbkdf_args: :class:`LUKS2PBKDFArgs`
 
             .. note::
 
@@ -134,6 +147,15 @@ class LUKS(DeviceFormat):
                 self.options = "discard"
             elif "discard" not in self.options:
                 self.options += ",discard"
+
+        self.pbkdf_args = kwargs.get("pbkdf_args")
+        if self.pbkdf_args:
+            if self.luks_version != "luks2":
+                raise ValueError("PBKDF arguments are valid only for LUKS version 2.")
+            if self.pbkdf_args.time_ms and self.pbkdf_args.iterations:
+                log.warning("Both iterations and time_ms specified for PBKDF, number of iterations will be ignored.")
+            if self.pbkdf_args.type == "pbkdf2" and self.pbkdf_args.max_memory_kb:
+                log.warning("Memory limit is not used for pbkdf2 and it will be ignored.")
 
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
@@ -257,13 +279,25 @@ class LUKS(DeviceFormat):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
         super(LUKS, self)._create(**kwargs)  # set up the event sync
+
+        if self.pbkdf_args:
+            pbkdf = blockdev.CryptoLUKSPBKDF(type=self.pbkdf_args.type,
+                                             hash=None,
+                                             max_memory_kb=self.pbkdf_args.max_memory_kb,
+                                             iterations=self.pbkdf_args.iterations,
+                                             time_ms=self.pbkdf_args.time_ms)
+            extra = blockdev.CryptoLUKSExtra(pbkdf=pbkdf)
+        else:
+            extra = None
+
         blockdev.crypto.luks_format(self.device,
                                     passphrase=self.__passphrase,
                                     key_file=self._key_file,
                                     cipher=self.cipher,
                                     key_size=self.key_size,
                                     min_entropy=self.min_luks_entropy,
-                                    luks_version=crypto.LUKS_VERSIONS[self.luks_version])
+                                    luks_version=crypto.LUKS_VERSIONS[self.luks_version],
+                                    extra=extra)
 
     def _post_create(self, **kwargs):
         super(LUKS, self)._post_create(**kwargs)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -307,3 +307,39 @@ class LUKS(DeviceFormat):
 
 
 register_device_format(LUKS)
+
+
+class Integrity(DeviceFormat):
+
+    """ DM integrity format """
+    _type = "integrity"
+    _name = N_("DM Integrity")
+    _udev_types = ["DM_integrity"]
+    _supported = False                 # is supported
+    _formattable = False               # can be formatted
+    _linux_native = True               # for clearpart
+    _resizable = False                 # can be resized
+    _packages = ["cryptsetup"]         # required packages
+    _plugin = availability.BLOCKDEV_CRYPTO_PLUGIN
+
+    def __init__(self, **kwargs):
+        """
+            :keyword device: the path to the underlying device
+            :keyword uuid: the LUKS UUID
+            :keyword exists: indicates whether this is an existing format
+            :type exists: bool
+            :keyword name: the name of the mapped device
+
+            .. note::
+
+                The 'device' kwarg is required for existing formats. For non-
+                existent formats, it is only necessary that the :attr:`device`
+                attribute be set before the :meth:`create` method runs. Note
+                that you can specify the device at the last moment by specifying
+                it via the 'device' kwarg to the :meth:`create` method.
+        """
+        log_method_call(self, **kwargs)
+        DeviceFormat.__init__(self, **kwargs)
+
+
+register_device_format(Integrity)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -352,6 +352,15 @@ class LUKS(DeviceFormat):
                                       directory, backup_passphrase)
         log.debug("escrow: escrow_volume done for %s", repr(self.device))
 
+    def populate_ksdata(self, data):
+        super(LUKS, self).populate_ksdata(data)
+        data.luks_version = self.luks_version
+
+        if self.pbkdf_args:
+            data.pbkdf = self.pbkdf_args.type
+            data.pbkdf_memory = self.pbkdf_args.max_memory_kb
+            data.pbkdf_iterations = self.pbkdf_args.iterations
+            data.pbkdf_time = self.pbkdf_args.time_ms
 
 register_device_format(LUKS)
 

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -11,7 +11,7 @@ from .disklabel import DiskLabelFormatPopulator
 from .dm import DMDevicePopulator
 from .dmraid import DMRaidFormatPopulator
 from .loop import LoopDevicePopulator
-from .luks import LUKSDevicePopulator, LUKSFormatPopulator
+from .luks import LUKSDevicePopulator, LUKSFormatPopulator, IntegrityDevicePopulator
 from .lvm import LVMDevicePopulator, LVMFormatPopulator
 from .mdraid import MDDevicePopulator, MDFormatPopulator
 from .multipath import MultipathDevicePopulator, MultipathFormatPopulator

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -11,7 +11,7 @@ from .disklabel import DiskLabelFormatPopulator
 from .dm import DMDevicePopulator
 from .dmraid import DMRaidFormatPopulator
 from .loop import LoopDevicePopulator
-from .luks import LUKSDevicePopulator, LUKSFormatPopulator, IntegrityDevicePopulator
+from .luks import LUKSDevicePopulator, LUKSFormatPopulator, IntegrityDevicePopulator, IntegrityFormatPopulator
 from .lvm import LVMDevicePopulator, LVMFormatPopulator
 from .mdraid import MDDevicePopulator, MDFormatPopulator
 from .multipath import MultipathDevicePopulator, MultipathFormatPopulator

--- a/blivet/populator/helpers/dm.py
+++ b/blivet/populator/helpers/dm.py
@@ -38,6 +38,7 @@ class DMDevicePopulator(DevicePopulator):
         return (udev.device_is_dm(data) and
                 not udev.device_is_dm_partition(data) and
                 not udev.device_is_dm_luks(data) and
+                not udev.device_is_dm_integrity(data) and
                 not udev.device_is_dm_lvm(data) and
                 not udev.device_is_dm_mpath(data) and
                 not udev.device_is_dm_raid(data))

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -26,7 +26,7 @@ gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from ... import udev
-from ...devices import LUKSDevice
+from ...devices import LUKSDevice, IntegrityDevice
 from ...errors import DeviceError, LUKSError
 from ...flags import flags
 from .devicepopulator import DevicePopulator
@@ -48,6 +48,21 @@ class LUKSDevicePopulator(DevicePopulator):
                             sysfs_path=udev.device_get_sysfs_path(self.data),
                             parents=parents,
                             exists=True)
+        self._devicetree._add_device(device)
+        return device
+
+
+class IntegrityDevicePopulator(DevicePopulator):
+    @classmethod
+    def match(cls, data):
+        return udev.device_is_dm_integrity(data)
+
+    def run(self):
+        parents = self._devicetree._add_slave_devices(self.data)
+        device = IntegrityDevice(udev.device_get_name(self.data),
+                                 sysfs_path=udev.device_get_sysfs_path(self.data),
+                                 parents=parents,
+                                 exists=True)
         self._devicetree._add_device(device)
         return device
 

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -122,3 +122,8 @@ class LUKSFormatPopulator(FormatPopulator):
         else:
             log.warning("luks device %s already in the tree",
                         self.device.format.map_name)
+
+
+class IntegrityFormatPopulator(FormatPopulator):
+    priority = 100
+    _type_specifier = "integrity"

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -113,23 +113,12 @@ class LUKSFormatPopulator(FormatPopulator):
                     else:
                         break
 
-            luks_device = LUKSDevice(self.device.format.map_name,
-                                     parents=[self.device],
-                                     exists=True)
+            # try only to setup the luks format -- the luks device will be
+            # discovered and added later by the LUKSDevicePopulator
             try:
-                luks_device.setup()
+                self.device.format.setup()
             except (LUKSError, blockdev.CryptoError, DeviceError) as e:
                 log.info("setup of %s failed: %s", self.device.format.map_name, e)
-                self.device.remove_child(luks_device)
-            else:
-                luks_device.update_sysfs_path()
-                self._devicetree._add_device(luks_device)
-                luks_info = udev.get_device(luks_device.sysfs_path)
-                if not luks_info:
-                    log.error("failed to get udev data for %s", luks_device.name)
-                    return
-
-                self._devicetree.handle_device(luks_info, update_orig_fmt=True)
         else:
             log.warning("luks device %s already in the tree",
                         self.device.format.map_name)

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -74,6 +74,7 @@ class LUKSFormatPopulator(FormatPopulator):
     def _get_kwargs(self):
         kwargs = super(LUKSFormatPopulator, self)._get_kwargs()
         kwargs["name"] = "luks-%s" % udev.device_get_uuid(self.data)
+        kwargs["luks_version"] = "luks%s" % udev.device_get_format_version(self.data)
         return kwargs
 
     def run(self):

--- a/blivet/static_data/luks_data.py
+++ b/blivet/static_data/luks_data.py
@@ -36,6 +36,8 @@ class LUKS_Data(object):
         self.__passphrases = []
         # dict of luks devices {device: passphrase}
         self.__luks_devs = {}
+        # default pbkdf parameters for LUKS2 format creation
+        self._pbkdf_args = None
 
     @property
     def encryption_passphrase(self):
@@ -63,6 +65,14 @@ class LUKS_Data(object):
     @luks_devs.setter
     def luks_devs(self, value):
         self.__luks_devs = value
+
+    @property
+    def pbkdf_args(self):
+        return self._pbkdf_args
+
+    @pbkdf_args.setter
+    def pbkdf_args(self, value):
+        self._pbkdf_args = value
 
     def clear_passphrases(self):
         self.__passphrases = []

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -321,6 +321,7 @@ BLOCKDEV_CRYPTO_ALL_MODES = (blockdev.CryptoTechMode.CREATE |
 BLOCKDEV_CRYPTO = BlockDevTechInfo(plugin_name="crypto",
                                    check_fn=blockdev.crypto_is_tech_avail,
                                    technologies={blockdev.CryptoTech.LUKS: BLOCKDEV_CRYPTO_ALL_MODES,
+                                                 blockdev.CryptoTech.LUKS2: BLOCKDEV_CRYPTO_ALL_MODES,
                                                  blockdev.CryptoTech.ESCROW: blockdev.CryptoTechMode.CREATE})
 BLOCKDEV_CRYPTO_TECH = BlockDevMethod(BLOCKDEV_CRYPTO)
 

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -86,6 +86,11 @@ class LUKSResize(task.BasicApplication, dfresize.DFResizeTask):
     def do_task(self):
         """ Resizes the LUKS format. """
         try:
-            blockdev.crypto.luks_resize(self.luks.map_name, self.luks.target_size.convert_to(self.unit))
+            if self.luks.luks_version == "luks2":
+                blockdev.crypto.luks_resize(self.luks.map_name, self.luks.target_size.convert_to(self.unit),
+                                            passphrase=self.luks._LUKS__passphrase,
+                                            key_file=self.luks._key_file)
+            else:
+                blockdev.crypto.luks_resize(self.luks.map_name, self.luks.target_size.convert_to(self.unit))
         except blockdev.CryptoError as e:
             raise LUKSError(e)

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -214,6 +214,11 @@ def device_get_format(udev_info):
     return udev_info.get("ID_FS_TYPE")
 
 
+def device_get_format_version(udev_info):
+    """ Return a device's format version as reported by udev. """
+    return udev_info.get("ID_FS_VERSION")
+
+
 def device_get_uuid(udev_info):
     """ Get the UUID from the device's format as reported by udev.
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -620,6 +620,20 @@ def device_is_dm_luks(info):
     return is_crypt and _type.startswith("luks")
 
 
+def device_is_dm_integrity(info):
+    """ Return True if the device is a mapped integrity device. """
+    is_crypt = device_dm_subsystem_match(info, "crypt")
+    if not is_crypt:
+        return False
+
+    try:
+        _type = info.get("DM_UUID", "").split("-")[1].lower()
+    except IndexError:
+        _type = ""
+
+    return _type.startswith("integrity")
+
+
 def device_is_dm_raid(info):
     """ Return True if the device is a dmraid array device. """
     return device_dm_subsystem_match(info, "dmraid")

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -310,6 +310,29 @@ def total_memory():
     mem = (mem / bs + 1) * bs
     return mem
 
+
+def available_memory():
+    """ Return the amount of system RAM that is currenly available.
+
+        :rtype: :class:`~.size.Size`
+    """
+    # import locally to avoid a cycle with size importing util
+    from .size import Size
+
+    with open("/proc/meminfo") as lines:
+        mems = {k.strip(): v.strip() for k, v in (l.split(":", 1) for l in lines)}
+
+    if "MemAvailable" in mems.keys():
+        return Size("%s KiB" % mems["MemAvailable"].split()[0])
+    else:
+        # MemAvailable is not present on linux < 3.14
+        free = Size("%s KiB" % mems["MemFree"].split()[0])
+        cached = Size("%s KiB" % mems["Cached"].split()[0])
+        buffers = Size("%s KiB" % mems["Buffers"].split()[0])
+
+        return (free + cached + buffers)
+
+
 ##
 # sysfs functions
 ##

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -36,7 +36,7 @@ Source0: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 2.6
+%global libblockdevver 2.17
 %global libbytesizever 0.3
 %global pyudevver 0.18
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -33,6 +33,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
     helper_class = DMDevicePopulator
 
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)
@@ -52,6 +53,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
         device_is_dm_luks.return_value = False
 
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)
@@ -137,6 +139,7 @@ class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_get_name")
     @patch("blivet.udev.device_is_dm", return_value=False)
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)
@@ -219,6 +222,7 @@ class LVMDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_is_loop", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=True)
     def test_get_helper(self, *args):
         """Test get_device_helper for lvm devices."""
@@ -306,6 +310,7 @@ class OpticalDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_is_dm", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_loop", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)
@@ -367,6 +372,7 @@ class PartitionDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_get_name")
     @patch("blivet.udev.device_is_dm", return_value=False)
     @patch("blivet.udev.device_is_dm_luks", return_value=False)
+    @patch("blivet.udev.device_is_dm_integrity", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)


### PR DESCRIPTION
This is first part of luks2 support for blivet. These changes solve problem with luks2+integrity -- blivet currently expects that the luks device is child of the partition with luks format and this is not true with integrity devices.