### PR TITLE
Ignore pylint 'no-value-for-parameter' warning

### DIFF
--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -235,7 +235,7 @@ class BlockDevMethod(Method):
             :returns: [] if the name of the plugin is loaded
             :rtype: list of str
         """
-        if resource.name not in blockdev.get_available_plugin_names():
+        if resource.name not in blockdev.get_available_plugin_names():  # pylint: disable=no-value-for-parameter
             return ["libblockdev plugin %s not loaded" % resource.name]
         else:
             tech_missing = self._check_technologies()

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -152,7 +152,7 @@ class MissingWeakDependenciesTestCase(unittest.TestCase):
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.disk1_file = create_sparse_tempfile("disk1", Size("2GiB"))
-        self.plugins = blockdev.plugin_specs_from_names(blockdev.get_available_plugin_names())
+        self.plugins = blockdev.plugin_specs_from_names(blockdev.get_available_plugin_names())  # pylint: disable=no-value-for-parameter
 
     def _clean_up(self):
         # reload all libblockdev plugins


### PR DESCRIPTION
Pylint thinks that 'get_available_plugin_names' has a "self"
paramter (it doesn't).