### PR TITLE
Fixed various issues preventing successful build

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1190,17 +1190,7 @@ class Blivet(object):
 
     def copy(self):
         log.debug("starting Blivet copy")
-
-        # Do not copy ksdata
-        old_data = self.ksdata
-        self.ksdata = None
-
         new = copy.deepcopy(self)
-
-        # Recover ksdata
-        self.ksdata = old_data
-        new.ksdata = old_data
-
         # go through and re-get parted_partitions from the disks since they
         # don't get deep-copied
         hidden_partitions = [d for d in new.devicetree._hidden

--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,4 @@ setup(name='blivet',
       url='http://github.com/storaged-project/blivet',
       data_files=data_files,
       packages=['blivet', 'blivet.dbus', 'blivet.devices', 'blivet.devicelibs', 'blivet.events', 'blivet.formats', 'blivet.populator', 'blivet.static_data', 'blivet.tasks', 'blivet.populator.helpers']
-)
+     )

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -16,7 +16,8 @@ class BlivetLintConfig(PocketLintConfig):
                                FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
                                FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
-                               FalsePositive(r"Parameters differ from overridden 'do_task' method$")
+                               FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
+                               FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$")
                                ]
 
     @property


### PR DESCRIPTION
- now marked as pylint false positive: non-existing 'id' attribute of ObjectID and its children
- fixed sudden wild ksdata variable reappearance caused by merging