### PR TITLE
Align base partition sizes in PartitionFactory.

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -469,7 +469,7 @@ class DiskLabel(DeviceFormat):
 
         return self._disk_label_alignment
 
-    def _get_minimal_alignment(self):
+    def get_minimal_alignment(self):
         """ Return the device's minimal alignment for new partitions.
 
             :rtype: :class:`parted.Alignment`
@@ -491,7 +491,7 @@ class DiskLabel(DeviceFormat):
 
         return self._minimal_alignment
 
-    def _get_optimal_alignment(self):
+    def get_optimal_alignment(self):
         """ Return the device's optimal alignment for new partitions.
 
             :rtype: :class:`parted.Alignment`
@@ -509,7 +509,7 @@ class DiskLabel(DeviceFormat):
                 # if there is no optimal alignment, use the minimal alignment,
                 # which has already been intersected with the disklabel
                 # alignment
-                alignment = self._get_minimal_alignment()
+                alignment = self.get_minimal_alignment()
             else:
                 try:
                     alignment = optimal_alignment.intersect(disklabel_alignment)
@@ -531,13 +531,13 @@ class DiskLabel(DeviceFormat):
                                                          small to be aligned
         """
         # default to the optimal alignment
-        alignment = self._get_optimal_alignment()
+        alignment = self.get_optimal_alignment()
         if size is None:
             return alignment
 
         # use the minimal alignment if the requested size is smaller than the
         # optimal io size
-        minimal_alignment = self._get_minimal_alignment()
+        minimal_alignment = self.get_minimal_alignment()
         optimal_grain_size = Size(alignment.grainSize * self.sector_size)
         minimal_grain_size = Size(minimal_alignment.grainSize * self.sector_size)
         if size < minimal_grain_size:

--- a/doc/api/formats.rst
+++ b/doc/api/formats.rst
@@ -42,6 +42,10 @@ formats
     * :class:`~blivet.formats.disklabel.DiskLabel` (see :ref:`inherited public API <DeviceFormatAPI>`)
         * :attr:`~blivet.formats.disklabel.DiskLabel.label_type`
         * :attr:`~blivet.formats.disklabel.DiskLabel.sector_size`
+        * :meth:`~blivet.formats.disklabel.DiskLabel.get_alignment`
+        * :meth:`~blivet.formats.disklabel.DiskLabel.get_end_alignment`
+        * :meth:`~blivet.formats.disklabel.DiskLabel.get_minimal_alignment`
+        * :meth:`~blivet.formats.disklabel.DiskLabel.get_optimal_alignment`
 
 * :mod:`~blivet.formats.dmraid`
     * :class:`~blivet.formats.dmraid.DMRaidMember` (see :ref:`inherited public API <DeviceFormatAPI>`)

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -41,8 +41,8 @@ class DiskLabelTestCase(unittest.TestCase):
 
         # make sure the private methods all return the expected values
         self.assertEqual(dl._get_disk_label_alignment(), disklabel_alignment)
-        self.assertEqual(dl._get_minimal_alignment(), minimal_alignment)
-        self.assertEqual(dl._get_optimal_alignment(), optimal_alignment)
+        self.assertEqual(dl.get_minimal_alignment(), minimal_alignment)
+        self.assertEqual(dl.get_optimal_alignment(), optimal_alignment)
 
         # validate result when passing a start alignment to get_end_alignment
         self.assertEqual(dl.get_end_alignment(alignment=optimal_alignment),
@@ -61,7 +61,7 @@ class DiskLabelTestCase(unittest.TestCase):
                          minimal_end_alignment)
 
         # test the old deprecated properties' values
-        self.assertEqual(dl.alignment, dl._get_optimal_alignment())
+        self.assertEqual(dl.alignment, dl.get_optimal_alignment())
         self.assertEqual(dl.end_alignment, dl.get_end_alignment())
 
     @patch("blivet.formats.disklabel.arch")


### PR DESCRIPTION
Take the alignment of candidate disks into account when creating the partition request to ensure that the initial/base size is never too small to be allocatable on the specified disks. A simpler approach, like choosing a larger base size than `1 MiB`, is appealing but could be problematic for certain formatting (eg: biosboot).