### PR TITLE
More consistent lvm errors (API break)

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1658,6 +1658,7 @@ class LVMThinPFactory(LVMFactory):
         new_size = self._get_pool_size()
         self.pool.size = new_size
         self.pool.req_grow = False
+        self.pool.autoset_md_size(enforced=True)
 
     def _reconfigure_pool(self):
         """ Adjust the pool according to the set of devices it will contain. """

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1383,7 +1383,7 @@ class LVMFactory(DeviceFactory):
 
         if (self.vg and self.vg.thpool_reserve) or isinstance(self, LVMThinPFactory):
             # black maths (to make sure there's DEFAULT_THPOOL_RESERVE.percent reserve)
-            space_with_reserve = space * (1 / (1 - (DEFAULT_THPOOL_RESERVE.percent / 100)))
+            space_with_reserve = space.ensure_percent_reserve(DEFAULT_THPOOL_RESERVE.percent)
             reserve = space_with_reserve - space
             if reserve < DEFAULT_THPOOL_RESERVE.min:
                 space = space + DEFAULT_THPOOL_RESERVE.min
@@ -1575,9 +1575,9 @@ class LVMThinPFactory(LVMFactory):
                 # reserved space in the VG are removed
                 size -= self.pool.free_space
 
-                # this is how we get the portion of the thpool reserve in the VG
-                # for the free space
-                reserve_portion = (self.pool.free_space * (1 / (1 - (DEFAULT_THPOOL_RESERVE.percent / 100)))) - self.pool.free_space
+                # get the portion of the thpool reserve in the VG for the free
+                # space
+                reserve_portion = self.pool.free_space.ensure_percent_reserve(DEFAULT_THPOOL_RESERVE.percent) - self.pool.free_space
 
                 # but we need to make sure at least DEFAULT_THPOOL_RESERVE.min
                 # is kept as the reserve

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1578,6 +1578,11 @@ class LVMThinPoolMixin(object):
 
         log.debug("Auto-setting thin pool metadata size%s", (" (enforced)" if enforced else ""))
 
+        if self._size <= Size(0):
+            log.debug("Thin pool size not bigger than 0, just setting metadata size to 0")
+            self._metadata_size = 0
+            return
+
         # we need to know chunk size to calculate recommended metadata size
         if self._chunk_size == 0:
             self._chunk_size = Size(blockdev.LVM_DEFAULT_CHUNK_SIZE)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1979,7 +1979,8 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def max_size(self):
         """ The maximum size this lv can be. """
-        max_lv = self.size + self.vg.free_space
+        max_lv = (self.vg.align(self.size, roundup=True) +
+                  self.vg.align(self.vg.free_space, roundup=False))
         max_format = self.format.max_size
         return min(max_lv, max_format) if max_format else max_lv
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1587,17 +1587,18 @@ class LVMThinPoolMixin(object):
         self._metadata_size = Size(blockdev.lvm.get_thpool_meta_size(self._size,
                                                                      self._chunk_size,
                                                                      100))  # snapshots
-        log.debug("Recommended metadata size: %s", self._metadata_size)
+        log.debug("Recommended metadata size: %s MiB", self._metadata_size.convert_to("MiB"))
 
         self._metadata_size = self.vg.align(self._metadata_size, roundup=True)
-        log.debug("Rounded metadata size to extents: %s", self._metadata_size)
+        log.debug("Rounded metadata size to extents: %s MiB", self._metadata_size.convert_to("MiB"))
 
         if self._metadata_size == old_md_size:
             log.debug("Rounded metadata size unchanged")
         else:
-            log.debug("Adjusting size from %s to %s",
-                      self.size, self.size - (self._metadata_size - old_md_size))
-            self.size = self.size - (self._metadata_size - old_md_size)
+            new_size = self.size - (self._metadata_size - old_md_size)
+            log.debug("Adjusting size from %s MiB to %s MiB",
+                      self.size.convert_to("MiB"), new_size.convert_to("MiB"))
+            self.size = new_size
 
     def _pre_create(self):
         # make sure all the LVs this LV should be created from exist (if any)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -303,7 +303,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
     def _add_log_vol(self, lv):
         """ Add an LV to this VG. """
         if lv in self._lvs:
