### PR TITLE
Fix toggling container encryption in devicefactory (#1827254)

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1151,6 +1151,8 @@ class PartitionSetFactory(PartitionFactory):
         for member in members[:]:
             member_encrypted = isinstance(member, LUKSDevice)
             if member_encrypted and not self.encrypted:
+                if container:
+                    container.parents.remove(member)
                 self.storage.destroy_device(member)
                 members.remove(member)
                 self.storage.format_device(member.slave,
@@ -1158,7 +1160,6 @@ class PartitionSetFactory(PartitionFactory):
                 members.append(member.slave)
                 if container:
                     container.parents.append(member.slave)
-                    container.parents.remove(member)
 
                 continue
 

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -443,6 +443,22 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         device = self._factory_device(device_type, **kwargs)
         self._validate_factory_device(device, device_type, **kwargs)
 
+        # enable, disable and enable container encryption
+        kwargs["container_encrypted"] = True
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        kwargs["container_encrypted"] = False
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        kwargs["container_encrypted"] = True
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
     def _get_size_delta(self, devices=None):
         if not devices:
             delta = Size("2 MiB") * len(self.b.disks)
@@ -567,6 +583,22 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
         kwargs["fstype"] = "xfs"
         kwargs["device"] = device
         # kwargs["encrypted"] = False
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # enable, disable and enable container encryption
+        kwargs["container_encrypted"] = True
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        kwargs["container_encrypted"] = False
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        kwargs["container_encrypted"] = True
+        kwargs["device"] = device
         device = self._factory_device(device_type, **kwargs)
         self._validate_factory_device(device, device_type, **kwargs)
 


### PR DESCRIPTION
We need to remove the member (LUKSDevice) from the container's
parents before trying to remove the member itself. Removing it
from the container parents will also remove the container from
the member children allowing us to remove the member because
devices with children (non-leaf devices) can't be removed.