### PR TITLE
minor cleanups to reduce log noise

### DIFF
--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -132,6 +132,9 @@ class FileDevice(StorageDevice):
         # Override StorageDevice.is_name_valid to allow /
         return not('\x00' in name or name == '.' or name == '..')
 
+    def update_sysfs_path(self):
+        pass
+
 
 class SparseFileDevice(FileDevice):
 

--- a/blivet/devices/nfs.py
+++ b/blivet/devices/nfs.py
@@ -77,3 +77,6 @@ class NFSDevice(StorageDevice, NetworkStorageDevice):
     def is_name_valid(self, name):
         # Override StorageDevice.is_name_valid to allow /
         return not('\x00' in name or name == '.' or name == '..')
+
+    def update_sysfs_path(self):
+        pass

--- a/blivet/devices/nodev.py
+++ b/blivet/devices/nodev.py
@@ -75,6 +75,9 @@ class NoDevice(StorageDevice):
     def update_size(self, newsize=None):
         pass
 
+    def update_sysfs_path(self):
+        pass
+
 
 class TmpFSDevice(NoDevice):
 

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -76,6 +76,7 @@ class FS(DeviceFormat):
     _sync_class = fssync.UnimplementedFSSync
     _writelabel_class = fswritelabel.UnimplementedFSWriteLabel
     _writeuuid_class = fswriteuuid.UnimplementedFSWriteUUID
+    _selinux_supported = True
     # This constant is aquired by testing some filesystems
     # and it's giving us percentage of space left after the format.
     # This number is more guess than precise number because this
@@ -565,7 +566,7 @@ class FS(DeviceFormat):
         chroot = kwargs.get("chroot", "/")
         mountpoint = kwargs.get("mountpoint") or self.mountpoint
 
-        if flags.selinux and "ro" not in self._mount.mount_options(options).split(",") and flags.selinux_reset_fcon:
+        if self._selinux_supported and flags.selinux and "ro" not in self._mount.mount_options(options).split(",") and flags.selinux_reset_fcon:
             ret = util.reset_file_context(mountpoint, chroot)
             if not ret:
                 log.warning("Failed to reset SElinux context for newly mounted filesystem root directory to default.")
@@ -902,6 +903,7 @@ class FATFS(FS):
     _metadata_size_factor = 0.99  # fat metadata may take 1% of space
     # FIXME this should be fat32 in some cases
     parted_system = fileSystemType["fat16"]
+    _selinux_supported = False
 
     def generate_new_uuid(self):
         ret = ""
@@ -1235,6 +1237,7 @@ class NoDevFS(FS):
     """ nodev filesystem base class """
     _type = "nodev"
     _mount_class = fsmount.NoDevFSMount
+    _selinux_supported = False
 
     def __init__(self, **kwargs):
         FS.__init__(self, **kwargs)

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -43,7 +43,10 @@ class SELinuxContextTestCase(unittest.TestCase):
 
             blivet.flags.flags.selinux_reset_fcon = True
             fmt.setup(mountpoint="dummy")  # param needed to pass string check
-            lsetfilecon.assert_called_with(ANY, lost_found_context)
+            if isinstance(fmt, fs.Ext2FS):
+                lsetfilecon.assert_called_with(ANY, lost_found_context)
+            else:
+                lsetfilecon.assert_not_called()
 
             lsetfilecon.reset_mock()
 


### PR DESCRIPTION
This removes a bunch of unnecessary error messages from the logs by avoiding operations that are expected to fail.