### PR TITLE
Always set default key size to 512 bits for ciphers with XTS mode

### DIFF
--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -89,10 +89,11 @@ class LUKS(DeviceFormat):
         self.key_size = kwargs.get("key_size")
         self.mapName = kwargs.get("name")
 
-        if not self.exists and not self.cipher:
-            self.cipher = "aes-xts-plain64"
-            if not self.key_size:
-                # default to the max (512 bits) for aes-xts
+        if not self.exists:
+            if not self.cipher:
+                self.cipher = "aes-xts-plain64"
+            if not self.key_size and "xts" in self.cipher:
+                # default to the max (512 bits) for xts
                 self.key_size = 512
 
         # FIXME: these should both be lists, but managing them will be a pain


### PR DESCRIPTION
Anaconda documentation says that default for XTS should be 512 bits,
our current implementation only works if the cipher is not specified,
if you specify "aes-xts-plain64" (default cipher and mode) without
specifying key size, we will fallback to LUKS default which is only
256 bits.

Resolves: rhbz#1716674