### PR TITLE
add `-y' to lvm.pvcreate

### DIFF
--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -120,9 +120,8 @@ class LVMPhysicalVolume(DeviceFormat):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
 
-        # Consider use of -Z|--zero
-        # -f|--force or -y|--yes may be required
-        blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment)
+        ea_yes = blockdev.ExtraArg.new("-y", "")
+        blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
 
     def _destroy(self, **kwargs):
         log_method_call(self, device=self.device,

--- a/tests/formats_test/methods_test.py
+++ b/tests/formats_test/methods_test.py
@@ -389,10 +389,12 @@ class LVMPhysicalVolumeMethodsTestCase(FormatMethodsTestCase):
         self.patches["blockdev"].lvm.pvremove.assert_called_with(self.format.device)
 
     def _test_create_backend(self):
+        self.patches["blockdev"].ExtraArg.new.return_value = sentinel.extra_arg
         self.format.exists = False
         self.format.create()
         self.patches["blockdev"].lvm.pvcreate.assert_called_with(self.format.device,
-                                                                 data_alignment=self.format.data_alignment)  # pylint: disable=no-member
+                                                                 data_alignment=self.format.data_alignment,  # pylint: disable=no-member
+                                                                 extra=[sentinel.extra_arg])
 
 
 class MDRaidMemberMethodsTestCase(FormatMethodsTestCase):


### PR DESCRIPTION
While reinstall a crypt fs, it occasionally failed
[snip]
|gi.overrides.BlockDev.LVMError: Process reported exit code 5:
WARNING: atari signature detected on /dev/mapper/luks-0e5f891c
-7701-48bc-a41e-8d626b6ef953 at offset 466. Wipe it? [y/n]:
[snip]

Add `-y' to lvm.pvcreate

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>