### PR TITLE
Fixed various issues preventing successful build

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1190,17 +1190,7 @@ class Blivet(object):
 
     def copy(self):
         log.debug("starting Blivet copy")
-
-        # Do not copy ksdata
-        old_data = self.ksdata
-        self.ksdata = None
-
         new = copy.deepcopy(self)
-
-        # Recover ksdata
-        self.ksdata = old_data
-        new.ksdata = old_data
-
         # go through and re-get parted_partitions from the disks since they
         # don't get deep-copied
         hidden_partitions = [d for d in new.devicetree._hidden

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -599,7 +599,7 @@ class DeviceFactory(object):
     def _create_container(self):
         """ Create the container device required by this factory device. """
         parents = self._get_parent_devices()
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable=attribute-defined-outside-init, assignment-from-no-return
         self.container = self._get_new_container(name=self.container_name,
                                                  parents=parents)
         self.storage.create_device(self.container)
@@ -694,6 +694,7 @@ class DeviceFactory(object):
         parents = self._get_parent_devices()
 
         try:
+            # pylint: disable=assignment-from-no-return
             device = self._get_new_device(parents=parents,
                                           size=size,
                                           fmt_type=fstype,

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1120,7 +1120,7 @@ class LVMInternalLogicalVolumeMixin(object):
 
     @property
     def resizable(self):
-        if DMDevice.resizable.__get__(self) and self._lv_type is LVMInternalLVtype.meta:  # pylint: disable=no-member,too-many-function-args
+        if DMDevice.resizable.__get__(self) and self._lv_type is LVMInternalLVtype.meta:  # pylint: disable=no-member,too-many-function-args,no-value-for-parameter
             if self._parent_lv:
                 return self._parent_lv.is_thin_pool
             else:

--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,4 @@ setup(name='blivet',
       url='http://github.com/storaged-project/blivet',
       data_files=data_files,
       packages=['blivet', 'blivet.dbus', 'blivet.devices', 'blivet.devicelibs', 'blivet.events', 'blivet.formats', 'blivet.populator', 'blivet.static_data', 'blivet.tasks', 'blivet.populator.helpers']
-)
+     )

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -17,7 +17,8 @@ class BlivetLintConfig(PocketLintConfig):
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
                                FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
                                FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
-                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise)'")
+                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise)'"),
+                               FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$")
                                ]
 
     @property


### PR DESCRIPTION
- now marked as pylint false positive: non-existing 'id' attribute of ObjectID and its children
- fixed ksdata variable reappearance caused by merging