### PR TITLE
Make extended partitions resizable

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -934,8 +934,12 @@ class PartitionDevice(StorageDevice):
 
     @property
     def resizable(self):
-        return super(PartitionDevice, self).resizable and \
-            self.disk.type != 'dasd' and self.disklabel_supported
+        if self.disk.type == 'dasd' or not self.disklabel_supported:
+            return False
+        elif self.is_extended and self.exists:
+            return True
+        else:
+            return super(PartitionDevice, self).resizable
 
     def check_size(self):
         """ Check to make sure the size of the device is allowed by the

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -196,6 +196,9 @@ class PartitionDeviceTestCase(unittest.TestCase):
             extended_device.exists = True
             extended_device.parted_partition = extended
 
+            # existing extended partition should be always resizable
+            self.assertTrue(extended_device.resizable)
+
             # no logical partitions --> min size should be max of 1 KiB and grain_size
             self.assertEqual(extended_device.min_size,
                              extended_device.align_target_size(max(grain_size, Size("1 KiB"))))


### PR DESCRIPTION
Existing extended partitions should be always resizable. We can't
default to StorageDevice.resizable because it also checks format
for being resizable.

------
I found this when fixing resize option in blivet-gui in https://github.com/storaged-project/blivet-gui/pull/182.