### PR TITLE
Recommend DASD disk label for disks with an existing DASD label

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -350,9 +350,16 @@ class S390(Platform):
         # the device is FBA DASD
         if dasd.is_fba_dasd(device.name):
             return "msdos"
+
         # the device is DASD or has DASD disklabel
-        elif (parted.Device(path=device.path).type == parted.DEVICE_DASD or
-              parted.Disk(device=parted.Device(path=device.path)).type == "dasd"):
+        dev = parted.Device(path=device.path)
+        try:
+            disk = parted.Disk(device=dev)
+        except Exception:  # pylint: disable=broad-except
+            log.info("unable to check existing disklabel on %s", device.name)
+            disk = None
+
+        if dev.type == parted.DEVICE_DASD or disk and disk.type == "dasd":
             return "dasd"
 
         # other types of devices

--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -350,8 +350,9 @@ class S390(Platform):
         # the device is FBA DASD
         if dasd.is_fba_dasd(device.name):
             return "msdos"
-        # the device is DASD
-        elif parted.Device(path=device.path).type == parted.DEVICE_DASD:
+        # the device is DASD or has DASD disklabel
+        elif (parted.Device(path=device.path).type == parted.DEVICE_DASD or
+              parted.Disk(device=parted.Device(path=device.path)).type == "dasd"):
             return "dasd"
 
         # other types of devices


### PR DESCRIPTION
It is possible to have a virtio disk backed by a DASD disk and
in this case we use disk type to determine best label type
because disk type is not DASD.

Resolves: rhbz#1677383

Submitted-by: Masahiro Matsuya <mmatsuya@redhat.com>