### PR TITLE
Make sure WWNs are set for multipaths

### DIFF
--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -68,7 +68,8 @@ class DMRaidFormatPopulator(FormatPopulator):
                 # Activate the Raid set.
                 blockdev.dm.activate_raid_set(rs_name)
                 dm_array = DMRaidArrayDevice(rs_name,
-                                             parents=[self.device])
+                                             parents=[self.device],
+                                             wwn=self.device.wwn)
 
                 self._devicetree._add_device(dm_array)
 

--- a/blivet/populator/helpers/multipath.py
+++ b/blivet/populator/helpers/multipath.py
@@ -46,7 +46,7 @@ class MultipathDevicePopulator(DevicePopulator):
         if slave_devices:
             device = MultipathDevice(name, parents=slave_devices,
                                      sysfs_path=udev.device_get_sysfs_path(self.data),
-                                     wwn=udev.device_get_wwn(self.data))
+                                     wwn=slave_devices[0].wwn)
             self._devicetree._add_device(device)
 
         return device


### PR DESCRIPTION
The fact that ID_WWN is not set for multipath devices was made apparent in rhinstaller/anaconda#1503.