### PR TITLE
Log current storage state before reset using lsblk

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -42,6 +42,7 @@ from .devicetree import DeviceTree
 from .formats import get_default_filesystem_type
 from .flags import flags
 from .formats import get_format
+from .util import capture_output
 from . import arch
 from . import devicefactory
 from . import __version__
@@ -74,6 +75,14 @@ class Blivet(object):
 
         self._next_id = 0
         self._dump_file = "%s/storage.state" % tempfile.gettempdir()
+
+        try:
+            options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,FSAVAIL,FSUSE%,MOUNTPOINT"
+            out = capture_output(["lsblk", "--bytes", "-a", "-o", options])
+        except Exception:  # pylint: disable=broad-except
+            pass
+        else:
+            log.debug("lsblk output:\n%s", out)
 
         # these will both be empty until our reset method gets called
         self.devicetree = DeviceTree(ignored_disks=self.ignored_disks,


### PR DESCRIPTION
We have all the information in the storage.log from reset but it's sometimes hard to decrypt the real storage layout from our populate/reset messages. Anaconda saves lsblk output but only for crashes so we don't always have it and if the crash happens during do_it, storage configuration is already changed. I'm logging lsblk in blivet-gui and it's really useful to have it for a quick debugging.