-            raise ValueError("lv is already part of this vg")
+            raise errors.DeviceError("lv is already part of this vg")
 
         # verify we have the space, then add it
         # do not verify for growing vg (because of ks)
@@ -336,7 +336,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
     def _remove_log_vol(self, lv):
         """ Remove an LV from this VG. """
         if lv not in self.lvs:
-            raise ValueError("specified lv is not part of this vg")
+            raise errors.DeviceError("specified lv is not part of this vg")
 
         self._lvs.remove(lv)
 
@@ -395,7 +395,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
     @thpool_reserve.setter
     def thpool_reserve(self, value):
         if value is not None and not isinstance(value, ThPoolReserveSpec):
-            raise ValueError("Invalid thpool_reserve given, must be of type ThPoolReserveSpec")
+            raise AttributeError("Invalid thpool_reserve given, must be of type ThPoolReserveSpec")
         self._thpool_reserve = value
 
     @property
@@ -602,13 +602,13 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
             if seg_type not in [None, "linear", "thin", "thin-pool", "cache"] + lvm.raid_seg_types:
                 raise ValueError("Invalid or unsupported segment type: %s" % seg_type)
             if seg_type and seg_type in lvm.raid_seg_types and not pvs:
-                raise ValueError("List of PVs has to be given for every non-linear LV")
+                raise errors.DeviceError("List of PVs has to be given for every non-linear LV")
             elif (not seg_type or seg_type == "linear") and pvs:
                 if not all(isinstance(pv, LVPVSpec) for pv in pvs):
