### PR TITLE
Do not remove _netdev mount option specified manually by users

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -752,10 +752,11 @@ class StorageDevice(Device):
 
         netdev_option = "_netdev"
         option_list = self._format.options.split(",")
+        user_options = self._format._user_mountopts.split(",")
         is_netdev = any(isinstance(a, NetworkStorageDevice)
                         for a in self.ancestors)
         has_netdev_option = netdev_option in option_list
-        if not is_netdev and has_netdev_option:
+        if not is_netdev and has_netdev_option and netdev_option not in user_options:
             option_list.remove(netdev_option)
             self._format.options = ",".join(option_list)
         elif is_netdev and not has_netdev_option:

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -135,9 +135,11 @@ class FS(DeviceFormat):
         self._chrooted_mountpoint = None
 
         self.mountpoint = kwargs.get("mountpoint")
-        self.mountopts = kwargs.get("mountopts")
+        self.mountopts = kwargs.get("mountopts", "")
         self.label = kwargs.get("label")
         self.fsprofile = kwargs.get("fsprofile")
+
+        self._user_mountopts = self.mountopts
 
         if flags.auto_dev_updates and self._resize.available:
             # if you want current/min size you have to call update_size_info

--- a/tests/devices_test/network_test.py
+++ b/tests/devices_test/network_test.py
@@ -37,3 +37,27 @@ class NetDevMountOptionTestCase(unittest.TestCase):
         dev.create()
 
         self.assertTrue("_netdev" in dev.format.options.split(","))
+
+    def test_net_dev_update_remove(self):
+        """ Verify netdev mount option is removed after removing the netdev parent. """
+        netdev = FakeNetDev("net1")
+        dev = StorageDevice("dev1", parents=[netdev], fmt=get_format("ext4"))
+        self.assertTrue("_netdev" in dev.format.options.split(","))
+
+        dev.parents.remove(netdev)
+
+        # these create methods shouldn't write anything to disk
+        netdev.create()
+        dev.create()
+
+        self.assertFalse("_netdev" in dev.format.options.split(","))
+
+    def test_net_device_manual(self):
+        """ Verify netdev mount option is not removed if explicitly set by the user. """
+        dev = StorageDevice("dev1", fmt=get_format("ext4", mountopts="_netdev"))
+        self.assertTrue("_netdev" in dev.format.options.split(","))
+
+        # these create methods shouldn't write anything to disk
+        dev.create()
+
+        self.assertTrue("_netdev" in dev.format.options.split(","))


### PR DESCRIPTION
This option is used also for non-network devices like Clevis-Tang
protected LUKS devices so we can't remove it.

Resolves: rhbz#1722262