### PR TITLE
Do no include destroyed devices in list of names (#1830515)

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -155,7 +155,11 @@ class DeviceTreeBase(object):
                dev.name not in names:
                 names.append(dev.name)
 
-        names.extend(n for n in lv_info if n not in names)
+        # include LVs that are not in the devicetree and not scheduled for removal
+        removed_names = [ac.device.name for ac in self.actions.find(action_type="destroy",
+                                                                    object_type="device")]
+        names.extend(n for n in lv_info if n not in names and n not in removed_names)
+
         return names
 
     def _add_device(self, newdev, new=True):


### PR DESCRIPTION
Without this it's not possible to create a device with same name
after destroying and existing one.

-------

The issue is result of switching to names being a property in #688 The code which checked names of all existing LVs was originally in the LVM populator helper. I'm not sure why exactly we were adding names of all LVs to the list but I assume it was to include names of unsupported and internal LVs.
I think with this change the `names` property should behave the way it did before the change -- it will always contain all LVs except the ones we scheduled for removal (these were originally removed from the list in `devicetree._remove_device`) so this change should be safe.