### PR TITLE
Correctly handle non-unicode iSCSI initiator names

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -206,7 +206,9 @@ class iSCSI(object):
         if self._initiator != "":
             return self._initiator
 
-        return self._call_initiator_method("GetInitiatorName")[0]
+        # udisks returns initiatorname as a NULL terminated bytearray
+        raw_initiator = bytes(self._call_initiator_method("GetInitiatorNameRaw")[0][:-1])
+        return raw_initiator.decode("utf-8", errors="replace")
 
     @initiator.setter
     @storaged_iscsi_required(critical=True, eval_mode=util.EvalMode.onetime)

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -836,24 +836,26 @@ def device_get_iscsi_nic(info):
 
 
 def device_get_iscsi_initiator(info):
-    initiator = None
+    initiator_name = None
     if device_is_partoff_iscsi(info):
         host = re.match(r'.*/(host\d+)', device_get_sysfs_path(info)).groups()[0]
         if host:
             initiator_file = "/sys/class/iscsi_host/%s/initiatorname" % host
             if os.access(initiator_file, os.R_OK):
-                initiator = open(initiator_file).read().strip()
+                initiator = open(initiator_file, "rb").read().strip()
+                initiator_name = initiator.decode("utf-8", errors="replace")
                 log.debug("found offload iscsi initiatorname %s in file %s",
-                          initiator, initiator_file)
-                if initiator.lstrip("(").rstrip(")").lower() == "null":
-                    initiator = None
-    if initiator is None:
+                          initiator_name, initiator_file)
+                if initiator_name.lstrip("(").rstrip(")").lower() == "null":
+                    initiator_name = None
+    if initiator_name is None:
         session = device_get_iscsi_session(info)
         if session:
             initiator = open("/sys/class/iscsi_session/%s/initiatorname" %
-                             session).read().strip()
-            log.debug("found iscsi initiatorname %s", initiator)
-    return initiator
+                             session, "rb").read().strip()
+            initiator_name = initiator.decode("utf-8", errors="replace")
+            log.debug("found iscsi initiatorname %s", initiator_name)
+    return initiator_name
 
 
 # fcoe disks have ID_PATH in the form of:


### PR DESCRIPTION
This needs new version of UDisks with the `GetInitiatorNameRaw` function. #774 should be merged first to avoid conflicts.