### PR TITLE
Remove Anaconda flags

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -925,12 +925,7 @@ class Blivet(object):
         return tmp
 
     def _get_container_name_template(self, prefix=None):
-        template = prefix or ""
-
-        if flags.image_install:
-            template = "%s_image" % template
-
-        return template
+        return prefix or ""
 
     def suggest_container_name(self, prefix=""):
         """ Return a reasonable, unused device name.

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -38,13 +38,6 @@ class Flags(object):
         self.uevents = False
 
         #
-        # minor modes (installer-specific)
-        #
-        self.automated_install = False
-        self.live_install = False
-        self.image_install = False
-
-        #
         # enable/disable functionality
         #
         self.selinux = selinux.is_selinux_enabled()

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -426,7 +426,7 @@ class PopulatorMixin(object):
         self.drop_lvm_cache()
         mpath_members.drop_cache()
 
-        if flags.auto_dev_updates and not flags.image_install:
+        if flags.auto_dev_updates:
             blockdev.mpath.set_friendly_names(flags.multipath_friendly_names)
 
         self.setup_disk_images()

--- a/tests/imagebackedtestcase.py
+++ b/tests/imagebackedtestcase.py
@@ -5,7 +5,6 @@ import unittest
 from blivet import Blivet
 from blivet import util
 from blivet.size import Size
-from blivet.flags import flags
 
 
 @unittest.skip("disabled until it can be converted to run in a vm")
@@ -94,7 +93,6 @@ class ImageBackedTestCase(unittest.TestCase):
 
     def setUp(self):
         """ Do any setup required prior to running a test. """
-        flags.image_install = True
         self.blivet = Blivet()
 
         self.addCleanup(self._clean_up)
@@ -118,5 +116,3 @@ class ImageBackedTestCase(unittest.TestCase):
         for fn in self.blivet.disk_images.values():
             if os.path.exists(fn):
                 os.unlink(fn)
-
-        flags.image_install = False


### PR DESCRIPTION
The flags `automated_install`, `live_install` and `image_install` can be
removed, because they are not used or not useful anymore.

Depends on: https://github.com/rhinstaller/anaconda/pull/1613