### PR TITLE
Copy the iSCSI initiator name file to the installed system

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -563,6 +563,11 @@ class iSCSI(object):
             shutil.copytree("/var/lib/iscsi", root + "/var/lib/iscsi",
                             symlinks=True)
 
+        # copy the initiator file too
+        if not os.path.isdir(root + "/etc/iscsi"):
+            os.makedirs(root + "/etc/iscsi", 0o755)
+        shutil.copyfile(INITIATOR_FILE, root + INITIATOR_FILE)
+
     def get_node(self, name, address, port, iface):
         for node in self.active_nodes():
             if node.name == name and node.address == address and \


### PR DESCRIPTION
The initiatorname.iscsi file is used (sometimes) during boot so
we need to write the configuration to the installed system.

Resolves: rhbz#1664587

----
We do this on rhel7-branch, the code that saves the `initiatorname.iscsi` file was probably accidentally removed in https://github.com/storaged-project/blivet/commit/9280eff7016da0e58b8a58c1c844470e8fddeb55.
This was not  discovered because dracut should prefer the `rd.iscsi` boot option but this currently also broken -- https://github.com/dracutdevs/dracut/pull/518 -- and it tries to use the config file that has wrong (some random default) initiator name.