### PR TITLE
Fix util.detect_virt function

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -40,7 +40,7 @@ program_log_lock = Lock()
 
 
 SYSTEMD_SERVICE = "org.freedesktop.systemd1"
-SYSTEMD_MANAGER_PATH = "/org/freedesktop/systemd1/Manager"
+SYSTEMD_MANAGER_PATH = "/org/freedesktop/systemd1"
 SYSTEMD_MANAGER_IFACE = "org.freedesktop.systemd1.Manager"
 VIRT_PROP_NAME = "Virtualization"
 
@@ -1115,6 +1115,6 @@ def detect_virt():
         vm = safe_dbus.get_property_sync(SYSTEMD_SERVICE, SYSTEMD_MANAGER_PATH,
                                          SYSTEMD_MANAGER_IFACE, VIRT_PROP_NAME)
     except (safe_dbus.DBusCallError, safe_dbus.DBusPropertyError):
-        vm = None
-
-    return vm in ('qemu', 'kvm')
+        return False
+    else:
+        return vm[0] in ('qemu', 'kvm')

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -163,16 +163,18 @@ class DiskLabelTestCase(unittest.TestCase):
         arch.is_efi.return_value = False
 
         arch.is_s390.return_value = True
-        with mock.patch.object(dl, '_label_type_size_check') as size_check:
-            size_check.return_value = True
-            with mock.patch("blivet.formats.disklabel.blockdev.s390") as _s390:
-                _s390.dasd_is_fba.return_value = False
-                self.assertEqual(dl._get_best_label_type(), "msdos")
+        with mock.patch('blivet.util.detect_virt') as virt:
+            virt.return_value = False
+            with mock.patch.object(dl, '_label_type_size_check') as size_check:
+                size_check.return_value = True
+                with mock.patch("blivet.formats.disklabel.blockdev.s390") as _s390:
+                    _s390.dasd_is_fba.return_value = False
+                    self.assertEqual(dl._get_best_label_type(), "msdos")
 
-                _s390.dasd_is_fba.return_value = True
-                self.assertEqual(dl._get_best_label_type(), "msdos")
+                    _s390.dasd_is_fba.return_value = True
+                    self.assertEqual(dl._get_best_label_type(), "msdos")
 
-                _s390.dasd_is_fba.return_value = False
-                dl._parted_device.type = parted.DEVICE_DASD
-                self.assertEqual(dl._get_best_label_type(), "dasd")
+                    _s390.dasd_is_fba.return_value = False
+                    dl._parted_device.type = parted.DEVICE_DASD
+                    self.assertEqual(dl._get_best_label_type(), "dasd")
         arch.is_s390.return_value = False

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -37,6 +37,10 @@ class MiscTest(unittest.TestCase):
         # real deduplication
         self.assertEqual([1, 2, 3, 4, 5, 6], util.dedup_list([1, 2, 3, 4, 2, 2, 2, 1, 3, 5, 3, 6, 6, 2, 3, 1, 5]))
 
+    def test_detect_virt(self):
+        in_virt = not util.run_program(["systemd-detect-virt", "--vm"])
+        self.assertEqual(util.detect_virt(), in_virt)
+
 
 class TestDefaultNamedtuple(unittest.TestCase):
     def test_default_namedtuple(self):


### PR DESCRIPTION
Fixed the systemd Manager object path, also get_property_sync
returns a tuple so we need to check its first element.