### PR TITLE
Add dependency on python-six

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -44,6 +44,7 @@ Requires: python-pyblock >= %{pythonpyblockver}
 Requires: device-mapper-multipath
 Requires: lsof
 Requires: python-blockdev
+Requires: python-six
 
 %description
 The python-blivet package is a python module for examining and modifying


### PR DESCRIPTION
six is needed since 3af623c2a5e57e8397468b4825362275cb0f1ccb but
we forgot to add the dependency to the spec file.

Resolves: rhbz#1647173