### PR TITLE
Allow removing btrfs volumes without btrfs support

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -162,7 +162,8 @@ class DeviceAction(util.ObjectID):
 
         self.device = device
 
-        self._check_device_dependencies()
+        if self.is_device:
+            self._check_device_dependencies()
 
         self.container = getattr(self.device, "container", None)
         self._applied = False

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -160,14 +160,18 @@ class DeviceAction(util.ObjectID):
         if not isinstance(device, StorageDevice):
             raise ValueError("arg 1 must be a StorageDevice instance")
 
-        unavailable_dependencies = device.unavailable_dependencies
-        if unavailable_dependencies:
-            dependencies_str = ", ".join(str(d) for d in unavailable_dependencies)
-            raise DependencyError("device type %s requires unavailable_dependencies: %s" % (device.type, dependencies_str))
-
         self.device = device
+
+        self._check_device_dependencies()
+
         self.container = getattr(self.device, "container", None)
         self._applied = False
+
+    def _check_device_dependencies(self):
+        unavailable_dependencies = self.device.unavailable_dependencies
+        if unavailable_dependencies:
+            dependencies_str = ", ".join(str(d) for d in unavailable_dependencies)
+            raise DependencyError("device type %s requires unavailable_dependencies: %s" % (self.device.type, dependencies_str))
 
     def apply(self):
         """ apply changes related to the action to the device(s) """
@@ -378,6 +382,15 @@ class ActionDestroyDevice(DeviceAction):
     def __init__(self, device):
         # XXX should we insist that device.fs be None?
         DeviceAction.__init__(self, device)
+
+    def _check_device_dependencies(self):
+        if self.device.type == "btrfs volume":
+            # XXX destroying a btrfs volume is a special case -- we don't destroy
+            # the device, but use wipefs to destroy format on its parents so we
+            # don't need btrfs plugin or btrfs-progs for this
+            return
+
+        super(ActionDestroyDevice, self)._check_device_dependencies()
 
     def execute(self, callbacks=None):
         super(ActionDestroyDevice, self).execute(callbacks=callbacks)

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -97,10 +97,6 @@ class MockingDeviceDependenciesTestCase1(unittest.TestCase):
             ActionCreateDevice(self.luks)
         with self.assertRaises(DependencyError):
             ActionDestroyDevice(self.dev)
-        with self.assertRaises(DependencyError):
-            ActionCreateFormat(self.dev)
-        with self.assertRaises(DependencyError):
-            ActionDestroyFormat(self.dev)
 
     def _clean_up(self):
         availability.BLOCKDEV_MDRAID_PLUGIN._method = self.mdraid_method


### PR DESCRIPTION
Btrfs volumes are removed using wipefs so we don't need to check
for device dependencies availability when removing the volume
(btrfs support depends on libblockdev btrfs plugin).

Resolves: rhbz#1605213

----

Fixing this in `DeviceAction` is definitely not ideal, but I don't think there is a better way -- this would require a quite radical rewrite of the availability code to be able to define different dependencies for adding, removing and modifying devices. And right now this problem exists only for Btrfs devices.