### PR TITLE
Mark exported VGs as protected

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -95,7 +95,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
     def __init__(self, name, parents=None, size=None, free=None,
                  pe_size=None, pe_count=None, pe_free=None, pv_count=None,
-                 uuid=None, exists=False, sysfs_path=''):
+                 uuid=None, exists=False, sysfs_path='', exported=False):
         """
             :param name: the device name (generally a device node's basename)
             :type name: str
@@ -134,6 +134,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
         self.pe_size = util.numeric_type(pe_size)
         self.pe_count = util.numeric_type(pe_count)
         self.pe_free = util.numeric_type(pe_free)
+        self.exported = exported
 
         # TODO: validate pe_size if given
         if not self.pe_size:
@@ -545,6 +546,13 @@ class LVMVolumeGroupDevice(ContainerDevice):
     def direct(self):
         """ Is this device directly accessible? """
         return False
+
+    @property
+    def protected(self):
+        if self.exported:
+            return True
+
+        return super(LVMVolumeGroupDevice, self).protected
 
     def remove_hook(self, modparent=True):
         if modparent:

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -46,7 +46,7 @@ from ..flags import flags
 from ..storage_log import log_method_call
 from ..threads import SynchronizedMeta
 from .helpers import get_device_helper, get_format_helper
-from ..static_data import lvs_info, pvs_info, luks_data, mpath_members
+from ..static_data import lvs_info, pvs_info, vgs_info, luks_data, mpath_members
 from ..callbacks import callbacks
 
 import logging
@@ -468,6 +468,7 @@ class PopulatorMixin(object):
         """ Drop cached lvm information. """
         lvs_info.drop_cache()
         pvs_info.drop_cache()
+        vgs_info.drop_cache()
 
     def handle_nodev_filesystems(self):
         for line in open("/proc/mounts").readlines():

--- a/blivet/static_data/__init__.py
+++ b/blivet/static_data/__init__.py
@@ -1,4 +1,4 @@
-from .lvm_info import lvs_info, pvs_info
+from .lvm_info import lvs_info, pvs_info, vgs_info
 from .luks_data import luks_data
 from .mpath_info import mpath_members
 from .nvdimm import nvdimm

--- a/blivet/static_data/lvm_info.py
+++ b/blivet/static_data/lvm_info.py
@@ -95,3 +95,32 @@ class PVsInfo(object):
 
 
 pvs_info = PVsInfo()
+
+
+class VGsInfo(object):
+    """ Class to be used as a singleton.
+        Maintains the VGs cache.
+    """
+
+    def __init__(self):
+        self._vgs_cache = None
+
+    @property
+    def cache(self):
+        if self._vgs_cache is None:
+            try:
+                vgs = blockdev.lvm.vgs()
+            except NotImplementedError:
+                log.error("libblockdev lvm plugin is missing")
+                self._vgs_cache = dict()
+                return self._vgs_cache
+
+            self._vgs_cache = dict(("%s" % (vg.uuid), vg) for vg in vgs)
+
+        return self._vgs_cache
+
+    def drop_cache(self):
+        self._vgs_cache = None
+
+
+vgs_info = VGsInfo()

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -968,18 +968,20 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
             mock_pvs_cache.return_value = {sentinel.pv_path: pv_info}
-            with patch("blivet.udev.device_get_format", return_value=self.udev_type):
-                helper = self.helper_class(devicetree, data, device)
-                helper.run()
-                self.assertEqual(device.format.type,
-                                 self.blivet_type,
-                                 msg="Wrong format type after FormatPopulator.run on %s" % self.udev_type)
+            with patch("blivet.static_data.lvm_info.VGsInfo.cache", new_callable=PropertyMock) as mock_vgs_cache:
+                mock_vgs_cache.return_value = {pv_info.vg_uuid: Mock()}
+                with patch("blivet.udev.device_get_format", return_value=self.udev_type):
+                    helper = self.helper_class(devicetree, data, device)
+                    helper.run()
+                    self.assertEqual(device.format.type,
+                                     self.blivet_type,
+                                     msg="Wrong format type after FormatPopulator.run on %s" % self.udev_type)
 
-                self.assertEqual(get_device_by_uuid.call_count, 2)
-                get_device_by_uuid.assert_called_with(pv_info.vg_uuid, incomplete=True)
-                vg_device = devicetree.get_device_by_name(pv_info.vg_name)
-                self.assertTrue(vg_device is not None)
-                devicetree._remove_device(vg_device)
+                    self.assertEqual(get_device_by_uuid.call_count, 2)
+                    get_device_by_uuid.assert_called_with(pv_info.vg_uuid, incomplete=True)
+                    vg_device = devicetree.get_device_by_name(pv_info.vg_name)
+                    self.assertTrue(vg_device is not None)
+                    devicetree._remove_device(vg_device)
 
         get_device_by_uuid.reset_mock()
 
@@ -1014,29 +1016,31 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
             mock_pvs_cache.return_value = {sentinel.pv_path: pv_info}
-            with patch("blivet.static_data.lvm_info.LVsInfo.cache", new_callable=PropertyMock) as mock_lvs_cache:
-                mock_lvs_cache.return_value = lv_info
-                with patch("blivet.udev.device_get_format", return_value=self.udev_type):
-                    self.assertEqual(devicetree.get_device_by_name(pv_info.vg_name, incomplete=True), None)
-                    helper = self.helper_class(devicetree, data, device)
-                    helper.run()
-                    self.assertEqual(device.format.type,
-                                     self.blivet_type,
-                                     msg="Wrong format type after FormatPopulator.run on %s" % self.udev_type)
+            with patch("blivet.static_data.lvm_info.VGsInfo.cache", new_callable=PropertyMock) as mock_vgs_cache:
+                mock_vgs_cache.return_value = {pv_info.vg_uuid: Mock()}
+                with patch("blivet.static_data.lvm_info.LVsInfo.cache", new_callable=PropertyMock) as mock_lvs_cache:
+                    mock_lvs_cache.return_value = lv_info
+                    with patch("blivet.udev.device_get_format", return_value=self.udev_type):
+                        self.assertEqual(devicetree.get_device_by_name(pv_info.vg_name, incomplete=True), None)
+                        helper = self.helper_class(devicetree, data, device)
+                        helper.run()
+                        self.assertEqual(device.format.type,
+                                         self.blivet_type,
+                                         msg="Wrong format type after FormatPopulator.run on %s" % self.udev_type)
 
-                    self.assertEqual(get_device_by_uuid.call_count, 4,
-                                     get_device_by_uuid.mock_calls)  # two for vg and one for each lv
-                    get_device_by_uuid.assert_has_calls([call(pv_info.vg_uuid, incomplete=True),
-                                                        call(lv1.uuid),
-                                                        call(lv2.uuid)],
-                                                        any_order=True)
-                    vg_device = devicetree.get_device_by_name(pv_info.vg_name)
-                    self.assertTrue(vg_device is not None)
+                        self.assertEqual(get_device_by_uuid.call_count, 4,
+                                         get_device_by_uuid.mock_calls)  # two for vg and one for each lv
+                        get_device_by_uuid.assert_has_calls([call(pv_info.vg_uuid, incomplete=True),
+                                                            call(lv1.uuid),
+                                                            call(lv2.uuid)],
+                                                            any_order=True)
+                        vg_device = devicetree.get_device_by_name(pv_info.vg_name)
+                        self.assertTrue(vg_device is not None)
 
-                    lv1_device = devicetree.get_device_by_name(lv1_name)
-                    self.assertEqual(lv1_device.uuid, lv1.uuid)
-                    lv2_device = devicetree.get_device_by_name(lv2_name)
-                    self.assertEqual(lv2_device.uuid, lv2.uuid)
+                        lv1_device = devicetree.get_device_by_name(lv1_name)
+                        self.assertEqual(lv1_device.uuid, lv1.uuid)
+                        lv2_device = devicetree.get_device_by_name(lv2_name)
+                        self.assertEqual(lv2_device.uuid, lv2.uuid)
 
 
 class MDFormatPopulatorTestCase(FormatPopulatorTestCase):


### PR DESCRIPTION
This needs some libblockdev changes -- https://github.com/storaged-project/libblockdev/pull/420 -- and it make take some time before this is merged and available, because it as a backwards incompatible ABI change, so we might need to wait to libblockdev 3.0. But this issue is not so common, so it shouldn't be a problem.