### PR TITLE
Fix crash on reset on systems without nvdimm plugin

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -946,6 +946,11 @@ def device_is_nvdimm_namespace(info):
     if info.get("DEVTYPE") != "disk":
         return False
 
+    if not blockdev.is_plugin_available(blockdev.Plugin.NVDIMM):
+        # nvdimm plugin is not available -- even if this is an nvdimm device we
+        # don't have tools to work with it, so we should pretend it's just a disk
+        return False
+
     devname = info.get("DEVNAME", "")
     ninfo = blockdev.nvdimm_namespace_get_devname(devname)
     return ninfo is not None

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -572,7 +572,9 @@ class NVDIMMNamespaceDevicePopulatorTestCase(PopulatorHelperTestCase):
                            uuid='test-uuid', sector_size=512)
 
         with patch("blivet.static_data.nvdimm.get_namespace_info", return_value=nvdimm_data):
-            device = helper.run()
+            with patch("blivet.populator.helpers.disk.blockdev.nvdimm_namespace_get_mode_str", return_value="sector"):
+                device = helper.run()
+
         self.assertIsInstance(device, NVDIMMNamespaceDevice)
         self.assertTrue(device.exists)
         self.assertTrue(device.is_disk)


### PR DESCRIPTION
There is no easier way how to check if disk is an nvdimm
namespace so without nvdimm plugin udev.device_is_nvdimm_namespace
will return False and the device will be added as a normal disk.