### PR TITLE
 Use 'pycodestyle' instead of 'pep8' 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,8 @@ VERSION_TAG=$(PKGNAME)-$(VERSION)
 
 ifeq ($(PYTHON),python3)
   COVERAGE=coverage3
-  PEP8=$(PYTHON)-pep8
 else
   COVERAGE=coverage
-  PEP8=pep8
 endif
 
 ZANATA_PULL_ARGS = --transdir ./po/
@@ -62,7 +60,16 @@ pylint:
 
 pep8:
 	@echo "*** Running pep8 compliance check ***"
-	$(PEP8) --ignore=E501,E402,E731 blivet/ tests/ examples/
+	@if test `which pycodestyle-3` ; then \
+		pep8='pycodestyle-3' ; \
+	elif test `which pycodestyle` ; then \
+		pep8='pycodestyle' ; \
+	elif test `which pep8` ; then \
+		pep8='pep8' ; \
+	else \
+		echo "You need to install pycodestyle/pep8 to run this check."; exit 1; \
+	fi ; \
+	$$pep8 --ignore=E501,E402,E731 blivet/ tests/ examples/
 
 canary: po-fallback
 	@echo "*** Running translation-canary tests ***"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ pep8:
 	else \
 		echo "You need to install pycodestyle/pep8 to run this check."; exit 1; \
 	fi ; \
-	$$pep8 --ignore=E501,E402,E731 blivet/ tests/ examples/
+	$$pep8 --ignore=E501,E402,E731,W504 blivet/ tests/ examples/
 
 canary: po-fallback
 	@echo "*** Running translation-canary tests ***"

--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -123,6 +123,7 @@ class _LazyImportObject(object):
         sys.modules["%s.%s" % (__package__, self._name)] = val
         return dir(val)
 
+
 # this way things like 'from blivet import Blivet' work without an overhead of
 # importing of everything the Blivet class needs whenever anything from the
 # 'blivet' package is imported (e.g. the 'arch' module)

--- a/blivet/callbacks.py
+++ b/blivet/callbacks.py
@@ -67,6 +67,7 @@ def create_new_callbacks_register(create_format_pre=None,
                               resize_format_pre, resize_format_post,
                               wait_for_entropy, report_progress)
 
