### PR TITLE
Do not limit swap to 128 GiB

### DIFF
--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -52,8 +52,7 @@ class SwapSpace(DeviceFormat):
     _linux_native = True                # for clearpart
     _plugin = availability.BLOCKDEV_SWAP_PLUGIN
 
-    # see rhbz#744129 for details
-    _max_size = Size("128 GiB")
+    _max_size = Size("16 TiB")
 
     config_actions_map = {"label": "write_label"}
 

--- a/tests/formats_test/swap_test.py
+++ b/tests/formats_test/swap_test.py
@@ -1,0 +1,24 @@
+import test_compat  # pylint: disable=unused-import
+
+import six
+import unittest
+
+from blivet.devices.storage import StorageDevice
+from blivet.errors import DeviceError
+from blivet.formats import get_format
+
+from blivet.size import Size
+
+
+class SwapNodevTestCase(unittest.TestCase):
+
+    def test_swap_max_size(self):
+        StorageDevice("dev", size=Size("129 GiB"),
+                      fmt=get_format("swap"))
+
+        StorageDevice("dev", size=Size("15 TiB"),
+                      fmt=get_format("swap"))
+
+        with six.assertRaisesRegex(self, DeviceError, "device is too large for new format"):
+            StorageDevice("dev", size=Size("17 TiB"),
+                          fmt=get_format("swap"))


### PR DESCRIPTION
The limit was part of change to limit suggested swap size in
kickstart which doesn't use the SwapSpace._max_size so there is no
reason to limit this for manual installations.

Resolves: rhbz#1656485

----

I'm not sure why the limit was enforced here in the first place. The `iutil.swapSuggestion` never used it (its original version used the same `SWAP_SIZE_LIMIT` constant but never `SwapSpace._max_size` directly) and the referenced bug is only about the `swap --recommended` kickstart command.

Few very old anaconda commits related to this:
- https://github.com/rhinstaller/anaconda/commit/d665afe10a38e5eae2e0605513fdce554d3b2cf4
- https://github.com/rhinstaller/anaconda/commit/62c250e71e6040f71d9ad09d50908342f2d1b394
- https://github.com/rhinstaller/anaconda/commit/98a347672c4a7c6972fa7e4af3d22d041588ca3d
- https://github.com/rhinstaller/anaconda/commit/37415063594d00c896ff3c50496582f0c4e9e3d9

Also I wasn't able to find a "real" max size for swaps so I decided to use 16 EiB (2^64) which we use for other formats without max size.