### PR TITLE
Ensure correct type of mpath cache member list.

### DIFF
--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -42,8 +42,11 @@ class MpathMembers(object):
         :param str device: path of the device to query
 
         """
-        if self._members is None and availability.BLOCKDEV_MPATH_PLUGIN.available:
-            self._members = set(blockdev.mpath.get_mpath_members())
+        if self._members is None:
+            if availability.BLOCKDEV_MPATH_PLUGIN.available:
+                self._members = set(blockdev.mpath.get_mpath_members())
+            else:
+                self._members = set()
 
         device = os.path.realpath(device)
         device = device[len("/dev/"):]


### PR DESCRIPTION
This is a followup for #760. I had fixed this in some copy of the code already, but apparently not the one that matters.