### PR TITLE
Always use luks_data.min_entropy as a default minimum entropy

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -611,13 +611,10 @@ class ActionCreateFormat(DeviceAction):
             udev.settle()
 
         if isinstance(self.device.format, luks.LUKS):
-            if self.device.format.min_luks_entropy is None:
-                min_required_entropy = luks_data.min_entropy
-            else:
-                min_required_entropy = self.device.format.min_luks_entropy
-
             # LUKS needs to wait for random data entropy if it is too low
+            min_required_entropy = self.device.format.min_luks_entropy
             current_entropy = get_current_entropy()
+
             if current_entropy < min_required_entropy:
                 force_cont = False
                 if callbacks and callbacks.wait_for_entropy:

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -332,7 +332,11 @@ class DeviceFactory(object):
             setattr(self, setting, value)
 
         self.fstype = None  # not included in default_settings b/c of special handling below
-        self.min_luks_entropy = kwargs.get("min_luks_entropy") or luks_data.min_entropy
+        self.min_luks_entropy = kwargs.get("min_luks_entropy")
+
+        if self.min_luks_entropy is None:
+            self.min_luks_entropy = luks_data.min_entropy
+
         self.luks_version = kwargs.get("luks_version") or crypto.DEFAULT_LUKS_VERSION
         self.pbkdf_args = kwargs.get("pbkdf_args", None)
 

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -130,7 +130,10 @@ class LUKS(DeviceFormat):
         self._key_file = kwargs.get("key_file")
         self.escrow_cert = kwargs.get("escrow_cert")
         self.add_backup_passphrase = kwargs.get("add_backup_passphrase", False)
-        self.min_luks_entropy = kwargs.get("min_luks_entropy", 0)
+        self.min_luks_entropy = kwargs.get("min_luks_entropy")
+
+        if self.min_luks_entropy is None:
+            self.min_luks_entropy = luks_data.min_entropy
 
         if not self.map_name and self.exists and self.uuid:
             self.map_name = "luks-%s" % self.uuid


### PR DESCRIPTION
Use `luks_data.min_entropy` if the minimum entropy is not set.