### PR TITLE
Move btrfs name validation to devicelibs

### DIFF
--- a/blivet/devicelibs/btrfs.py
+++ b/blivet/devicelibs/btrfs.py
@@ -38,3 +38,7 @@ raid_levels = raid.RAIDLevels(["raid0", "raid1", "raid10", "single"])
 metadata_levels = raid.RAIDLevels(["raid0", "raid1", "raid10", "single", "dup"])
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_BTRFS_PLUGIN]
+
+
+def is_btrfs_name_valid(name):
+    return '\x00' not in name

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -153,7 +153,7 @@ class BTRFSDevice(StorageDevice):
 
     def is_name_valid(self, name):
         # Override StorageDevice.is_name_valid to allow pretty much anything
-        return not('\x00' in name)
+        return btrfs.is_btrfs_name_valid(name)
 
 
 class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):


### PR DESCRIPTION
This allows name validation without constructing the BtrfsDevice
object. There is a similar function in devicelibs.lvm.