### PR TITLE
Always set default key size to 512 bits for ciphers with XTS mode

### DIFF
--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -119,10 +119,11 @@ class LUKS(DeviceFormat):
         if not self.exists and self.luks_version not in crypto.LUKS_VERSIONS.keys():
             raise ValueError("Unknown or unsupported LUKS version '%s'" % self.luks_version)
 
-        if not self.exists and not self.cipher:
-            self.cipher = "aes-xts-plain64"
-            if not self.key_size:
-                # default to the max (512 bits) for aes-xts
+        if not self.exists:
+            if not self.cipher:
+                self.cipher = "aes-xts-plain64"
+            if not self.key_size and "xts" in self.cipher:
+                # default to the max (512 bits) for xts
                 self.key_size = 512
 
         # FIXME: these should both be lists, but managing them will be a pain

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -81,3 +81,21 @@ class LUKSNodevTestCase(unittest.TestCase):
             # add with comma after other option(s)
             fmt = LUKS(exists=False, options="blah")
             self.assertEqual(fmt.options, "blah,discard")
+
+    def test_key_size(self):
+        # default cipher is AES-XTS with 512b key
+        fmt = LUKS()
+        self.assertEqual(fmt.cipher, "aes-xts-plain64")
+        self.assertEqual(fmt.key_size, 512)
+
+        # setting cipher shouldn't change the key size
+        fmt = LUKS(cipher="aes-xts-plain64")
+        self.assertEqual(fmt.key_size, 512)
+
+        # all XTS mode ciphers should default to 512
+        fmt = LUKS(cipher="serpent-xts-plain64")
+        self.assertEqual(fmt.key_size, 512)
+
+        # no default for non-XTS modes
+        fmt = LUKS(cipher="aes-cbc-plain64")
+        self.assertEqual(fmt.key_size, 0)


### PR DESCRIPTION
Anaconda documentation says that default for XTS should be 512 bits,
our current implementation only works if the cipher is not specified,
if you specify "aes-xts-plain64" (default cipher and mode) without
specifying key size, we will fallback to LUKS default which is only
256 bits.

Resolves: rhbz#1740210

----

#799 for `3.1-devel`