### PR TITLE
Add 'protected' property setter to LVMVolumeGroupDevice (#1729363)

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -553,6 +553,10 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         return super(LVMVolumeGroupDevice, self).protected
 
+    @protected.setter
+    def protected(self, value):
+        self._protected = value
+
     def remove_hook(self, modparent=True):
         if modparent:
             for pv in self.pvs:


### PR DESCRIPTION
Inherited setters do not work after being wrapped using the
SynchronizedMeta meta class.

-----

I've tried to find a way how to fix this in SynchronizedMeta, but it looks like it is not possible, the setter is just not visible in the child class. There is no problem for properties where both getter and setter are inherited.