### PR TITLE
Check for PV sector size when creating new VG

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -687,7 +687,7 @@ class NVDIMMNamespaceDevice(DiskDevice):
         """
         self.mode = kwargs.pop("mode")
         self.devname = kwargs.pop("devname")
-        self.sector_size = kwargs.pop("sector_size")
+        self._sector_size = kwargs.pop("sector_size")
 
         DiskDevice.__init__(self, device, **kwargs)
 
@@ -710,3 +710,7 @@ class NVDIMMNamespaceDevice(DiskDevice):
                % {'devname': self.devname,
                   'mode': self.mode,
                   'path': self.path}
+
+    @property
+    def sector_size(self):
+        return self._sector_size

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -19,9 +19,12 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+import math
 import os
 import six
 import time
+
+from six.moves import reduce
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -194,6 +197,14 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
             raise errors.DeviceError(e)
 
         self._level = level
+
+    @property
+    def sector_size(self):
+        if not self.exists:
+            # Least common multiple of parents' sector sizes
+            return reduce(lambda a, b: a * b // math.gcd(a, b), (int(p.sector_size) for p in self.parents))
+
+        return super(MDRaidArrayDevice, self).sector_size
 
     @property
     def chunk_size(self):

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -729,6 +729,13 @@ class PartitionDevice(StorageDevice):
     def protected(self, value):
         self._protected = value
 
+    @property
+    def sector_size(self):
+        if self.disk:
+            return self.disk.sector_size
+
+        return super(PartitionDevice, self).sector_size
+
     def _pre_resize(self):
         if not self.exists:
             raise errors.DeviceError("device has not been created", self.name)

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -191,6 +191,21 @@ class StorageDevice(Device):
         return self
 
     @property
+    def sector_size(self):
+        """ Logical sector (block) size of this device """
+        if not self.exists:
+            if self.parents:
+                return self.parents[0].sector_size
+            else:
+                return LINUX_SECTOR_SIZE
+
+        block_size = util.get_sysfs_attr(self.sysfs_path, "queue/logical_block_size")
+        if block_size:
+            return int(block_size)
+        else:
+            return LINUX_SECTOR_SIZE
+
+    @property
     def controllable(self):
         return self._controllable and not flags.testing and not self.unavailable_type_dependencies()
 


### PR DESCRIPTION
LVM no longer allows creating VGs on top of disks with different logical sector sizes so we need to check this before running vgcreate (which fails).

There is a pull request for anaconda -- https://github.com/rhinstaller/anaconda/pull/2142 -- which adds a new StorageChecker check but we need to check this also for other users and we also need to provide API for getting sector size for disks without a disklabel.