+
 CreateFormatPreData = namedtuple("CreateFormatPreData",
                                  ["msg"])
 CreateFormatPostData = namedtuple("CreateFormatPostData",
@@ -144,6 +145,7 @@ class Callbacks(object):
 
         self.attribute_changed = CallbackList()
         """ callback list for when a device or format attribute's value is changed"""
+
 
 """
     .. data:: callbacks

--- a/blivet/devicelibs/disk.py
+++ b/blivet/devicelibs/disk.py
@@ -57,6 +57,7 @@ class _LSMDependencyGuard(util.DependencyGuard):
 
         return lsm is not None
 
+
 _lsm_required = _LSMDependencyGuard()
 
 

--- a/blivet/devicelibs/mdraid.py
+++ b/blivet/devicelibs/mdraid.py
@@ -42,6 +42,7 @@ class MDRaidLevels(raid.RAIDLevels):
             hasattr(level, 'get_recommended_stride') and \
             hasattr(level, 'get_size')
 
+
 raid_levels = MDRaidLevels(["raid0", "raid1", "raid4", "raid5", "raid6", "raid10", "linear"])
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_MDRAID_PLUGIN]

--- a/blivet/devicelibs/raid.py
+++ b/blivet/devicelibs/raid.py
@@ -392,6 +392,7 @@ class RAIDLevels(object):
     def __iter__(self):
         return iter(self._raid_levels)
 
+
 ALL_LEVELS = RAIDLevels()
 
 
@@ -428,6 +429,7 @@ class Striped(RAID0):
     name = 'striped'
     names = [name]
 
+
 RAID0 = RAID0()
 ALL_LEVELS.add_raid_level(RAID0)
 Striped = Striped()
@@ -460,6 +462,7 @@ class RAID1(RAIDn):
     def _get_recommended_stride(self, member_count):
         return None
 
+
 RAID1 = RAID1()
 ALL_LEVELS.add_raid_level(RAID1)
 
@@ -489,6 +492,7 @@ class RAID4(RAIDn):
 
     def _get_recommended_stride(self, member_count):
         return (member_count - 1) * 16
+
 
 RAID4 = RAID4()
 ALL_LEVELS.add_raid_level(RAID4)
@@ -520,6 +524,7 @@ class RAID5(RAIDn):
     def _get_recommended_stride(self, member_count):
         return (member_count - 1) * 16
 
+
 RAID5 = RAID5()
 ALL_LEVELS.add_raid_level(RAID5)
 
@@ -549,6 +554,7 @@ class RAID6(RAIDn):
 
     def _get_recommended_stride(self, member_count):
         return None
+
 
 RAID6 = RAID6()
 ALL_LEVELS.add_raid_level(RAID6)
@@ -580,6 +586,7 @@ class RAID10(RAIDn):
     def _get_recommended_stride(self, member_count):
         return None
 
+
 RAID10 = RAID10()
 ALL_LEVELS.add_raid_level(RAID10)
 
@@ -609,6 +616,7 @@ class Container(RAIDLevel):
     def get_size(self, member_sizes, num_members=None, chunk_size=None, superblock_size_func=None):
         # pylint: disable=unused-argument
         return sum(member_sizes, Size(0))
+
 
 Container = Container()
 ALL_LEVELS.add_raid_level(Container)
@@ -662,6 +670,7 @@ class Linear(ErsatzRAID):
     name = 'linear'
     names = [name, 'jbod']
 
+
 Linear = Linear()
 ALL_LEVELS.add_raid_level(Linear)
 
@@ -671,6 +680,7 @@ class Single(ErsatzRAID):
     """ subclass with canonical btrfs name. """
     name = 'single'
     names = [name]
+
 
 Single = Single()
 ALL_LEVELS.add_raid_level(Single)
@@ -690,6 +700,7 @@ class Dup(RAIDLevel):
 
     def has_redundancy(self):
         return True
+
 
 Dup = Dup()
 ALL_LEVELS.add_raid_level(Dup)

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -279,10 +279,10 @@ class Device(util.ObjectID):
     @property
     def ancestors(self):
         """ A list of all of this device's ancestors, including itself. """
-        l = set([self])
-        for p in [d for d in self.parents if d not in l]:
-            l.update(set(p.ancestors))
-        return list(l)
+        ancestors = set([self])
+        for p in [d for d in self.parents if d not in ancestors]:
+            ancestors.update(set(p.ancestors))
+        return list(ancestors)
 
     @property
     def packages(self):

--- a/blivet/devices/lib.py
+++ b/blivet/devices/lib.py
@@ -55,6 +55,8 @@ def _collect_device_major_data():
         except ValueError:
             continue
     return (by_major, by_device)
+
+
 _devices_by_major, _majors_by_device = _collect_device_major_data()
 
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -64,6 +64,7 @@ class LVPVSpec(object):
         self.pv = pv
         self.size = size
 
+
 PVFreeInfo = namedtuple("PVFreeInfo", ["pv", "size", "free"])
 """ A namedtuple class holding the information about PV's (usable) size and free space """
 

--- a/blivet/fcoe.py
+++ b/blivet/fcoe.py
@@ -227,6 +227,7 @@ MODE="fabric"
                             line = 'MODE="%s"\n' % mode
                 new_cfg.write(line)
 
+
 # Create FCoE singleton
 fcoe = FCoE()
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -63,6 +63,7 @@ def register_device_format(fmt_class):
     log.debug("registered device format class %s as %s", fmt_class.__name__,
               fmt_class._type)
 
+
 default_fstypes = ("ext4", "xfs", "ext3", "ext2")
 
 
@@ -735,6 +736,7 @@ class DeviceFormat(ObjectID):
         data.format = not self.exists
         data.fstype = self.type
         data.mountpoint = self.ks_mountpoint
+
 
 register_device_format(DeviceFormat)
 

--- a/blivet/formats/biosboot.py
+++ b/blivet/formats/biosboot.py
@@ -61,4 +61,5 @@ class BIOSBoot(DeviceFormat):
     def supported(self):
         return super(BIOSBoot, self).supported and arch.is_x86() and not arch.is_efi()
 
+
 register_device_format(BIOSBoot)

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -576,4 +576,5 @@ class DiskLabel(DeviceFormat):
         else:
             return 0
 
+
 register_device_format(DiskLabel)

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -697,7 +697,7 @@ class FS(DeviceFormat):
 
         try:
             self.write_uuid()
-        except:
+        except Exception:  # pylint: disable=broad-except
             # something went wrong, restore the original UUID
             self.uuid = orig_uuid
             raise
@@ -850,6 +850,7 @@ class Ext2FS(FS):
             if not ret:
                 log.warning("Failed to set SELinux context for newly mounted filesystem lost+found directory at %s to %s", lost_and_found_path, lost_and_found_context)
 
+
 register_device_format(Ext2FS)
 
 
@@ -868,6 +869,7 @@ class Ext3FS(Ext2FS):
     _max_size = Size("16 TiB")
     _metadata_size_factor = 0.90  # ext3 metadata may take 10% of space
 
+
 register_device_format(Ext3FS)
 
 
@@ -880,6 +882,7 @@ class Ext4FS(Ext3FS):
     parted_system = fileSystemType["ext4"]
     _max_size = Size("1 EiB")
     _metadata_size_factor = 0.85  # ext4 metadata may take 15% of space
+
 
 register_device_format(Ext4FS)
 
@@ -911,6 +914,7 @@ class FATFS(FS):
             ret += random.choice("0123456789ABCDEF")
         return ret[:4] + "-" + ret[4:]
 
+
 register_device_format(FATFS)
 
 
@@ -925,6 +929,7 @@ class EFIFS(FATFS):
     @property
     def supported(self):
         return super(EFIFS, self).supported and arch.is_efi()
+
 
 register_device_format(EFIFS)
 
@@ -974,6 +979,7 @@ class BTRFS(FS):
     def container_uuid(self, uuid):
         self.vol_uuid = uuid
 
+
 register_device_format(BTRFS)
 
 
@@ -996,6 +1002,7 @@ class GFS2(FS):
     def supported(self):
         """ Is this filesystem a supported type? """
         return self.utils_available if flags.gfs2 else self._supported
+
 
 register_device_format(GFS2)
 
@@ -1025,6 +1032,7 @@ class JFS(FS):
         """ Is this filesystem a supported type? """
         return self.utils_available if flags.jfs else self._supported
 
+
 register_device_format(JFS)
 
 
@@ -1053,6 +1061,7 @@ class ReiserFS(FS):
     def supported(self):
         """ Is this filesystem a supported type? """
         return self.utils_available if flags.reiserfs else self._supported
+
 
 register_device_format(ReiserFS)
 
@@ -1097,6 +1106,7 @@ class XFS(FS):
 
         super(XFS, self).write_uuid()
 
+
 register_device_format(XFS)
 
 
@@ -1107,6 +1117,7 @@ class HFS(FS):
     _formattable = True
     _mkfs_class = fsmkfs.HFSMkfs
     parted_system = fileSystemType["hfs"]
+
 
 register_device_format(HFS)
 
@@ -1122,6 +1133,7 @@ class AppleBootstrapFS(HFS):
     @property
     def supported(self):
         return super(AppleBootstrapFS, self).supported and arch.is_pmac()
+
 
 register_device_format(AppleBootstrapFS)
 
@@ -1142,6 +1154,7 @@ class HFSPlus(FS):
     _mkfs_class = fsmkfs.HFSPlusMkfs
     _mount_class = fsmount.HFSPlusMount
 
+
 register_device_format(HFSPlus)
 
 
@@ -1160,6 +1173,7 @@ class MacEFIFS(HFSPlus):
         if "label" not in kwargs:
             kwargs["label"] = self._name
         super(MacEFIFS, self).__init__(**kwargs)
+
 
 register_device_format(MacEFIFS)
 
@@ -1210,6 +1224,7 @@ class NFS(FS):
             return "device must be of the form <host>:<path>"
         return None
 
+
 register_device_format(NFS)
 
 
@@ -1218,6 +1233,7 @@ class NFSv4(NFS):
     """ NFSv4 filesystem. """
     _type = "nfs4"
     _modules = ["nfs4"]
+
 
 register_device_format(NFSv4)
 
@@ -1228,6 +1244,7 @@ class Iso9660FS(FS):
     _type = "iso9660"
     _supported = True
     _mount_class = fsmount.Iso9660FSMount
+
 
 register_device_format(Iso9660FS)
 
@@ -1251,6 +1268,7 @@ class NoDevFS(FS):
     def type(self):
         return self.device
 
+
 register_device_format(NoDevFS)
 
 
@@ -1260,6 +1278,7 @@ class DevPtsFS(NoDevFS):
     _type = "devpts"
     _mount_class = fsmount.DevPtsFSMount
 
+
 register_device_format(DevPtsFS)
 
 
@@ -1267,11 +1286,13 @@ register_device_format(DevPtsFS)
 class ProcFS(NoDevFS):
     _type = "proc"
 
+
 register_device_format(ProcFS)
 
 
 class SysFS(NoDevFS):
     _type = "sysfs"
+
 
 register_device_format(SysFS)
 
@@ -1388,12 +1409,14 @@ class TmpFS(NoDevFS):
         FS.do_resize(self)
         self._accept_default_size = self._accept_default_size and original_size == self._size
 
+
 register_device_format(TmpFS)
 
 
 class BindFS(FS):
     _type = "bind"
     _mount_class = fsmount.BindFSMount
+
 
 register_device_format(BindFS)
 
@@ -1402,16 +1425,19 @@ class SELinuxFS(NoDevFS):
     _type = "selinuxfs"
     _mount_class = fsmount.SELinuxFSMount
 
+
 register_device_format(SELinuxFS)
 
 
 class USBFS(NoDevFS):
     _type = "usbfs"
 
+
 register_device_format(USBFS)
 
 
 class EFIVarFS(NoDevFS):
     _type = "efivarfs"
+
 
 register_device_format(EFIVarFS)

--- a/blivet/formats/fslib.py
+++ b/blivet/formats/fslib.py
@@ -34,4 +34,5 @@ def update_kernel_filesystems():
             if fields[0] == "nodev":
                 nodev_filesystems.append(fstype)
 
+
 update_kernel_filesystems()

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -373,6 +373,7 @@ class LUKS(DeviceFormat):
             data.pbkdf_iterations = self.pbkdf_args.iterations
             data.pbkdf_time = self.pbkdf_args.time_ms
 
+
 register_device_format(LUKS)
 
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -181,4 +181,5 @@ class LVMPhysicalVolume(DeviceFormat):
     def container_uuid(self, uuid):
         self.vg_uuid = uuid
 
+
 register_device_format(LVMPhysicalVolume)

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -112,10 +112,12 @@ class MDRaidMember(DeviceFormat):
     def container_uuid(self, uuid):
         self.md_uuid = uuid
 
+
 # nodmraid -> Wether to use BIOS RAID or not
 # Note the anaconda cmdline has not been parsed yet when we're first imported,
 # so we can not use flags.dmraid here
 if not flags.noiswmd and flags.dmraid:
     MDRaidMember._udev_types.append("isw_raid_member")
+
 
 register_device_format(MDRaidMember)

--- a/blivet/formats/multipath.py
+++ b/blivet/formats/multipath.py
@@ -80,4 +80,5 @@ class MultipathMember(DeviceFormat):
                         type=self.type, status=self.status)
         raise MultipathMemberError("destruction of multipath members is non-sense")
 
