### PR TITLE
More (abstract) property related fixes for new pylint

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2311,7 +2311,7 @@ class LVMCache(Cache):
             raise ValueError("Not enough free space in the PVs for this cache: %s short" % space_to_assign)
 
     @property
-    def size(self):  # pylint: disable=invalid-overridden-method
+    def size(self):
         # self.stats is always dynamically fetched so store and reuse the value here
         stats = self.stats
         if stats:
@@ -2331,11 +2331,11 @@ class LVMCache(Cache):
         return self.size + self.md_size
 
     @property
-    def exists(self):  # pylint: disable=invalid-overridden-method
+    def exists(self):
         return self._exists
 
     @property
-    def stats(self):  # pylint: disable=invalid-overridden-method
+    def stats(self):
         # to get the stats we need the cached LV to exist and be activated
         if self._exists and self._cached_lv.status:
             return LVMCacheStats(blockdev.lvm.cache_stats(self._cached_lv.vg.name, self._cached_lv.lvname))
@@ -2343,7 +2343,7 @@ class LVMCache(Cache):
             return None
 
     @property
-    def mode(self):  # pylint: disable=invalid-overridden-method
+    def mode(self):
         if not self._exists:
             return self._mode
         else:
@@ -2351,14 +2351,14 @@ class LVMCache(Cache):
             return blockdev.lvm.cache_get_mode_str(stats.mode)
 
     @property
-    def backing_device_name(self):  # pylint: disable=invalid-overridden-method
+    def backing_device_name(self):
         if self._exists:
             return self._cached_lv.name
         else:
             return None
 
     @property
-    def cache_device_name(self):  # pylint: disable=invalid-overridden-method
+    def cache_device_name(self):
         if self._exists:
             vg_name = self._cached_lv.vg.name
             return "%s-%s" % (vg_name, blockdev.lvm.cache_pool_name(vg_name, self._cached_lv.lvname))
@@ -2406,23 +2406,23 @@ class LVMCacheStats(CacheStats):
 
     # common properties for all caches
     @property
-    def block_size(self):  # pylint: disable=invalid-overridden-method
+    def block_size(self):
         return self._block_size
 
     @property
-    def size(self):  # pylint: disable=invalid-overridden-method
+    def size(self):
         return self._cache_size
 
     @property
-    def used(self):  # pylint: disable=invalid-overridden-method
+    def used(self):
         return self._cache_used
 
     @property
-    def hits(self):  # pylint: disable=invalid-overridden-method
+    def hits(self):
         return self._read_hits + self._write_hits
 
     @property
-    def misses(self):  # pylint: disable=invalid-overridden-method
+    def misses(self):
         return self._read_misses + self._write_misses
 
     # LVM cache specific properties
@@ -2478,11 +2478,11 @@ class LVMCacheRequest(CacheRequest):
                 self._pv_specs.append(LVPVSpec(pv_spec, Size(0)))
 
     @property
-    def size(self):  # pylint: disable=invalid-overridden-method
+    def size(self):
         return self._size
 
     @property
-    def fast_devs(self):  # pylint: disable=invalid-overridden-method
+    def fast_devs(self):
         return [spec.pv for spec in self._pv_specs]
 
     @property
@@ -2495,5 +2495,5 @@ class LVMCacheRequest(CacheRequest):
         return self._pv_specs
 
     @property
-    def mode(self):  # pylint: disable=invalid-overridden-method
+    def mode(self):
         return self._mode

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -298,7 +298,7 @@ class UdevEventManager(EventManager):
         self._pyudev_observer = None
 
     @property
-    def enabled(self):  # pylint: disable=invalid-overridden-method
+    def enabled(self):
         return self._pyudev_observer and self._pyudev_observer.monitor.started
 
     def enable(self):

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -8,6 +8,7 @@ from blivet.events.manager import Event, EventManager
 
 
 class FakeEventManager(EventManager):
+    @property
     def enabled(self):
         return False
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -17,7 +17,7 @@ class BlivetLintConfig(PocketLintConfig):
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
                                FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
                                FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
-                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|invalid-overridden-method)'"),
+                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise)'"),
                                FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$")
                                ]
 


### PR DESCRIPTION
Newest release of pylint now correctly recognizes abstract properties -- it found a new problem in `events_test` and we can also remove some disable comments introduced in #804 