### PR TITLE
Do not try to get format free space for non-existing formats

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -456,9 +456,9 @@ class Blivet(object):
             if disk.partitioned:
                 disk_free = disk.format.free
                 for partition in (p for p in partitions if p.disk == disk):
-                    if hasattr(partition.format, "free"):
+                    if partition.format.exists and hasattr(partition.format, "free"):
                         fs_free += partition.format.free
-            elif hasattr(disk.format, "free"):
+            elif disk.format.exists and hasattr(disk.format, "free"):
                 fs_free = disk.format.free
             elif disk.format.type is None:
                 disk_free = disk.size


### PR DESCRIPTION
Resolves: rhbz#1676480

`lvmpv.free` raises exception for non-existing PVs. I'm not sure why, it is possible that simply returning "0" would be better way to solve this bug, but it is possible there is some reason behind this behaviour.
Also `fs_free` in `get_free_space` is defined as *space available by shrinking filesystems* so it probably doesn't make sense to include non-existing filesystems.