### PR TITLE
Fix renaming encrypted devices in the DeviceFactory

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -857,7 +857,7 @@ class DeviceFactory(object):
 
             log.debug("renaming device '%s' to '%s'",
                       self.device.name, safe_new_name)
-            self.device.name = safe_new_name
+            self.raw_device.name = safe_new_name
 
     def _post_create(self):
         """ Hook for post-creation operations. """
@@ -1473,7 +1473,7 @@ class LVMFactory(DeviceFactory):
             safe_new_name = safe_new_name[len(self.vg.name) + 1:]
             log.debug("renaming device '%s' to '%s'",
                       self.device.name, safe_new_name)
-            self.device.name = safe_new_name
+            self.raw_device.name = safe_new_name
 
     def _configure(self):
         self._set_container()  # just sets self.container based on the specs


### PR DESCRIPTION
We need to rename the underlying device (LV in this case), not
the LUKSDevice which doesn't have name. This is a problem only
when encrypting LVs directly, this doesn't happen with the default
configuration where PVs are encrypted (because PVs are usually
partitions that can't be encrypted).

Resolves: rhbz#1759972