### PR TITLE
Add a new "id_path" attribute for iSCSI and FCoE disks

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -439,6 +439,7 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
         self.address = kwargs.pop("address")
         self.port = kwargs.pop("port")
         self.iface = kwargs.pop("iface")
+        self.id_path = kwargs.pop("id_path")
         DiskDevice.__init__(self, device, **kwargs)
         NetworkStorageDevice.__init__(self, host_address=self.address, nic=self.iface)
         log.debug("created new iscsi disk %s from target: %s lun: %s portal: %s:%s interface: %s partial offload: %s)",
@@ -503,6 +504,7 @@ class FcoeDiskDevice(DiskDevice, NetworkStorageDevice):
         """
         self.nic = kwargs.pop("nic")
         self.identifier = kwargs.pop("identifier")
+        self.id_path = kwargs.pop("id_path")
         DiskDevice.__init__(self, device, **kwargs)
         NetworkStorageDevice.__init__(self, nic=self.nic)
         log.debug("created new fcoe disk %s (%s) @ %s",
@@ -687,6 +689,7 @@ class NVDIMMNamespaceDevice(DiskDevice):
         """
         self.mode = kwargs.pop("mode")
         self.devname = kwargs.pop("devname")
+        self.id_path = kwargs.pop("id_path")
         self._sector_size = kwargs.pop("sector_size")
 
         DiskDevice.__init__(self, device, **kwargs)

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -95,6 +95,7 @@ class iScsiDevicePopulator(DiskDevicePopulator):
         kwargs["name"] = udev.device_get_name(self.data)
         kwargs["iface"] = udev.device_get_iscsi_nic(self.data)
         kwargs["offload"] = kwargs["initiator"] != iscsi.initiator
+        kwargs["id_path"] = udev.device_get_path(self.data)
         log.info("%s is an iscsi disk", kwargs["name"])
 
         # Backward compatibility attributes - to be removed
@@ -132,6 +133,7 @@ class FCoEDevicePopulator(DiskDevicePopulator):
         kwargs = super(FCoEDevicePopulator, self)._get_kwargs()
         kwargs["nic"] = udev.device_get_fcoe_nic(self.data)
         kwargs["identifier"] = udev.device_get_fcoe_identifier(self.data)
+        kwargs["id_path"] = udev.device_get_path(self.data)
         log.info("%s is an fcoe disk", udev.device_get_name(self.data))
         return kwargs
 
@@ -243,6 +245,7 @@ class NVDIMMNamespaceDevicePopulator(DiskDevicePopulator):
         kwargs["devname"] = ninfo.dev
         kwargs["uuid"] = ninfo.uuid
         kwargs["sector_size"] = ninfo.sector_size
+        kwargs["id_path"] = udev.device_get_path(self.data)
 
         log.info("%s is an NVDIMM namespace device", udev.device_get_name(self.data))
         return kwargs

--- a/tests/devices_test/tags_test.py
+++ b/tests/devices_test/tags_test.py
@@ -63,11 +63,11 @@ class DeviceTagsTest(unittest.TestCase):
         # automatically-set tags for networked storage devices
         #
         iscsi_kwarg_names = ["initiator", "name", "offload", "target", "address", "port",
-                             "lun", "iface", "node", "ibft", "nic"]
+                             "lun", "iface", "node", "ibft", "nic", "id_path"]
         iscsi_device = iScsiDiskDevice('test5', **dict((k, None) for k in iscsi_kwarg_names))
         self.assertIn(Tags.remote, iscsi_device.tags)
         self.assertNotIn(Tags.local, iscsi_device.tags)
-        fcoe_device = FcoeDiskDevice('test6', nic=None, identifier=None)
+        fcoe_device = FcoeDiskDevice('test6', nic=None, identifier=None, id_path=None)
         self.assertIn(Tags.remote, fcoe_device.tags)
         self.assertNotIn(Tags.local, fcoe_device.tags)
         zfcp_device = ZFCPDiskDevice('test7', hba_id=None, wwpn=None, fcp_lun=None)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -566,7 +566,7 @@ class NVDIMMNamespaceDevicePopulatorTestCase(PopulatorHelperTestCase):
         devicetree = DeviceTree()
 
         # set up some fake udev data to verify handling of specific entries
-        data = {'SYS_PATH': 'dummy', 'DEVNAME': 'dummy'}
+        data = {'SYS_PATH': 'dummy', 'DEVNAME': 'dummy', 'ID_PATH': 'dummy'}
 
         device_name = "nop"
         device_get_name.return_value = device_name


### PR DESCRIPTION
Anaconda needs the "ID_PATH" udev attribute so it's better to
add it to our API so they don't need to get it from "device_links".