### PR TITLE
Add "is_empty" property to StorageDevice

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -237,6 +237,10 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         return True
 
+    @property
+    def is_empty(self):
+        return len(self.lvs) == 0
+
     def _pre_setup(self, orig=False):
         if self.exists and not self.complete:
             raise errors.DeviceError("cannot activate VG with missing PV(s)", self.name)

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -810,6 +810,13 @@ class StorageDevice(Device):
         return self._is_disk
 
     @property
+    def is_empty(self):
+        if not self.partitioned:
+            return self.format.type is None and len(self.children) == 0
+
+        return all(p.type == "partition" and p.is_magic for p in self.children)
+
+    @property
     def partitionable(self):
         return self._partitionable
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -394,6 +394,17 @@ class LVMDeviceTest(unittest.TestCase):
                 lv.setup()
                 self.assertTrue(lvm.lvactivate.called_with(vg.name, lv.lvname, ignore_skip=False))
 
+    def test_vg_is_empty(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1024 MiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv])
+        self.assertTrue(vg.is_empty)
+
+        LVMLogicalVolumeDevice("testlv", parents=[vg], size=Size("512 MiB"),
+                               fmt=blivet.formats.get_format("xfs"),
+                               exists=False)
+        self.assertFalse(vg.is_empty)
+
 
 class TypeSpecificCallsTest(unittest.TestCase):
     def test_type_specific_calls(self):

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -361,3 +361,15 @@ class PartitionDeviceTestCase(unittest.TestCase):
                     f.return_value = func in spec.true_funcs
 
                 self.assertEqual(part.weight, spec.weight)
+
+    @patch("blivet.devices.partition.PartitionDevice.update_size", lambda part: None)
+    @patch("blivet.devices.partition.PartitionDevice.probe", lambda part: None)
+    def test_disk_is_empty(self):
+        disk = StorageDevice("testdisk", exists=True)
+        disk._partitionable = True
+        with patch.object(disk, "_format") as fmt:
+            fmt.type = "disklabel"
+            self.assertTrue(disk.is_empty)
+
+            PartitionDevice("testpart1", exists=True, parents=[disk])
+            self.assertFalse(disk.is_empty)


### PR DESCRIPTION
A simple check if the device is empty -- there is no filesystem
and partitioned devices don't have partitions (or only "magic"
partitions).

This is basically just a copy of the `_is_device_empty` function from Anaconda used for clearpart -- https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/modules/storage/disk_initialization/configuration.py#L119 -- I don't think installer should deal with such "low level" stuff as magic partitions so this makes more sense in Blivet.