### PR TITLE
Add a simple script for running tests manually

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -17,7 +17,7 @@ class BlivetLintConfig(PocketLintConfig):
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
                                FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
                                FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
-                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise)'"),
+                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify)'"),
                                FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$")
                                ]
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+from __future__ import print_function
+
+import os
+import six
+import sys
+import argparse
+import unittest
+
+
+if __name__ == '__main__':
+    testdir = os.path.abspath(os.path.dirname(__file__))
+    projdir = os.path.abspath(os.path.normpath(os.path.join(testdir, '..')))
+
+    suite = unittest.TestSuite()
+
+    if 'PYTHONPATH' not in os.environ:
+        os.environ['PYTHONPATH'] = projdir  # pylint: disable=environment-modify
+
+        try:
+            pyver = 'python3' if six.PY3 else 'python'
+            os.execv(sys.executable, [pyver] + sys.argv)
+        except OSError as e:
+            print('Failed re-exec with a new PYTHONPATH: %s' % str(e))
+            sys.exit(1)
+
+    argparser = argparse.ArgumentParser(description="Blivet test suite")
+    argparser.add_argument("testname", nargs="*",
+                           help="name of test class or method (e. g. 'devices_test' or 'formats_test.fs_test.Ext2FSTestCase'")
+    args = argparser.parse_args()
+
+    testdir = os.path.abspath(os.path.dirname(__file__))
+
+    if args.testname:
+        for n in args.testname:
+            suite.addTests(unittest.TestLoader().loadTestsFromName(n))
+    else:
+        # Load all files in this directory whose name ends with '_test.py'
+        for test_cases in unittest.defaultTestLoader.discover(testdir, pattern="*_test.py"):
+            suite.addTest(test_cases)
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+
+    if result.wasSuccessful():
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
We have a similar script in libblockdev and udisks. I plan to add more features later (e.g. running against installed version, some logging etc.) but for now the biggest feature is it allows running a simple test case using something like `sudo python3 tests/run_tests.py devices_test.device_properties_test.LVMLogicalVolumeDeviceTestCase`