+
 register_device_format(MultipathMember)

--- a/blivet/formats/prepboot.py
+++ b/blivet/formats/prepboot.py
@@ -98,4 +98,5 @@ class PPCPRePBoot(DeviceFormat):
     def supported(self):
         return super(PPCPRePBoot, self).supported and arch.is_ipseries()
 
+
 register_device_format(PPCPRePBoot)

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -181,4 +181,5 @@ class SwapSpace(DeviceFormat):
             blockdev.swap.mkswap(self.device, label=self.label,
                                  extra={"-U": self.uuid})
 
+
 register_device_format(SwapSpace)

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -118,6 +118,7 @@ class iSCSIDependencyGuard(util.DependencyGuard):
             return False
         return safe_dbus.check_object_available(STORAGED_SERVICE, STORAGED_MANAGER_PATH, INITIATOR_IFACE)
 
+
 storaged_iscsi_required = iSCSIDependencyGuard()
 
 
@@ -544,6 +545,7 @@ class iSCSI(object):
                 node_disks.append(disk)
 
         return node_disks
+
 
 # Create iscsi singleton
 iscsi = iSCSI()

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -174,4 +174,5 @@ class MountsCache(object):
             self.mounts_hash = md5hash
             self._get_active_mounts()
 
+
 mounts_cache = MountsCache()

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -111,6 +111,7 @@ def partition_compare(part1, part2):
 
     return ret
 
