### PR TITLE
Use raid names when looking for slave devices

### DIFF
--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -23,10 +23,6 @@
 import copy
 import six
 
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
-
 from ... import udev
 from ...devicelibs import lvm
 from ...devices import PartitionDevice
@@ -51,11 +47,9 @@ class PartitionDevicePopulator(DevicePopulator):
         log_method_call(self, name=name)
         sysfs_path = udev.device_get_sysfs_path(self.data)
 
-        if name.startswith("md"):
-            name = blockdev.md.name_from_node(name)
-            device = self._devicetree.get_device_by_name(name)
-            if device:
-                return device
+        device = self._devicetree.get_device_by_name(name)
+        if device:
+            return device
 
         disk = None
         disk_name = udev.device_get_partition_disk(self.data)

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -200,9 +200,18 @@ def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info and not device_is_partition(udev_info):
-        # md partitions have MD_DEVNAME set to the partition's parent/disk
-        name = udev_info["MD_DEVNAME"]
+    elif "MD_DEVNAME" in udev_info:
+        mdname = udev_info["MD_DEVNAME"]
+        if device_is_partition(udev_info):
+            # for partitions on named RAID we want to use the raid name, not
+            # the node, e.g. "raid1" instead of "md127p1"
+            partnum = udev_info["ID_PART_ENTRY_NUMBER"]
+            if mdname[-1].isdigit():
+                name = mdname + "p" + partnum
+            else:
+                name = mdname + partnum
+        else:
+            name = mdname
     else:
         name = udev_info["SYS_NAME"]
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -429,10 +429,15 @@ class PartitionDevicePopulatorTestCase(PopulatorHelperTestCase):
         disk = DiskDevice("xyz", fmt=fmt, exists=True)
         devicetree._add_device(disk)
 
+        # pylint: disable=unused-argument
+        def _get_device_by_name(name, **kwargs):
+            if name == "xyz":
+                return disk
+
         device_name = "xyz1"
         device_get_name.return_value = device_name
+        get_device_by_name.side_effect = _get_device_by_name
         device_get_partition_disk.return_value = "xyz"
-        get_device_by_name.return_value = disk
         helper = self.helper_class(devicetree, data)
 
         device = helper.run()


### PR DESCRIPTION
This fixes DeviceTreeError when adding LUKS device on a partition
on a raid -- the partition is added as "name1" so we can't use
the name from udev ("md127p1") here.