### PR TITLE
Use SHA256 instead of MD5 for /proc/mounts hash calculation

### DIFF
--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -165,13 +165,13 @@ class MountsCache(object):
                     self.mountpoints[(devspec, None)].append(mountpoint)
 
     def _cache_check(self):
-        """ Computes the MD5 hash on /proc/mounts and updates the cache on change
+        """ Computes the SHA256 hash on /proc/mounts and updates the cache on change
         """
 
-        md5hash = util.md5_file("/proc/mounts")
+        sha256hash = util.sha256_file("/proc/mounts")
 
-        if md5hash != self.mounts_hash:
-            self.mounts_hash = md5hash
+        if sha256hash != self.mounts_hash:
+            self.mounts_hash = sha256hash
             self._get_active_mounts()
 
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -569,17 +569,17 @@ def insert_colons(a_string):
         return suffix
 
 
-def md5_file(filename):
+def sha256_file(filename):
 
-    md5 = hashlib.md5()
+    sha256 = hashlib.sha256()
     with open(filename, "rb") as f:
 
         block = f.read(65536)
         while block:
-            md5.update(block)
+            sha256.update(block)
             block = f.read(65536)
 
-    return md5.hexdigest()
+    return sha256.hexdigest()
 
 
 class ObjectID(object):


### PR DESCRIPTION
MD5 is not available in the FIPS mode.

Resolves: rhbz#1792340