### PR TITLE
iscsi: Add default value to unused 'storage' argument in 'write'

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -552,7 +552,7 @@ class iSCSI(object):
 
         self.stabilize()
 
-    def write(self, root, storage):  # pylint: disable=unused-argument
+    def write(self, root, storage=None):  # pylint: disable=unused-argument
         if not self.initiator_set:
             return
 


### PR DESCRIPTION
We don't need the 'storage' argument since the rewrite to udisks.
It would be best to just remove it, but that would be an API
change, so at least set default value to None so blivet users can
easily ignore it.