### PR TITLE
Do not try to normalize size for zero size device factories

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -462,6 +462,10 @@ class DeviceFactory(object):
     def _normalize_size(self):
         if self.size is None:
             self._handle_no_size()
+        elif self.size == Size(0):
+            # zero size means we're adjusting the container after removing
+            # a device from it so we don't want to change the size here
+            return
 
         size = self.size
         fmt = get_format(self.fstype)


### PR DESCRIPTION
Factories with zero size are special cases for adjusting container
size after removing a device for it. We don't want to change size
of the factory in this case.
The recent change of filesystem minimal size to 2 MiB resulted
in changing of size of these factories from 0 to 2 MiB which
caused the "adjusting factory" to create a new LV after removing
one from the container.

Resolves: rhbz#1743753