-                    raise ValueError("Invalid specification of PVs for a linear LV: either no or complete "
+                    raise errors.DeviceError("Invalid specification of PVs for a linear LV: either no or complete "
                                      "specification (with all space split into PVs has to be given")
                 elif sum(spec.size for spec in pvs) != size:
-                    raise ValueError("Invalid specification of PVs for a linear LV: the sum of space "
+                    raise errors.DeviceError("Invalid specification of PVs for a linear LV: the sum of space "
                                      "assigned to PVs is not equal to the size of the LV")
 
         # When this device's format is set in the superclass constructor it will
@@ -657,13 +657,13 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         self._from_lvs = from_lvs
         if self._from_lvs:
             if exists:
-                raise ValueError("Only new LVs can be created from other LVs")
+                raise errors.DeviceError("Only new LVs can be created from other LVs")
             if size or maxsize or percent:
-                raise ValueError("Cannot specify size for a converted LV")
+                raise errors.DeviceError("Cannot specify size for a converted LV")
             if fmt:
-                raise ValueError("Cannot specify format for a converted LV")
+                raise errors.DeviceError("Cannot specify format for a converted LV")
             if any(lv.vg != self.vg for lv in self._from_lvs):
-                raise ValueError("Conversion of LVs only possible inside a VG")
+                raise errors.DeviceError("Conversion of LVs only possible inside a VG")
 
         self._cache = None
         if cache_request and not self.exists:
@@ -678,13 +678,13 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
             elif isinstance(pv_spec, StorageDevice):
                 self._pv_specs.append(LVPVSpec(pv_spec, Size(0)))
             else:
-                raise ValueError("Invalid PV spec '%s' for the '%s' LV" % (pv_spec, self.name))
+                raise AttributeError("Invalid PV spec '%s' for the '%s' LV" % (pv_spec, self.name))
         # Make sure any destination PVs are actually PVs in this VG
         if not set(spec.pv for spec in self._pv_specs).issubset(set(self.vg.parents)):
             missing = [r.name for r in
                        set(spec.pv for spec in self._pv_specs).difference(set(self.vg.parents))]
             msg = "invalid destination PV(s) %s for LV %s" % (missing, self.name)
-            raise ValueError(msg)
+            raise errors.DeviceError(msg)
         if self._pv_specs:
             self._assign_pv_space()
 
@@ -1023,7 +1023,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         else:
             msg = "the specified internal LV '%s' doesn't belong to this LV ('%s')" % (int_lv.lv_name,
                                                                                        self.name)
-            raise ValueError(msg)
+            raise errors.DeviceError(msg)
 
     def populate_ksdata(self, data):
         super(LVMLogicalVolumeBase, self).populate_ksdata(data)
@@ -1119,7 +1119,7 @@ class LVMInternalLogicalVolumeMixin(object):
     def _init_check(self):
         # an internal LV should have no parents
         if self._parent_lv and self._parents:
-            raise ValueError("an internal LV should have no parents")
+            raise errors.DeviceError("an internal LV should have no parents")
 
     @property
     def is_internal_lv(self):
@@ -1179,7 +1179,7 @@ class LVMInternalLogicalVolumeMixin(object):
 
     @readonly.setter
     def readonly(self, value):  # pylint: disable=unused-argument
-        raise ValueError("Cannot make an internal LV read-write")
+        raise errors.DeviceError("Cannot make an internal LV read-write")
 
     @property
     def type(self):
@@ -1215,7 +1215,7 @@ class LVMInternalLogicalVolumeMixin(object):
     def _check_parents(self):
         # an internal LV should have no parents
         if self._parents:
-            raise ValueError("an internal LV should have no parents")
+            raise errors.DeviceError("an internal LV should have no parents")
 
     def _add_to_parents(self):
         # nothing to do here, an internal LV has no parents (in the DeviceTree's
@@ -1225,13 +1225,13 @@ class LVMInternalLogicalVolumeMixin(object):
     # internal LVs follow different rules limitting size
     def _set_size(self, newsize):
         if not isinstance(newsize, Size):
-            raise ValueError("new size must of type Size")
+            raise AttributeError("new size must of type Size")
 
         if not self.takes_extra_space:
             if newsize <= self.parent_lv.size:  # pylint: disable=no-member
                 self._size = newsize  # pylint: disable=attribute-defined-outside-init
             else:
-                raise ValueError("Internal LV cannot be bigger than its parent LV")
+                raise errors.DeviceError("Internal LV cannot be bigger than its parent LV")
         else:
             # same rules apply as for any other LV
             raise NotTypeSpecific()
@@ -1309,18 +1309,18 @@ class LVMSnapshotMixin(object):
             return
 
         if self.origin and not isinstance(self.origin, LVMLogicalVolumeDevice):
-            raise ValueError("lvm snapshot origin must be a logical volume")
+            raise errors.DeviceError("lvm snapshot origin must be a logical volume")
         if self.vorigin and not self.exists:
-            raise ValueError("only existing vorigin snapshots are supported")
+            raise errors.DeviceError("only existing vorigin snapshots are supported")
 
         if isinstance(self.origin, LVMLogicalVolumeDevice) and \
            isinstance(self.parents[0], LVMVolumeGroupDevice) and \
            self.origin.vg != self.parents[0]:
-            raise ValueError("lvm snapshot and origin must be in the same vg")
+            raise errors.DeviceError("lvm snapshot and origin must be in the same vg")
 
         if self.is_thin_lv:
             if self.origin and self.size and not self.exists:
-                raise ValueError("thin snapshot size is determined automatically")
+                raise errors.DeviceError("thin snapshot size is determined automatically")
 
     @property
     def is_snapshot_lv(self):
@@ -1498,7 +1498,7 @@ class LVMThinPoolMixin(object):
     def _check_from_lvs(self):
         if self._from_lvs:
             if len(self._from_lvs) != 2:
-                raise ValueError("two LVs required to create a thin pool")
+                raise errors.DeviceError("two LVs required to create a thin pool")
 
     def _convert_from_lvs(self):
         data_lv, metadata_lv = self._from_lvs
@@ -1544,7 +1544,7 @@ class LVMThinPoolMixin(object):
     def _add_log_vol(self, lv):
         """ Add an LV to this pool. """
         if lv in self._lvs:
-            raise ValueError("lv is already part of this vg")
+            raise errors.DeviceError("lv is already part of this vg")
 
         # TODO: add some checking to prevent overcommit for preexisting
         self.vg._add_log_vol(lv)
@@ -1555,7 +1555,7 @@ class LVMThinPoolMixin(object):
     def _remove_log_vol(self, lv):
         """ Remove an LV from this pool. """
         if lv not in self._lvs:
-            raise ValueError("specified lv is not part of this vg")
+            raise errors.DeviceError("specified lv is not part of this vg")
 
         self._lvs.remove(lv)
         self.vg._remove_log_vol(lv)
@@ -1664,14 +1664,14 @@ class LVMThinLogicalVolumeMixin(object):
         """Check that this device has parents as expected"""
         if isinstance(self.parents, (list, ParentList)):
             if len(self.parents) != 1:
-                raise ValueError("constructor requires a single thin-pool LV")
+                raise errors.DeviceError("constructor requires a single thin-pool LV")
 
             container = self.parents[0]
         else:
             container = self.parents
 
         if not container or not isinstance(container, LVMLogicalVolumeDevice) or not container.is_thin_pool:
-            raise ValueError("constructor requires a thin-pool LV")
+            raise errors.DeviceError("constructor requires a thin-pool LV")
 
     @property
     def is_thin_lv(self):
@@ -1708,7 +1708,7 @@ class LVMThinLogicalVolumeMixin(object):
 
     def _set_size(self, newsize):
         if not isinstance(newsize, Size):
-            raise ValueError("new size must of type Size")
+            raise AttributeError("new size must of type Size")
 
         newsize = self.vg.align(newsize)
         newsize = self.vg.align(util.numeric_type(newsize))
@@ -1933,7 +1933,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             container = self.parents
 
         if not isinstance(container, LVMVolumeGroupDevice):
-            raise ValueError("constructor requires a LVMVolumeGroupDevice")
+            raise AttributeError("constructor requires a LVMVolumeGroupDevice")
 
     @type_specific
     def _add_to_parents(self):
@@ -1944,12 +1944,12 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def _check_from_lvs(self):
         """Check the LVs to create this LV from"""
-        raise ValueError("Cannot create a new LV of type '%s' from other LVs" % self.seg_type)
+        raise errors.DeviceError("Cannot create a new LV of type '%s' from other LVs" % self.seg_type)
 
     @type_specific
     def _convert_from_lvs(self):
         """Convert the LVs to create this LV from into its internal LVs"""
-        raise ValueError("Cannot create a new LV of type '%s' from other LVs" % self.seg_type)
+        raise errors.DeviceError("Cannot create a new LV of type '%s' from other LVs" % self.seg_type)
 
     @property
     @type_specific
@@ -1960,7 +1960,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def _set_size(self, newsize):
         if not isinstance(newsize, Size):
-            raise ValueError("new size must be of type Size")
+            raise AttributeError("new size must be of type Size")
 
         newsize = self.vg.align(newsize)
         log.debug("trying to set lv %s size to %s", self.name, newsize)
@@ -1969,7 +1969,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         # space for it. A similar reasoning applies to shrinking the LV.
         if not self.exists and newsize > self.size and newsize > self.vg.free_space + self.vg_space_used:
             log.error("failed to set size: %s short", newsize - (self.vg.free_space + self.vg_space_used))
-            raise ValueError("not enough free space in volume group")
+            raise errors.DeviceError("not enough free space in volume group")
 
         LVMLogicalVolumeBase._set_size(self, newsize)
 
@@ -2292,7 +2292,7 @@ class LVMCache(Cache):
                 spec.size = spec.pv.format.free
                 space_to_assign -= spec.pv.format.free
         if space_to_assign > 0:
-            raise ValueError("Not enough free space in the PVs for this cache: %s short" % space_to_assign)
+            raise errors.DeviceError("Not enough free space in the PVs for this cache: %s short" % space_to_assign)
 
     @property
     def size(self):

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -71,6 +71,7 @@ class FS(DeviceFormat):
     _uuidfs = None                       # functionality for UUIDs
     _fsck_class = fsck.UnimplementedFSCK
     _mkfs_class = fsmkfs.UnimplementedFSMkfs
+    _min_size = Size("2 MiB")            # default minimal size
     _mount_class = fsmount.FSMount
     _readlabel_class = fsreadlabel.UnimplementedFSReadLabel
     _sync_class = fssync.UnimplementedFSSync
@@ -1256,6 +1257,7 @@ class NoDevFS(FS):
     _type = "nodev"
     _mount_class = fsmount.NoDevFSMount
     _selinux_supported = False
+    _min_size = Size(0)
 
     def __init__(self, **kwargs):
         FS.__init__(self, **kwargs)

--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -70,12 +70,13 @@ class DMRaidFormatPopulator(FormatPopulator):
                 # We add the new device.
                 dm_array.parents.append(self.device)
             else:
-                # Activate the Raid set.
-                try:
-                    blockdev.dm.activate_raid_set(rs_name)
-                except blockdev.DMError:
-                    log.warning("Failed to activate the RAID set '%s'", rs_name)
-                    return
+                if not blockdev.dm.map_exists(rs_name, True, True):
+                    # Activate the Raid set.
+                    try:
+                        blockdev.dm.activate_raid_set(rs_name)
+                    except blockdev.DMError:
+                        log.warning("Failed to activate the RAID set '%s'", rs_name)
+                        return
 
                 dm_array = DMRaidArrayDevice(rs_name,
                                              parents=[self.device],

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -159,3 +159,24 @@ class Size(bytesize.Size):
                 raise ValueError("invalid rounding size: %s" % size)
 
         return Size(bytesize.Size.round_to_nearest(self, size, rounding))
+
+    def ensure_percent_reserve(self, percent):
+        """Get a new size with given space reserve.
+
+            :param percent: number of percent to reserve
+            :returns: a new size with :param:`percent` space reserve
+            :rtype: :class:`Size`
+
+            Best described with an example:
+            >>> Size("80 GiB").ensure_percent_reserve(20)
+            Size (100 GiB)
+
+            This method returns a new size in which there's a :param:`percent`%
+            reserve (on top of the original size). In other words::
+
+              with_reserve - orig_size == with_reserve * (percent / 100)
+
+            except that due to float arithmetics the numbers are unlikely to be
+            exactly equal.
+        """
+        return Size(self * (1 / (1 - (percent / 100))))

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -301,7 +301,7 @@ class DeviceActionTestCase(StorageTestCase):
                                name="sdc1", size=Size("100 GiB"),
                                parents=[sdc], exists=True)
 
-        sdc1_format = self.new_format("ext2", device=sdc1.path, mountpoint="/")
+        sdc1_format = self.new_format("ext2", device=sdc1.path, mountpoint="/", size=Size("100 GiB"))
         create_sdc1_format = ActionCreateFormat(sdc1, sdc1_format)
         create_sdc1_format.apply()
         with self.assertRaises(blivet.errors.DeviceTreeError):

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -33,6 +33,7 @@ from blivet.devicelibs import mdraid
 from blivet.size import Size
 
 from blivet.formats import get_format
+from blivet.formats.fs import FS
 
 BTRFS_MIN_MEMBER_SIZE = get_format("btrfs").min_size
 
@@ -599,7 +600,8 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
             "media_present": xform(self.assertTrue),
             "metadata_level": lambda d, a: self.assertFalse(hasattr(d, a)),
             "type": xform(lambda x, m: self.assertEqual(x, "btrfs", m)),
-            "vol_id": xform(lambda x, m: self.assertEqual(x, btrfs.MAIN_VOLUME_ID, m))}
+            "vol_id": xform(lambda x, m: self.assertEqual(x, btrfs.MAIN_VOLUME_ID, m))
+        }
         self._state_functions.update(state_functions)
 
     def setUp(self):
