### PR TITLE
 Deactivate partially hidden VGs during installation

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -218,7 +218,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         # if any of our PVs are not active then we cannot be
         for pv in self.pvs:
-            if not pv.status:
+            if not pv.format.status:
                 return False
 
         # if we are missing some of our PVs we cannot be active
@@ -878,7 +878,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         # setup_parents (via _pre_setup, below), we should wait for auto-
         # activation before trying to manually activate this LV.
         auto_activate = (lvm.lvmetad_socket_exists() and
-                         any(not pv.status for pv in self.vg.pvs))
+                         any(not pv.format.status for pv in self.vg.pvs))
         if not super(LVMLogicalVolumeBase, self)._pre_setup(orig=orig):
             return False
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -862,7 +862,9 @@ class DeviceTreeBase(object):
         if not device.exists:
             return
 
-        self._remove_device(device, force=True, modparent=False)
+        # XXX set modparent=True when hiding a VG to unset vg_name from PVs
+        modparent = device.type == "lvmvg"
+        self._remove_device(device, force=True, modparent=modparent)
 
         self._hidden.append(device)
         lvm.lvm_cc_addFilterRejectRegexp(device.name)


### PR DESCRIPTION
Alternative solution by forcing `vgdeactivate` in `_pre_destroy` -- https://github.com/vojtechtrefny/blivet/commit/fedb62320a5169635733910276f373209676177f -- but I think this way is safer.

Also this currently doesn't work -- we need to run the `pvremove` with `--force --force` but this is currently broken in libblockdev.