### PR TITLE
Make sure _chrooted_mountpoint attribute is defined before using it

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -123,6 +123,7 @@ class FS(DeviceFormat):
         self._writeuuid = self._writeuuid_class(self)
 
         self._current_info = None  # info obtained by _info task
+        self._chrooted_mountpoint = None
 
         self.mountpoint = kwargs.get("mountpoint")
         self.mountopts = kwargs.get("mountopts")
@@ -138,8 +139,6 @@ class FS(DeviceFormat):
                             self.device)
 
         self._target_size = self._size
-
-        self._chrooted_mountpoint = None
 
         if self.supported:
             self.load_module()


### PR DESCRIPTION
Fot existing TmpFS formats the _chrooted_mountpoint attribute can
be accessed when running update_size_info() during init so we
need to define it sooner.

Resolves: rhbz#1784690