### PR TITLE
Move dependencies code from StorageDevice to Device

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -60,7 +60,6 @@ class StorageDevice(Device):
     _partitionable = False
     _is_disk = False
     _encrypted = False
-    _external_dependencies = []
 
     def __init__(self, name, fmt=None, uuid=None,
                  size=None, major=None, minor=None,
@@ -840,48 +839,3 @@ class StorageDevice(Device):
 
         badchars = any(c in ('\x00', '/') for c in name)
         return not(badchars or name == '.' or name == '..')
-
-    #
-    # dependencies
-    #
-    @classmethod
-    def type_external_dependencies(cls):
-        """ A list of external dependencies of this device type.
-
-            :returns: a set of external dependencies
-            :rtype: set of availability.ExternalResource
-
-            The external dependencies include the dependencies of this
-            device type and of all superclass device types.
-        """
-        return set(
-            d for p in cls.__mro__ if issubclass(p, StorageDevice) for d in p._external_dependencies
-        )
-
-    @classmethod
-    def unavailable_type_dependencies(cls):
-        """ A set of unavailable dependencies for this type.
-
-            :return: the unavailable external dependencies for this type
-            :rtype: set of availability.ExternalResource
-        """
-        return set(e for e in cls.type_external_dependencies() if not e.available)
-
-    @property
-    def external_dependencies(self):
-        """ A list of external dependencies of this device and its parents.
-
-            :returns: the external dependencies of this device and all parents.
-            :rtype: set of availability.ExternalResource
-        """
-        return set(d for p in self.ancestors for d in p.type_external_dependencies())
-
-    @property
-    def unavailable_dependencies(self):
-        """ Any unavailable external dependencies of this device or its
-            parents.
-
-            :returns: A list of unavailable external dependencies.
-            :rtype: set of availability.external_resource
-        """
-        return set(e for e in self.external_dependencies if not e.available)


### PR DESCRIPTION
This fixes a new pylint warning about Device not having the
'type_external_dependencies' method. The 'external_dependencies'
checks dependencies of all ancestors and theoretically it is
possible that a StorageDevice has Device in its ancestors.

----

We could simply ignore this pylint warning, but I think this time pylint is right, technically we can have a `StorageDevice` with `Device` within its ancestors. And all the `ancestors` and `parents` methods/properties are defined in the `Device` class so it makes sense to have the dependencies functions there too.