### PR TITLE
Fix crash for devices without ID_PATH udev property (#1814920)

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -406,7 +406,7 @@ def device_get_bus(udev_info):
 
 
 def device_get_path(info):
-    return info["ID_PATH"]
+    return info.get("ID_PATH", "")
 
 
 def device_get_symlinks(info):


### PR DESCRIPTION
In some cases some NVDIMM namespaces don't have the ID_PATH set
and this makes the populate helper crash.