### PR TITLE
Remove teardown_all from the populate method

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -416,9 +416,6 @@ class PopulatorMixin(object):
             parted.clear_exn_handler()
             self._hide_ignored_disks()
 
-        if flags.auto_dev_updates:
-            self.teardown_all()
-
     def _populate(self):
         log.info("DeviceTree.populate: ignored_disks is %s ; exclusive_disks is %s",
                  self.ignored_disks, self.exclusive_disks)


### PR DESCRIPTION
It is not possible to protect devices from teardown when the
`auto_dev_updates` flag is set. So let's remove` teardown_all`
from the `populate` method and let users to do that.