### PR TITLE
Fix mounting of the filesystem iso9660

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1242,6 +1242,7 @@ class Iso9660FS(FS):
 
     """ ISO9660 filesystem. """
     _type = "iso9660"
+    _modules = ["iso9660"]
     _supported = True
     _mount_class = fsmount.Iso9660FSMount
 


### PR DESCRIPTION
It is not possible to mount the filesystem iso9660, if the kernel
module isofs (with alias iso9660) is not already loaded. Blivet will
fail with a message "mounting filesystem iso9660 is not supported",
because the mount type is not in kernel_filesystems, there is no file
/sbin/mount.iso9660 and there is no module iso9660.ko*. Therefore,
let's make sure that the kernel module is loaded.