### PR TITLE
Use ID_WWN_WITH_EXTENSION for WWNs.

### DIFF
--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -68,7 +68,8 @@ class DMRaidFormatPopulator(FormatPopulator):
                 # Activate the Raid set.
                 blockdev.dm.activate_raid_set(rs_name)
                 dm_array = DMRaidArrayDevice(rs_name,
-                                             parents=[self.device])
+                                             parents=[self.device],
+                                             wwn=self.device.wwn)
 
                 self._devicetree._add_device(dm_array)
 

--- a/blivet/populator/helpers/multipath.py
+++ b/blivet/populator/helpers/multipath.py
@@ -46,7 +46,7 @@ class MultipathDevicePopulator(DevicePopulator):
         if slave_devices:
             device = MultipathDevice(name, parents=slave_devices,
                                      sysfs_path=udev.device_get_sysfs_path(self.data),
-                                     wwn=udev.device_get_wwn(self.data))
+                                     wwn=slave_devices[0].wwn)
             self._devicetree._add_device(device)
 
         return device

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -377,7 +377,11 @@ def device_get_serial(udev_info):
 
 
 def device_get_wwn(udev_info):
-    return udev_info.get("ID_WWN")
+    """ Return the WWID as reported by udev without '0x' prefix. """
+    wwn = udev_info.get("ID_WWN_WITH_EXTENSION")
+    if wwn:
+        wwn = wwn[2:]  # strip off the leading '0x'
+    return wwn
 
 
 def device_get_vendor(udev_info):

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -704,8 +704,8 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         devicetree = DeviceTree()
         # set up some fake udev data to verify handling of specific entries
         data = Mock()
-        _data = {"ID_WWN_WITH_EXTENSION": "0x5000c50086fb75ca",
-                 "DM_UUID": "1-2-3-4"}
+        wwn = "0x5000c50086fb75ca"
+        _data = {"DM_UUID": "1-2-3-4"}
 
         def _getitem_(key, extra=None):
             return _data.get(key, extra)
@@ -714,9 +714,9 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
 
         device_name = "mpathtest"
         device_get_name.return_value = device_name
-        slave_1 = Mock(tags=set())
+        slave_1 = Mock(tags=set(), wwn=wwn[2:])
         slave_1.parents = []
-        slave_2 = Mock(tags=set())
+        slave_2 = Mock(tags=set(), wwn=wwn[2:])
         slave_2.parents = []
         devicetree._add_device(slave_1)
         devicetree._add_device(slave_2)
@@ -728,7 +728,7 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertIsInstance(device, MultipathDevice)
         self.assertTrue(device.exists)
         self.assertEqual(device.name, device_name)
-        self.assertEqual(device.wwn, _data["ID_WWN_WITH_EXTENSION"][2:])
+        self.assertEqual(device.wwn, wwn[2:])
         self.assertTrue(device in devicetree.devices)
 
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -557,7 +557,7 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         devicetree = DeviceTree()
 
         # set up some fake udev data to verify handling of specific entries
-        data = {"SYS_PATH": "dummy", "ID_WWN": "0x5000c50086fb75ca"}
+        data = {"SYS_PATH": "dummy", "ID_WWN_WITH_EXTENSION": "0x5000c50086fb75ca"}
 
         device_name = "nop"
         device_get_name.return_value = device_name
@@ -567,7 +567,7 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertIsInstance(device, DiskDevice)
         self.assertTrue(device.exists)
         self.assertTrue(device.is_disk)
-        self.assertEqual(device.wwn, data["ID_WWN"])
+        self.assertEqual(device.wwn, data["ID_WWN_WITH_EXTENSION"][2:])
         self.assertEqual(device.name, device_name)
         self.assertTrue(device in devicetree.devices)
 
@@ -704,7 +704,7 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         devicetree = DeviceTree()
         # set up some fake udev data to verify handling of specific entries
         data = Mock()
-        _data = {"ID_WWN": "0x5000c50086fb75ca",
+        _data = {"ID_WWN_WITH_EXTENSION": "0x5000c50086fb75ca",
                  "DM_UUID": "1-2-3-4"}
 
         def _getitem_(key, extra=None):
@@ -728,7 +728,7 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertIsInstance(device, MultipathDevice)
         self.assertTrue(device.exists)
         self.assertEqual(device.name, device_name)
-        self.assertEqual(device.wwn, _data["ID_WWN"])
+        self.assertEqual(device.wwn, _data["ID_WWN_WITH_EXTENSION"][2:])
         self.assertTrue(device in devicetree.devices)
 
 


### PR DESCRIPTION
Also strip off the '0x' prefix, which just takes up space.