+
 _partition_compare_key = functools.cmp_to_key(partition_compare)
 
 
@@ -1974,6 +1975,7 @@ def lv_compare(lv1, lv2):
         ret = -1
 
     return ret
+
 
 _lv_compare_key = functools.cmp_to_key(lv_compare)
 

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -41,6 +41,7 @@ def _build_helper_lists():
     _device_helpers.sort(key=lambda h: h.priority, reverse=True)
     _format_helpers.sort(key=lambda h: h.priority, reverse=True)
 
+
 _build_helper_lists()
 
 

--- a/blivet/static_data/lvm_info.py
+++ b/blivet/static_data/lvm_info.py
@@ -51,6 +51,7 @@ class LVsInfo(object):
     def drop_cache(self):
         self._lvs_cache = None  # pylint: disable=attribute-defined-outside-init
 
+
 lvs_info = LVsInfo()
 
 
@@ -91,5 +92,6 @@ class PVsInfo(object):
 
     def drop_cache(self):
         self._pvs_cache = None  # pylint: disable=attribute-defined-outside-init
+
 
 pvs_info = PVsInfo()

--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -62,4 +62,5 @@ class MpathMembers(object):
     def drop_cache(self):
         self._members = None
 
+
 mpath_members = MpathMembers()

--- a/blivet/static_data/nvdimm.py
+++ b/blivet/static_data/nvdimm.py
@@ -42,6 +42,7 @@ class NVDIMMDependencyGuard(util.DependencyGuard):
             return False
         return True
 
