### PR TITLE
Install ndctl when NVDIMMs are used.

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -618,6 +618,7 @@ class NVDIMMNamespaceDevice(DiskDevice):
 
     """ Non-volatile memory namespace """
     _type = "nvdimm"
+    _packages = ["ndctl"]
 
     def __init__(self, device, **kwargs):
         """


### PR DESCRIPTION
Related: rhbz#1600496


__TODO__: I need to open a pull request for the same change on 3.1-devel.