### PR TITLE
Remove unused API code

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -265,12 +265,6 @@ class UnrecognizedFSTabEntryError(StorageError):
 class FSTabTypeMismatchError(StorageError):
     pass
 
-# probing
-
-
-class UnknownSourceDeviceError(StorageError):
-    pass
-
 # factories
 
 

--- a/doc/api/blivet.rst
+++ b/doc/api/blivet.rst
@@ -181,7 +181,6 @@ blivet
     * :class:`~blivet.errors.SwapSpaceError`
     * :class:`~blivet.errors.ThreadError`
     * :class:`~blivet.errors.UdevError`
-    * :class:`~blivet.errors.UnknownSourceDeviceError`
     * :class:`~blivet.errors.UnrecognizedFSTabEntryError`
     * :class:`~blivet.errors.UnusableConfigurationError`
 


### PR DESCRIPTION
You have as part of your API `UnknownSourceDeviceError` exception but this error is not used anywhere in your code and Anaconda removed the import.

I know you can't just remove this now because it is your API but you should do that on the next opportunity to remove unused code and make your API more lightweight.

Anaconda removing this in PR: https://github.com/rhinstaller/anaconda/pull/1834/