### PR TITLE
Tell lvm to ignore skip-activation flag on lvs we are removing or otherwise modifying. (#1766498)

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -393,9 +393,28 @@ class ActionDestroyDevice(DeviceAction):
 
         super(ActionDestroyDevice, self)._check_device_dependencies()
 
+    def apply(self):
+        """ apply changes related to the action to the device(s) """
+        if self._applied:
+            return
+
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation += 1
+
+        super(ActionDestroyDevice, self).apply()
+
     def execute(self, callbacks=None):
         super(ActionDestroyDevice, self).execute(callbacks=callbacks)
         self.device.destroy()
+
+    def cancel(self):
+        if not self._applied:
+            return
+
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation -= 1
+
+        super(ActionDestroyDevice, self).cancel()
 
     def requires(self, action):
         """ Return True if self requires action.
@@ -712,6 +731,9 @@ class ActionDestroyFormat(DeviceAction):
             return
 
         self.device.format = None
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation += 1
+
         super(ActionDestroyFormat, self).apply()
 
     def execute(self, callbacks=None):
@@ -736,6 +758,8 @@ class ActionDestroyFormat(DeviceAction):
             return
 
         self.device.format = self.orig_format
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation -= 1
         super(ActionDestroyFormat, self).cancel()
 
     @property
@@ -831,6 +855,9 @@ class ActionResizeFormat(DeviceAction):
             return
 
         self.device.format.target_size = self._target_size
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation += 1
+
         super(ActionResizeFormat, self).apply()
 
     def execute(self, callbacks=None):
@@ -851,6 +878,9 @@ class ActionResizeFormat(DeviceAction):
             return
 
         self.device.format.target_size = self.orig_size
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation -= 1
+
         super(ActionResizeFormat, self).cancel()
 
     def requires(self, action):
@@ -1053,6 +1083,9 @@ class ActionConfigureFormat(DeviceAction):
             return
 
         setattr(self.device.format, self.attr, self.new_value)
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation += 1
+
         super(ActionConfigureFormat, self).apply()
 
     def cancel(self):
@@ -1060,6 +1093,8 @@ class ActionConfigureFormat(DeviceAction):
             return
 
         setattr(self.device.format, self.attr, self.old_value)
+        if hasattr(self.device, 'ignore_skip_activation'):
+            self.device.ignore_skip_activation -= 1
 
     def execute(self, callbacks=None):
         super(ActionConfigureFormat, self).execute(callbacks=callbacks)

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -742,6 +742,9 @@ class ActionDestroyFormat(DeviceAction):
         super(ActionDestroyFormat, self).execute(callbacks=callbacks)
         status = self.device.status
         self.device.setup(orig=True)
+        if hasattr(self.device, 'set_rw'):
+            self.device.set_rw()
+
         self.format.destroy()
         udev.settle()
         if isinstance(self.device, PartitionDevice) and self.device.disklabel_supported:

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1012,6 +1012,10 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         # set up the vg's pvs so lvm can remove the lv
         self.vg.setup_parents(orig=True)
 
+    def set_rw(self):
+        """ Run lvchange as needed to ensure the lv is not read-only. """
+        lvm.ensure_lv_is_writable(self.vg.name, self.lvname)
+
     @property
     def lvname(self):
         """ The LV's name (not including VG name). """

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1025,12 +1025,28 @@ class DeviceActionTestCase(StorageTestCase):
         # ActionDestroyFormat
         original_format = lv_root.format
         action = ActionDestroyFormat(lv_root)
+        orig_ignore_skip = lv_root.ignore_skip_activation
         self.assertEqual(lv_root.format, original_format)
         self.assertNotEqual(lv_root.format.type, None)
         action.apply()
         self.assertEqual(lv_root.format.type, None)
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip + 1)
         action.cancel()
         self.assertEqual(lv_root.format, original_format)
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip)
+
+        # ActionDestroyDevice
+        action1 = ActionDestroyFormat(lv_root)
+        orig_ignore_skip = lv_root.ignore_skip_activation
+        action1.apply()
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip + 1)
+        action2 = ActionDestroyDevice(lv_root)
+        action2.apply()
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip + 2)
+        action2.cancel()
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip + 1)
+        action1.cancel()
+        self.assertEqual(lv_root.ignore_skip_activation, orig_ignore_skip)
 
         sdc = self.storage.devicetree.get_device_by_name("sdc")
         sdc.format = None

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -363,6 +363,35 @@ class LVMDeviceTest(unittest.TestCase):
             with six.assertRaisesRegex(self, ValueError, "The volume group testvg cannot be created."):
                 LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
 
+    def test_skip_activate(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1 GiB"), exists=True)
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv], exists=True)
+        lv = LVMLogicalVolumeDevice("data_lv", parents=[vg], size=Size("500 MiB"), exists=True)
+
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            with patch.object(lv, "_pre_setup"):
+                lv.setup()
+                self.assertTrue(lvm.lvactivate.called_with(vg.name, lv.lvname, ignore_skip=False))
+
+        lv.ignore_skip_activation += 1
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            with patch.object(lv, "_pre_setup"):
+                lv.setup()
+                self.assertTrue(lvm.lvactivate.called_with(vg.name, lv.lvname, ignore_skip=True))
+
+        lv.ignore_skip_activation += 1
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            with patch.object(lv, "_pre_setup"):
+                lv.setup()
+                self.assertTrue(lvm.lvactivate.called_with(vg.name, lv.lvname, ignore_skip=True))
+
+        lv.ignore_skip_activation -= 2
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            with patch.object(lv, "_pre_setup"):
+                lv.setup()
+                self.assertTrue(lvm.lvactivate.called_with(vg.name, lv.lvname, ignore_skip=False))
+
 
 class TypeSpecificCallsTest(unittest.TestCase):
     def test_type_specific_calls(self):


### PR DESCRIPTION
The problem is that we try to activate an lv in order to remove the formatting before destroying the lv, but the activation fails because the user set the lv to ignore activation commands.

It is possible that we should be more cautious and possibly only pass `ignore_skip=True` when we're about to wipe the formatting. That would require setting up a generic mechanism for passing additional arguments, which seems quite disruptive given the problem.

Opinions?