### PR TITLE
Do not ignore "Image out-of-sync" internal LVs

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1010,7 +1010,7 @@ class LVMInternalLVtype(Enum):
         attr_letters = {cls.data: ("T", "C"),
                         cls.meta: ("e",),
                         cls.log: ("l", "L"),
-                        cls.image: ("i",),
+                        cls.image: ("i", "I"),
                         cls.origin: ("o",),
                         cls.cache_pool: ("C",)}
 


### PR DESCRIPTION
These are still "valid" existing internal RAID LVs just not synced
yet.

We are using internal lvs to calculate `free_space` property of vgs. If we ignore these we will report wrong free space, see https://github.com/storaged-project/blivet-gui/issues/107

There is also an issue in lvmdbus (https://bugzilla.redhat.com/show_bug.cgi?id=1608930) -- it doesn't update the Attr property of the LVs so we ignore all internal lvs for raid LVs (because the type is never changed from *(I)mage out-of-sync* to *(i)mage, mirror or raid*).