### PR TITLE
Ignore pycodestyle warning E741

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ pep8:
 	else \
 		echo "You need to install pycodestyle/pep8 to run this check."; exit 1; \
 	fi ; \
-	$$pep8 --ignore=E501,E402,E731,W504 blivet/ tests/ examples/
+	$$pep8 --ignore=E501,E402,E731,W504,E741 blivet/ tests/ examples/
 
 canary: po-fallback
 	@echo "*** Running translation-canary tests ***"


### PR DESCRIPTION
pycodestyle doesn't like variables named "l" and its latest
version got better in discovering them in our code.