+
 blockdev_nvdimm_required = NVDIMMDependencyGuard()
 
 

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -126,6 +126,7 @@ class Path(Method):
         else:
             return []
 
+
 Path = Path()
 
 
@@ -253,6 +254,7 @@ class UnavailableMethod(Method):
     def availability_errors(self, resource):
         return ["always unavailable"]
 
+
 UnavailableMethod = UnavailableMethod()
 
 
@@ -262,6 +264,7 @@ class AvailableMethod(Method):
 
     def availability_errors(self, resource):
         return []
+
 
 AvailableMethod = AvailableMethod()
 
@@ -298,6 +301,7 @@ def unavailable_resource(name):
 def available_resource(name):
     """ Construct an external resource that is always available. """
     return ExternalResource(AvailableMethod, name)
+
 
 # libblockdev btrfs plugin required technologies and modes
 BLOCKDEV_BTRFS_ALL_MODES = (blockdev.BtrfsTechMode.CREATE |

--- a/blivet/tsort.py
+++ b/blivet/tsort.py
@@ -102,5 +102,6 @@ def main():
     graph = create_graph(items, edges)
     print(tsort(graph))
 
+
 if __name__ == "__main__":
     main()

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -941,6 +941,7 @@ def _add_extra_doc_text(func, field=None, desc=None, field_unique=False):
     text += field + " " + desc
     func.__doc__ = base_text + "\n" + indent(text, indent_spaces)
 
+
 #
 # Deprecation decorator.
 #
@@ -949,6 +950,7 @@ _DEPRECATION_MESSAGE = "will be removed in a future version."
 
 def _default_deprecation_msg(func):
     return "%s %s" % (func.__name__, _DEPRECATION_MESSAGE)
+
 
 _SPHINX_DEPRECATE = ".. deprecated::"
 _DEPRECATION_INFO = """%(version)s

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -40,6 +40,7 @@ def logged_write_line_to_file(fn, value):
     f.write("%s\n" % (value))
     f.close()
 
+
 zfcpsysfs = "/sys/bus/ccw/drivers/zfcp"
 scsidevsysfs = "/sys/bus/scsi/devices"
 zfcpconf = "/etc/zfcp.conf"
@@ -381,6 +382,7 @@ class zFCP:
         f = open(root + "/etc/modprobe.conf", "a")
         f.write("alias scsi_hostadapter zfcp\n")
         f.close()
+
 
 # Create ZFCP singleton
 zfcp = zFCP()

--- a/examples/uevents.py
+++ b/examples/uevents.py
@@ -12,6 +12,7 @@ def print_changes(event, changes):
     print("***")
     print()
 
+
 set_up_logging(console_logs=["blivet.event"])
 b = blivet.Blivet()  # create an instance of Blivet
 b.reset()  # detect system storage configuration

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -23,13 +23,13 @@ def assertVerboseListEqual(left, right, msg=None):
     s = "\n"
     if leftmissing:
         s += "log has: \n"
-        for l in leftmissing:
-            s += " %s\n" % (pprint.pformat(l),)
+        for lm in leftmissing:
+            s += " %s\n" % (pprint.pformat(lm),)
 
     if rightmissing:
         s += "expected: \n"
-        for r in rightmissing:
-            s += " %s\n" % (pprint.pformat(r),)
+        for rm in rightmissing:
+            s += " %s\n" % (pprint.pformat(rm),)
 
     if leftmissing or rightmissing:
         raise AssertionError(s)
@@ -37,12 +37,12 @@ def assertVerboseListEqual(left, right, msg=None):
 
 def assertVerboseEqual(left, right, msg=None):
     if left != right:
-        l = len(left)
-        r = len(right)
-        for x in range(0, max(l, r)):
-            if x > l - 1:
+        ll = len(left)
+        rl = len(right)
+        for x in range(0, max(ll, rl)):
+            if x > ll - 1:
                 assertVerboseEqual(None, right[x], msg)
-            if x > r - 1:
+            if x > rl - 1:
                 assertVerboseEqual(left[x], None, msg)
             if left[x] != right[x]:
                 if msg:

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -42,6 +42,7 @@ class BlivetLintConfig(PocketLintConfig):
     def extraArgs(self):
         return ["--unsafe-load-any-extension=yes"]
 
+
 if __name__ == "__main__":
     conf = BlivetLintConfig()
     linter = PocketLinter(conf)

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -38,6 +38,10 @@ class BlivetLintConfig(PocketLintConfig):
     def ignoreNames(self):
         return {"translation-canary"}
 
+    @property
+    def extraArgs(self):
+        return ["--unsafe-load-any-extension=yes"]
+
 if __name__ == "__main__":
     conf = BlivetLintConfig()
     linter = PocketLinter(conf)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -125,6 +125,7 @@ class TestDependencyGuard(util.DependencyGuard):
     def _check_avail(self):
         return False
 
+
 _requires_something = TestDependencyGuard()
 
 

--- a/tests/vmtests/runvmtests.py
+++ b/tests/vmtests/runvmtests.py
@@ -180,5 +180,6 @@ def main():
     ret = run_tests(cmd_args)
     sys.exit(ret)
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
pep8 has been renamed to pycodestyle https://github.com/PyCQA/pycodestyle/issues/466 but the python-pep8 package in Fedora has never been deprecated, so we are still using the two years old 1.6 version. Fortunately newest python-codestyle is available for both Fedora and RHEL/CentOS 7 so we can switch to it.

This also containts fixes for some new errors/warnings discovered by the newest pycodestyle.