### PR TITLE
Check if disklabel supports partition names (#1723228)

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -329,6 +329,13 @@ class DiskLabel(DeviceFormat):
         """ Device status. """
         return False
 
+    @property
+    def supports_names(self):
+        if not self.supported or not self.parted_disk:
+            return False
+
+        return self.parted_disk.supportsFeature(parted.DISK_TYPE_PARTITION_NAME)
+
     def _create(self, **kwargs):
         """ Create the device. """
         log_method_call(self, device=self.device,

--- a/blivet/populator/helpers/boot.py
+++ b/blivet/populator/helpers/boot.py
@@ -59,6 +59,7 @@ class MacEFIFormatPopulator(BootFormatPopulator):
         fmt = formats.get_format(cls._type_specifier)
         try:
             return (super(MacEFIFormatPopulator, MacEFIFormatPopulator).match(data, device) and
+                    device.disk.format.supports_names and
                     device.parted_partition.name == fmt.name)
         except AttributeError:
             # just in case device.parted_partition has no name attr

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -1191,6 +1191,7 @@ class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
 
         if fmt_class._name:
             partition._parted_partition = FakePartedPart(partition, fmt_class._name)
+            partition.disk = Mock(format=Mock(supports_names=True))
 
         self.assertTrue(self.helper_class.match(data, partition))
 
@@ -1245,6 +1246,7 @@ class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
         partition._size = fmt_class._min_size
         if fmt_class._name:
             partition._parted_partition = FakePartedPart(partition, fmt_class._name)
+            partition.disk = Mock(format=Mock(supports_names=True))
         self.assertEqual(get_format_helper(data, partition), self.helper_class)
 
 


### PR DESCRIPTION
pyparted now raises an exception when trying to access partition
name on a disklabel that doesn't support partition names, see
https://github.com/dcantrell/pyparted/issues/59