@@ -759,6 +761,8 @@ class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
             "parents": xform(lambda x, m: self.assertEqual(len(x), 1, m) and
                              self.assertIsInstance(x, ParentList) and
                              self.assertIsInstance(x[0], LVMVolumeGroupDevice)),
+            "size": xform(lambda x, m: self.assertEqual(x, FS._min_size, m)),
+            "target_size": xform(lambda x, m: self.assertEqual(x, FS._min_size, m))
         }
 
         self._state_functions.update(state_functions)

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -87,13 +87,16 @@ class LVMDeviceTest(unittest.TestCase):
         vg = LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
 
         cache_req = LVMCacheRequest(Size("512 MiB"), [pv2], "writethrough")
-        lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
+        lv = LVMLogicalVolumeDevice("testlv",
+                                    parents=[vg],
                                     fmt=blivet.formats.get_format("xfs"),
-                                    exists=False, cache_request=cache_req)
+                                    size=Size(blivet.formats.get_format("xfs").min_size),
+                                    exists=False,
+                                    cache_request=cache_req)
 
         # the cache reserves space for its metadata from the requested size, but
         # it may require (and does in this case) a pmspare LV to be allocated
-        self.assertEqual(lv.vg_space_used, Size("504 MiB"))
+        self.assertEqual(lv.vg_space_used, Size("508 MiB"))
 
         # check that the LV behaves like a cached LV
         self.assertTrue(lv.cached)

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -34,7 +34,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         dev1_label = "dev1_label"
         dev1_uuid = "1234-56-7890"
         fmt1 = get_format("ext4", label=dev1_label, uuid=dev1_uuid)
