### PR TITLE
Do not set empty name instead of invalid one in devicefactory (#1813710)

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -846,6 +846,10 @@ class DeviceFactory(object):
 
         safe_new_name = self.storage.safe_device_name(self.device_name)
         if self.device.name != safe_new_name:
+            if not safe_new_name:
+                log.error("not renaming '%s' to invalid name '%s'",
+                          self.device.name, self.device_name)
+                return
             if safe_new_name in self.storage.names:
                 log.error("not renaming '%s' to in-use name '%s'",
                           self.device.name, safe_new_name)


### PR DESCRIPTION
For names that are made entirely of prohibited characters we
remove all of these and set name to empty string which is also
invalid a causes problems in Anaconda.