### PR TITLE
Allow running 'write_label' in dry run mode on non-existing devices

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -639,16 +639,16 @@ class FS(DeviceFormat):
             Raises a FSError if the label can not be set.
         """
 
-        if not self.exists:
-            raise FSError("filesystem has not been created")
-
         if not self._writelabel.available:
             raise FSError("no application to set label for filesystem %s" % self.type)
 
-        if not os.path.exists(self.device):
-            raise FSError("device does not exist")
-
         if not dry_run:
+            if not self.exists:
+                raise FSError("filesystem has not been created")
+
+            if not os.path.exists(self.device):
+                raise FSError("device does not exist")
+
             if self.label is None:
                 raise FSError("makes no sense to write a label when accepting default label")
 


### PR DESCRIPTION
We should be able to schedule action to change the label on
a non-existing device so we can't check for the device/format
existence in the dry run mode (it's run when applying the action).