### PR TITLE
Tests archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ archive: po-pull
 	git checkout -- po/$(PKGNAME).pot
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
+tests-archive:
+	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(VERSION_TAG) tests/ | gzip -9 > $(PKGNAME)-$(VERSION)-tests.tar.gz
+	@echo "The test archive is in $(PKGNAME)-$(VERSION)-tests.tar.gz"
+
 local: po-pull
 	@make -B ChangeLog
 	$(PYTHON) setup.py -q sdist --dist-dir .

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ archive: po-pull
 	rm -rf $(PKGNAME)-$(VERSION)
 	git checkout -- po/$(PKGNAME).pot
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
+	@make tests-archive
 
 tests-archive:
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(VERSION_TAG) tests/ | gzip -9 > $(PKGNAME)-$(VERSION)-tests.tar.gz
@@ -128,6 +129,8 @@ local: po-pull
 	@make -B ChangeLog
 	$(PYTHON) setup.py -q sdist --dist-dir .
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
+	git ls-files tests/ | tar -T- -czf $(PKGNAME)-$(VERSION)-tests.tar.gz
+	@echo "The test archive is in $(PKGNAME)-$(VERSION)-tests.tar.gz"
 
 rpmlog:
 	@git log --pretty="format:- %s (%ae)" $(RELEASE_TAG).. |sed -e 's/@.*)/)/'

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -875,7 +875,7 @@ class Blivet(object):
 
             LVM limits lv names to 128 characters. I don't know the limits for
             the other various device types, so I'm going to pick a number so
-            that we don't have to have an entire fucking library to determine
+            that we don't have to have an entire library to determine
             device name limits.
         """
         max_len = 96    # No, you don't need longer names than this. Really.

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -29,6 +29,7 @@ License: LGPLv2+
 %global realname blivet
 %global realversion %{version}%{?prerelease}
 Source0: http://github.com/storaged-project/blivet/archive/%{realname}-%{realversion}.tar.gz
+Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realversion}-tests.tar.gz
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
@@ -165,7 +166,8 @@ configuration.
 %endif
 
 %prep
-%autosetup -n %{realname}-%{realversion} -p1
+%autosetup -n %{realname}-%{realversion} -N
+%autosetup -n %{realname}-%{realversion} -b1 -p1
 
 %build
 %{?with_python2:make PYTHON=%{__python2}}


### PR DESCRIPTION
This provides a make target to create an archive of the tests/ subdirectory and spec file logic to add it to the unpacked sources during rpm build. The remaining piece (that I know of) is to change all of the test dependencies to from `Requires` to `BuildRequires`, which I'm not super excited about.

Thoughts?