### PR TITLE
Correctly recognize EFI format on an MD RAID device (#1695913)

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -486,6 +486,12 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         """
         return (self.member_devices <= len(self.members)) or not self.exists
 
+    @property
+    def bootable(self):
+        return (self.level == raid.RAID1 and
+                self.metadata_version in ("0.90", "1.0") and
+                all(getattr(p, "bootable", False) for p in self.parents))
+
     def _post_setup(self):
         super(MDRaidArrayDevice, self)._post_setup()
         self.update_sysfs_path()

--- a/blivet/populator/helpers/boot.py
+++ b/blivet/populator/helpers/boot.py
@@ -22,7 +22,7 @@
 
 from ... import formats
 from ... import udev
-from ...devices import PartitionDevice
+from ...devices import PartitionDevice, MDRaidArrayDevice
 
 from .formatpopulator import FormatPopulator
 
@@ -39,7 +39,7 @@ class BootFormatPopulator(FormatPopulator):
 
         fmt = formats.get_format(cls._type_specifier)
         return (udev.device_get_format(data) == cls._base_type_specifier and
-                isinstance(device, PartitionDevice) and
+                isinstance(device, (PartitionDevice, MDRaidArrayDevice)) and
                 (device.bootable or not cls._bootable) and
                 fmt.min_size <= device.size <= fmt.max_size)
 


### PR DESCRIPTION
It's possible to have /boot/efi on an MD RAID device -- with the
older version of metadata and RAID1 it looks like a normal
partition and EFI can boot from it.