### PR TITLE
Escape dots in lvm filter devices

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -90,7 +90,7 @@ def _getConfigArgs(args):
     filter_string = ""
     rejects = config_args_data["filterRejects"]
     for reject in rejects:
-        filter_string += ("\"r|/%s$|\"," % reject)
+        filter_string += ("\"r|/%s$|\"," % reject.replace(".", r"\."))
 
     if filter_string:
         filter_string = "filter=[%s]" % filter_string.strip(",")


### PR DESCRIPTION
Without this ignoring device like "pmem0.1" will also ignore
first partition on "pmem0s" ("pmem0s1").

Resolves: rhbz#1614039

----

It would probably be better to escape all special characters in the device name (using something like `re.escape`), but it would be quite big change for rhel7-branch and it might break some other things.