### PR TITLE
Do not crash if activation of a DM RAID array fails

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -1792,7 +1792,12 @@ class DeviceTree(object):
                 dm_array.parents.append(device)
             else:
                 # Activate the Raid set.
-                rs.activate(mknod=True)
+                try:
+                    rs.activate(mknod=True)
+                except Exception as e: # pylint: disable=broad-except
+                    log.warning("Failed to activate the RAID set '%s': %s", rs.name, str(e))
+                    return
+
                 dm_array = DMRaidArrayDevice(rs.name,
                                              raidSet=rs,
                                              parents=[device])


### PR DESCRIPTION
We don't want to crash during reset on systems with incomplete or
unsupported firmware RAIDs.

Resolves: rhbz#1616267

---

This is basically just a cherry-pick from master, see https://github.com/storaged-project/blivet/commit/bad259ce41a711d621fc03c1e2cb40110cde5e8e