### PR TITLE
Support legacy MBR (msdos) as part of UEFI to enable hybrid builds

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -228,7 +228,7 @@ class DiskLabel(DeviceFormat):
         elif arch.is_efi() and arch.is_arm():
             label_types = ["msdos", "gpt"]
         elif arch.is_efi() and not arch.is_aarch64():
-            label_types = ["gpt"]
+            label_types = ["gpt", "msdos"]
         elif arch.is_s390():
             label_types = ["msdos", "dasd"]
 

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -81,7 +81,7 @@ class DiskLabelTestCase(unittest.TestCase):
         arch.is_pmac.return_value = False
 
         arch.is_efi.return_value = True
-        self.assertEqual(disklabel_class.get_platform_label_types(), ["gpt"])
+        self.assertEqual(disklabel_class.get_platform_label_types(), ["gpt", "msdos"])
         arch.is_aarch64.return_value = True
         self.assertEqual(disklabel_class.get_platform_label_types(), ["gpt", "msdos"])
         arch.is_aarch64.return_value = False


### PR DESCRIPTION
The UEFI spec supports legacy MBR (msdos) in section 5.2 of the UEFI 2.7 spec [1].
There's a number of use cases where we might boot on a UEFI device but want to
support, but not by default, the creation of images using legacy MBR partitions.
One of these use cases is cloud images where we can produce a single image
tha will run on UEFI supported, including secure-boot, clouds but also
support AWS which only supports MBR partitioning schemes [2] and in the current
config anaconda fails the install where this is a perfectly valid and widely
supported deployment mechanism.

So enable the ability to use legacy msdos partitioning schemes, but don't use
it for default installs, so people may consume this mechanism using kickstarts
rather than having the install fail for a valid use case.

[1] https://uefi.org/sites/default/files/resources/UEFI%20Spec%202_7_A%20Sept%206.pdf
[2] https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>