### PR TITLE
Fix name resolution for md member partitions. (#1798792)

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -202,7 +202,7 @@ def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info:
+    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
         mdname = udev_info["MD_DEVNAME"]
         if device_is_partition(udev_info):
             # for partitions on named RAID we want to use the raid name, not


### PR DESCRIPTION
Taken from #785

This is a good workaround for rhbz#1798792 which is currently a Fedora 32 blocker. Root of the problem is an mdadm udev rule which adds the `MD_DEVNAME` property (and other `MD_` properties) to the RAID member partitions which makes us think the partition is actually on the mdraid.