### PR TITLE
RFC: Avoid some tracebacks during populate

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -196,8 +196,7 @@ class DeviceNotFoundError(StorageError):
     pass
 
 
-class UnusableConfigurationError(StorageError):
-
+class UnusableConfigurationError(DeviceTreeError):
     """ User has an unusable initial storage configuration. """
     suggestion = ""
 

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -81,6 +81,7 @@ class Flags(object):
 
         self.update_from_boot_cmdline()
         self.allow_imperfect_devices = True
+        self.allow_inconsistent_config = True
         self.debug_threads = False
 
     def get_boot_cmdline(self):

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -22,7 +22,6 @@ from . import udev
 from . import util
 from .flags import flags
 from .i18n import _
-from .storage_log import log_exception_info
 from . import safe_dbus
 import os
 import re
@@ -160,7 +159,7 @@ class iSCSI(object):
                 initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")[0]
                 self._initiator = initiatorname
             except Exception:  # pylint: disable=broad-except
-                log_exception_info(fmt_str="failed to get initiator name from iscsi firmware")
+                log.info("No iSCSI firmware initiator found")
 
     # So that users can write iscsi() to get the singleton instance
     def __call__(self):
@@ -278,7 +277,7 @@ class iSCSI(object):
                                           'GetManagedObjects',
                                           None)[0]
         except safe_dbus.DBusCallError:
-            log_exception_info(log.info, "iscsi: Failed to get active sessions.")
+            log.info("iscsi: Failed to get active sessions.")
             return []
 
         sessions = (obj for obj in objects.keys() if re.match(r'.*/iscsi/session[0-9]+$', obj))
@@ -303,7 +302,7 @@ class iSCSI(object):
         try:
             found_nodes, _n_nodes = self._call_initiator_method("DiscoverFirmware", args)
         except safe_dbus.DBusCallError:
-            log_exception_info(log.info, "iscsi: No IBFT info found.")
+            log.info("iscsi: No IBFT info found.")
             # an exception here means there is no ibft firmware, just return
             return
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -202,7 +202,7 @@ def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info:
+    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
         mdname = udev_info["MD_DEVNAME"]
         if device_is_partition(udev_info):
             # for partitions on named RAID we want to use the raid name, not

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -12,6 +12,7 @@ from blivet.devices import DiskDevice, DMDevice, FileDevice, LoopDevice
 from blivet.devices import MDRaidArrayDevice, MultipathDevice, OpticalDevice
 from blivet.devices import PartitionDevice, StorageDevice, NVDIMMNamespaceDevice
 from blivet.devicetree import DeviceTree
+from blivet.errors import DeviceTreeError
 from blivet.formats import get_device_format_class, get_format, DeviceFormat
 from blivet.formats.disklabel import DiskLabel
 from blivet.populator.helpers import DiskDevicePopulator, DMDevicePopulator, LoopDevicePopulator
@@ -23,6 +24,69 @@ from blivet.populator.helpers.boot import AppleBootFormatPopulator, EFIFormatPop
 from blivet.populator.helpers.formatpopulator import FormatPopulator
 from blivet.populator.helpers.disklabel import DiskLabelFormatPopulator
 from blivet.size import Size
+
+
+class PopulatorTestCase(unittest.TestCase):
+    @patch.object(DeviceTree, "_get_format_helper")
+    def test_handle_format_error_handling(self, *args):
+        """ Test handling of errors raised from populator (format) helpers' run methods.
+
+            The piece we want to test is that DeviceTreeError being raised from the
+            helper's run method results in no crash and an unset format on the device.
+            There is no need to test the various helpers individually since the only
+            machinery is in Populator.handle_format.
+        """
+        get_format_helper_patch = args[0]
+
+        devicetree = DeviceTree()
+
+        # Set up info to look like a specific format type
+        name = 'fhtest1'
+        fmt_type = 'xfs'
+        info = dict(SYS_NAME=name, ID_FS_TYPE=fmt_type)
+        device = StorageDevice(name, size=Size('50g'), exists=True)
+
+        # Set up helper to raise an exn in run()
+        helper = Mock()
+        helper.side_effect = DeviceTreeError("failed to populate format")
+        get_format_helper_patch.return_value = helper
+
+        devicetree.handle_format(info, device)
+
+        self.assertEqual(device.format.type, None)
+
+    @patch.object(DeviceTree, "_reason_to_skip_device", return_value=None)
+    @patch.object(DeviceTree, "_clear_new_multipath_member")
+    @patch.object(DeviceTree, "handle_format")
+    @patch.object(DeviceTree, "_add_slave_devices")
+    @patch.object(DeviceTree, "_get_device_helper")
+    def test_handle_device_error_handling(self, *args):
+        """ Test handling of errors raised from populator (device) helpers' run methods.
+
+            When the helper's run method raises DeviceTreeError we should end up with a
+            StorageDevice (and no traceback). There is no need to test the various
+            helper classes since all of the machinery is in Populator.handle_device.
+        """
+        get_device_helper_patch = args[0]
+        add_slave_devices_patch = args[1]
+
+        devicetree = DeviceTree()
+
+        # Set up info to look like a specific device type
+        name = 'dhtest1'
+        info = dict(SYS_NAME=name, SYS_PATH='/fake/sys/path/dhtest1')
+
+        # Set up helper to raise an exn in run()
+        helper = Mock()
+        helper.side_effect = DeviceTreeError("failed to populate device")
+        get_device_helper_patch.return_value = helper
+
+        add_slave_devices_patch.return_value = list()
+        devicetree.handle_device(info)
+
+        device = devicetree.get_device_by_name(name)
+        self.assertIsNotNone(device)
+        self.assertIsInstance(device, StorageDevice)
 
 
 class PopulatorHelperTestCase(unittest.TestCase):


### PR DESCRIPTION
Having fixed big issues with active LVM on partial VGs and with unusable dmraid arrays, the most-reported failure during blivet populate involves partitioned disks that have been cloned by users without adjusting the disklabel UUIDs to make them unique. In the past I have generally favored a "you must fix this problem before proceeding" approach, but now I'm thinking more about being robust and not crashing unless it's really necessary.

I'm mostly curious what people think of "Allow duplicate UUIDs...", "Unset partition UUIDs...", and "General protection against...". The first two of these are tested, both via unit tests and a "real" test using examples/list_devices.py in a vm. The third ("General protection...") probably needs more work.