-        dev1 = StorageDevice("dev1", exists=True, fmt=fmt1)
+        dev1 = StorageDevice("dev1", exists=True, fmt=fmt1, size=fmt1.min_size)
         dt._add_device(dev1)
 
         dev2_label = "dev2_label"

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -87,6 +87,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
 
         # sizes
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))
@@ -98,6 +99,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         an_fs = self._fs_class(size=NEW_SIZE)
 
         # sizes
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, NEW_SIZE)
         self.assertEqual(an_fs.current_size, Size(0))
@@ -114,6 +116,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertTrue(an_fs.exists)
         self.assertIsNone(an_fs.do_check())
 
+        self.assertEqual(an_fs.min_size, an_fs._min_size)
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -87,9 +87,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
 
         # sizes
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
-
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))
         self.assertEqual(an_fs.current_size, Size(0))
@@ -101,9 +98,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         an_fs = self._fs_class(size=NEW_SIZE)
 
         # sizes
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
-
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, NEW_SIZE)
         self.assertEqual(an_fs.current_size, Size(0))
@@ -119,9 +113,6 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.resizable, False)
         self.assertTrue(an_fs.exists)
         self.assertIsNone(an_fs.do_check())
-
-        expected_min_size = Size(0) if can_resize(an_fs) else an_fs._min_size
-        self.assertEqual(an_fs.min_size, expected_min_size)
 
         self.assertEqual(an_fs.max_size, an_fs._max_size)
         self.assertEqual(an_fs.size, Size(0))

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -214,6 +214,15 @@ class SizeTestCase(unittest.TestCase):
         s = Size("10 MiB")
         self.assertEqual(s, cPickle.loads(cPickle.dumps(s)))
 
+    def test_ensure_percent_reserve(self):
+        s = Size("8 GiB")
+        self.assertAlmostEqual(s.ensure_percent_reserve(20), Size("10 GiB"), delta=Size("1 MiB"))
+
+        for s in (Size("4 GiB"), Size("5 GiB"), Size("100 GiB")):
+            for percent in (10, 15, 20, 35, 80):
+                with_reserve = s.ensure_percent_reserve(percent)
+                self.assertAlmostEqual(with_reserve - s, with_reserve * (percent / 100), delta=Size("1 MiB"))
+
 
 # es_ES uses latin-characters but a comma as the radix separator
 # kk_KZ uses non-latin characters and is case-sensitive


### PR DESCRIPTION
- changed exception types in devices/lvm.py to
be more consistent (as per https://github.com/storaged-project/blivet/issues/528)
- these modifications change API