### PR TITLE
Remove NVDIMM support on non-x86_64

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2134,6 +2134,10 @@ class Blivet(object):
         :rtype: set(str)
         """
 
+        if not self.nvdimm.nvdimm_plugin_available:
+            log.debug("NVDIMM is not supported, all NVDIMM devices are ignored via a udev blacklist")
+            return set()
+
         ks_allowed_namespaces = set()
         ks_allowed_blockdevs = set()
         if nvdimm_ksdata:

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -28,6 +28,7 @@ import subprocess
 from . import util
 from .size import Size
 from .flags import flags
+from .nvdimm import nvdimm
 
 import pyudev
 global_udev = pyudev.Context()
@@ -39,8 +40,11 @@ from gi.repository import BlockDev as blockdev
 import logging
 log = logging.getLogger("blivet")
 
-INSTALLER_BLACKLIST = (r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram', r'ndblk')
+INSTALLER_BLACKLIST = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram', r'ndblk']
 """ device name regexes to ignore when flags.installer_mode is True """
+# we don't have NVDIMM plugin, just ignore all pmem devices too
+if not nvdimm.nvdimm_plugin_available:
+    INSTALLER_BLACKLIST.append(r'^pmem')
 
 def get_device(sysfs_path):
     try:
@@ -827,5 +831,11 @@ def device_is_nvdimm_namespace(info):
         return False
 
     devname = info.get("DEVNAME", "")
+
+    # we don't have NVDIMM plugin, just return false
+    if not nvdimm.nvdimm_plugin_available:
+        return False
+
     ninfo = blockdev.nvdimm_namespace_get_devname(devname)
+
     return ninfo is not None

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -44,7 +44,6 @@ Requires: python-pyblock >= %{pythonpyblockver}
 Requires: device-mapper-multipath
 Requires: lsof
 Requires: python-blockdev
-Requires: libblockdev-nvdimm
 
 %description
 The python-blivet package is a python module for examining and modifying


### PR DESCRIPTION
This basically ignores nvdimm devices on systems without libblockdev-nvdimm . In installer mode, all `pmem` devices will be ignored, outside of installer existing NVDIMM namespaces in sector mode will be treated as normal disks.