### PR TITLE
Fix getting names for MD member disks with MD properties (#1727180)

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -204,7 +204,11 @@ def device_get_name(udev_info):
         name = udev_info["DM_NAME"]
     elif "MD_DEVNAME" in udev_info:
         mdname = udev_info["MD_DEVNAME"]
-        if device_is_partition(udev_info):
+        if device_is_disk(udev_info):
+            # this device is actually not an MD device but a disk from the array
+            # these sometimes have the MD_* properties in udev database
+            name = udev_info["SYS_NAME"]
+        elif device_is_partition(udev_info):
             # for partitions on named RAID we want to use the raid name, not
             # the node, e.g. "raid1" instead of "md127p1"
             partnum = udev_info["ID_PART_ENTRY_NUMBER"]


### PR DESCRIPTION
Some MD member disks have the 'MD_*' properties in UDev database
which confuses our 'udev.device_get_name' function.

----

The result is three devices with same name (two disks and the array). This doesn't happen for all arrays, I was able to reproduce this  with a raid1 created directly on top of the disks (without partitions).

```
$ udevadm info /dev/vdc
P: /devices/pci0000:00/0000:00:0c.0/virtio6/block/vdc
N: vdc
L: 0
S: disk/by-path/pci-0000:00:0c.0
S: disk/by-path/virtio-pci-0000:00:0c.0
E: DEVPATH=/devices/pci0000:00/0000:00:0c.0/virtio6/block/vdc
E: DEVNAME=/dev/vdc
E: DEVTYPE=disk
E: MAJOR=252
E: MINOR=32
E: SUBSYSTEM=block
E: USEC_INITIALIZED=9888220
E: ID_PATH=pci-0000:00:0c.0
E: ID_PATH_TAG=pci-0000_00_0c_0
E: ID_FS_UUID=8a9a5a4a-bfa8-b1c7-2366-bcbde5ef324e
E: ID_FS_UUID_ENC=8a9a5a4a-bfa8-b1c7-2366-bcbde5ef324e
E: ID_FS_UUID_SUB=cae91f65-006e-ef11-b512-95331d445ea6
E: ID_FS_UUID_SUB_ENC=cae91f65-006e-ef11-b512-95331d445ea6
E: ID_FS_LABEL=localhost.localdomain:127
E: ID_FS_LABEL_ENC=localhost.localdomain:127
E: ID_FS_VERSION=1.2
E: ID_FS_TYPE=linux_raid_member
E: ID_FS_USAGE=raid
E: MD_DEVICE=md127
E: MD_DEVNAME=127
E: MD_FOREIGN=no
E: MD_STARTED=unsafe
E: SYSTEMD_WANTS=mdadm-last-resort@md127.timer
E: UDISKS_MD_MEMBER_LEVEL=raid1
E: UDISKS_MD_MEMBER_DEVICES=2
E: UDISKS_MD_MEMBER_NAME=localhost.localdomain:127
E: UDISKS_MD_MEMBER_ARRAY_SIZE=1071.64MB
E: UDISKS_MD_MEMBER_UUID=8a9a5a4a:bfa8b1c7:2366bcbd:e5ef324e
E: UDISKS_MD_MEMBER_UPDATE_TIME=1564873206
E: UDISKS_MD_MEMBER_DEV_UUID=cae91f65:006eef11:b5129533:1d445ea6
E: UDISKS_MD_MEMBER_EVENTS=20
E: DEVLINKS=/dev/disk/by-path/pci-0000:00:0c.0 /dev/disk/by-path/virtio-pci-0000:00:0c.0
E: TAGS=:systemd:
```