### PR TITLE
Don't crash if blockdev mpath plugin isn't available. (#1672971)

### DIFF
--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -27,6 +27,8 @@ from gi.repository import BlockDev as blockdev
 import logging
 log = logging.getLogger("blivet")
 
+from ..tasks import availability
+
 
 class MpathMembers(object):
     """A cache for querying multipath member devices"""
@@ -40,7 +42,7 @@ class MpathMembers(object):
         :param str device: path of the device to query
 
         """
-        if self._members is None:
+        if self._members is None and availability.BLOCKDEV_MPATH_PLUGIN.available:
             self._members = set(blockdev.mpath.get_mpath_members())
 
         device = os.path.realpath(device)
@@ -56,7 +58,8 @@ class MpathMembers(object):
         """
         device = os.path.realpath(device)
         device = device[len("/dev/"):]
-        if blockdev.mpath.is_mpath_member(device):
+
+        if availability.BLOCKDEV_MPATH_PLUGIN.available and blockdev.mpath.is_mpath_member(device):
             self._members.add(device)
 
     def drop_cache(self):


### PR DESCRIPTION
Other options include:
 1. use udev info to detect mpath membership
 2. try/except