### PR TITLE
Manually decode initiator name for logging

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -401,8 +401,9 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
             NetworkStorageDevice.__init__(self,
                                           host_address=address,
                                           nic=self.nic)
+            initiator_name = self.initiator.decode("utf-8", errors="replace")
             log.debug("created new iscsi disk %s %s:%s using fw initiator %s",
-                      name, address, port, self.initiator)
+                      name, address, port, initiator_name)
         else:
             DiskDevice.__init__(self, device, **kwargs)
             NetworkStorageDevice.__init__(self, host_address=self.node.address,

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -726,8 +726,9 @@ def device_get_iscsi_initiator(info):
             initiator_file = "/sys/class/iscsi_host/%s/initiatorname" % host
             if os.access(initiator_file, os.R_OK):
                 initiator = open(initiator_file).read().strip()
+                initiator_name = initiator.decode("utf-8", errors="replace")
                 log.debug("found offload iscsi initiatorname %s in file %s",
-                          initiator, initiator_file)
+                          initiator_name, initiator_file)
                 if initiator.lstrip("(").rstrip(")").lower() == "null":
                     initiator = None
     if initiator is None:
@@ -735,7 +736,8 @@ def device_get_iscsi_initiator(info):
         if session:
             initiator = open("/sys/class/iscsi_session/%s/initiatorname" %
                              session).read().strip()
-            log.debug("found iscsi initiatorname %s", initiator)
+            initiator_name = initiator.decode("utf-8", errors="replace")
+            log.debug("found iscsi initiatorname %s", initiator_name)
     return initiator
 
 


### PR DESCRIPTION
It is possible to have non-unicode characters in the initiator
name and it looks like all the tools are ok with it and only
python logger crashes when trying to decode it so we need to help
it a little.

Resolves: rhbz#1632274