### PR TITLE
Do not limit swap to 128 GiB

### DIFF
--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -42,8 +42,7 @@ class SwapSpace(DeviceFormat):
     _supported = True                  # is supported
     _linuxNative = True                # for clearpart
 
-    #see rhbz#744129 for details
-    _maxSize = Size("128 GiB")
+    _maxSize = Size("16 TiB")
 
     def __init__(self, **kwargs):
         """


### PR DESCRIPTION
The limit was part of change to limit suggested swap size in
kickstart which doesn't use the SwapSpace._max_size so there is no
reason to limit this for manual installations.

Resolves: rhbz#1444232

rhel7-branch version of #850 