### PR TITLE
Fix Blivet DBus service version in service and config files

### DIFF
--- a/dbus/blivet.conf
+++ b/dbus/blivet.conf
@@ -7,8 +7,8 @@
 
   <!-- Only root can own the service -->
   <policy user="root">
-    <allow own="com.redhat.Blivet1"/>
-    <allow send_destination="com.redhat.Blivet1"/>
+    <allow own="com.redhat.Blivet0"/>
+    <allow send_destination="com.redhat.Blivet0"/>
   </policy>
 
 </busconfig>

--- a/dbus/blivet.service
+++ b/dbus/blivet.service
@@ -3,5 +3,5 @@ Description=Blivet Service
 
 [Service]
 Type=dbus
-BusName=com.redhat.Blivet1
+BusName=com.redhat.Blivet0
 ExecStart=/usr/libexec/blivetd

--- a/dbus/com.redhat.Blivet0.service
+++ b/dbus/com.redhat.Blivet0.service
@@ -1,5 +1,5 @@
 [D-BUS Service]
-Name=com.redhat.Blivet1
+Name=com.redhat.Blivet0
 Exec=/usr/libexec/blivetd
 User=root
 SystemdService=blivet.service

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ class blivet_sdist(sdist):
 
 data_files = [
     ('/etc/dbus-1/system.d', ['dbus/blivet.conf']),
-    ('/usr/share/dbus-1/system-services', ['dbus/com.redhat.Blivet1.service']),
+    ('/usr/share/dbus-1/system-services', ['dbus/com.redhat.Blivet0.service']),
     ('/usr/libexec', ['dbus/blivetd']),
     ('/usr/lib/systemd/system', ['dbus/blivet.service'])
 ]


### PR DESCRIPTION
We have changed the version in 98efb38 but never adjusted the
'allow own' policy in the config file so the service actually
can't start now.

Resolves: rhbz#1786919