### PR TITLE
Create a separate availability check for dmraid support

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -225,7 +225,7 @@ class DMRaidArrayDevice(DMDevice, ContainerDevice):
     _is_disk = True
     _format_class_name = property(lambda s: "dmraidmember")
     _format_uuid_attr = property(lambda s: None)
-    _external_dependencies = [availability.BLOCKDEV_DM_PLUGIN]
+    _external_dependencies = [availability.BLOCKDEV_DM_PLUGIN_RAID]
 
     def __init__(self, name, fmt=None,
                  size=None, parents=None, sysfs_path='', wwn=None):

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -331,9 +331,13 @@ BLOCKDEV_DM_ALL_MODES = (blockdev.DMTechMode.CREATE_ACTIVATE |
                          blockdev.DMTechMode.QUERY)
 BLOCKDEV_DM = BlockDevTechInfo(plugin_name="dm",
                                check_fn=blockdev.dm_is_tech_avail,
-                               technologies={blockdev.DMTech.MAP: BLOCKDEV_DM_ALL_MODES,
-                                             blockdev.DMTech.RAID: BLOCKDEV_DM_ALL_MODES})
+                               technologies={blockdev.DMTech.MAP: BLOCKDEV_DM_ALL_MODES})
 BLOCKDEV_DM_TECH = BlockDevMethod(BLOCKDEV_DM)
+
+BLOCKDEV_DM_RAID = BlockDevTechInfo(plugin_name="dm",
+                                    check_fn=blockdev.dm_is_tech_avail,
+                                    technologies={blockdev.DMTech.RAID: BLOCKDEV_DM_ALL_MODES})
+BLOCKDEV_DM_TECH_RAID = BlockDevMethod(BLOCKDEV_DM_RAID)
 
 # libblockdev loop plugin required technologies and modes
 BLOCKDEV_LOOP_ALL_MODES = (blockdev.LoopTechMode.CREATE |
@@ -399,6 +403,7 @@ BLOCKDEV_SWAP_TECH = BlockDevMethod(BLOCKDEV_SWAP)
 BLOCKDEV_BTRFS_PLUGIN = blockdev_plugin("btrfs", BLOCKDEV_BTRFS_TECH)
 BLOCKDEV_CRYPTO_PLUGIN = blockdev_plugin("crypto", BLOCKDEV_CRYPTO_TECH)
 BLOCKDEV_DM_PLUGIN = blockdev_plugin("dm", BLOCKDEV_DM_TECH)
+BLOCKDEV_DM_PLUGIN_RAID = blockdev_plugin("dm", BLOCKDEV_DM_TECH_RAID)
 BLOCKDEV_LOOP_PLUGIN = blockdev_plugin("loop", BLOCKDEV_LOOP_TECH)
 BLOCKDEV_LVM_PLUGIN = blockdev_plugin("lvm", BLOCKDEV_LVM_TECH)
 BLOCKDEV_MDRAID_PLUGIN = blockdev_plugin("mdraid", BLOCKDEV_MD_TECH)


### PR DESCRIPTION
Libblockdev can now be build without dmraid support so we need
a separate check for dmraid and 'other' dm devices support.

Resolves: rhbz#1617958