### PR TITLE
Remove unused code

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -59,15 +59,7 @@ class Blivet(object):
 
     def __init__(self):
         # storage configuration variables
-        self.do_autopart = False
-        self.clear_part_choice = None
-        self.encrypted_autopart = False
         self.encryption_passphrase = None
-        self.encryption_cipher = None
-        self.escrow_certificates = {}
-        self.autopart_escrow_cert = None
-        self.autopart_add_backup_passphrase = False
-        self.autopart_requests = []
         self.edd_dict = {}
 
         self.ignored_disks = []
@@ -77,7 +69,6 @@ class Blivet(object):
         self.__luks_devs = {}
         self.size_sets = []
         self.set_default_fstype(get_default_filesystem_type())
-        self._default_boot_fstype = None
 
         self._short_product_name = 'blivet'
         self._sysroot = '/'
@@ -91,7 +82,6 @@ class Blivet(object):
                                      exclusive_disks=self.exclusive_disks,
                                      disk_images=self.disk_images)
         self.roots = []
-        self.services = set()
 
     @property
     def short_product_name(self):

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -71,8 +71,6 @@ class Blivet(object):
         self.set_default_fstype(get_default_filesystem_type())
 
         self._short_product_name = 'blivet'
-        self._sysroot = '/'
-        self._storage_root = '/'
 
         self._next_id = 0
         self._dump_file = "%s/storage.state" % tempfile.gettempdir()
@@ -95,23 +93,6 @@ class Blivet(object):
         """
         log.debug("new short product name: %s", name)
         self._short_product_name = name
-
-    @property
-    def sysroot(self):
-        return self._sysroot
-
-    @sysroot.setter
-    def sysroot(self, storage_root, sysroot):
-        """ Change the OS root path.
-        :param storage_root: The root of physical storage
-        :type storage_root: string
-        :param sysroot: An optional chroot subdirectory of storage_root
-        :type sysroot: string
-        """
-        self._storage_root = self._sysroot = storage_root
-        if sysroot is not None:
-            log.debug("new sysroot: %s", sysroot)
-            self._sysroot = sysroot
 
     def do_it(self, callbacks=None):
         """

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -50,8 +50,6 @@ class Flags(object):
         self.jfs = True
         self.reiserfs = True
 
-        self.gpt = False
-
         # for this flag to take effect,
         # blockdev.mpath.set_friendly_names(flags.multipath_friendly_names) must
         # be called prior to calling Blivet.reset() or DeviceTree.populate()


### PR DESCRIPTION
Remove the unused `gpt` flag. It is not used by Blivet
or Anaconda.

Remove the unused `sysroot` property. The property is
not used in Blivet or Anaconda.

Remove unused attributes from the `Blivet` class. The
attributes are moved to Anaconda, where they are used.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1758