### PR TITLE
Tell LVM to wipe cachepool metadata when attaching the cachepool

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -725,7 +725,7 @@ def lvcreate_cached(vg_name, lv_name, lv_size, cache_data_size, cache_md_size,
     vg_lv_name = lambda lv_name: "%s/%s" % (vg_name, lv_name)
 
     # attach the cache pool to the LV
-    args = ["lvconvert", "--type", "cache", "--cachepool", vg_lv_name(lv_name+"_cache"), vg_lv_name(lv_name)]
+    args = ["lvconvert", "--yes", "--type", "cache", "--cachepool", vg_lv_name(lv_name+"_cache"), vg_lv_name(lv_name)]
     try:
         lvm(args)
     except LVMError as msg:


### PR DESCRIPTION
Resolves: rhbz#1643531

Submitted-by: Renaud Métrich <rmetrich@redhat.com>

------

We already do this in libblockdev so newer versions don't need this change.