### PR TITLE
format_device: Revert destroy action if create fails (#1727589)

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -807,8 +807,16 @@ class Blivet(object):
         if device.protected:
             raise ValueError("cannot modify protected device")
 
-        self.devicetree.actions.add(ActionDestroyFormat(device))
-        self.devicetree.actions.add(ActionCreateFormat(device, fmt))
+        destroy_ac = ActionDestroyFormat(device)
+        create_ac = ActionCreateFormat(device, fmt)
+
+        self.devicetree.actions.add(destroy_ac)
+        try:
+            self.devicetree.actions.add(create_ac)
+        except Exception as e:
+            # creating the format failed, revert the destroy action too
+            self.devicetree.actions.remove(destroy_ac)
+            raise e
 
     def reset_device(self, device):
         """ Cancel all scheduled actions and reset formatting.


### PR DESCRIPTION
We shouldn't change the format at all if creating format fails for
some reason (for example device being to big/small for the new
format).

----
The original bug was about reusing an existing swap that was larger than our max size for swap (128 GiB). In this situation anaconda will not allow to reuse the swap but it will remove the swap format from it. Anaconda could remove the action too but it doesn't have the action instance so it would be complicated.