### PR TITLE
Add basic support for LVM writecache devices

### DIFF
--- a/blivet/devices/cache.py
+++ b/blivet/devices/cache.py
@@ -54,12 +54,6 @@ class Cache(object):
         """
 
     @abc.abstractproperty
-    def mode(self):
-        """Mode of the cache (writeback/writethrough...)
-        :rtype: str
-        """
-
-    @abc.abstractproperty
     def backing_device_name(self):
         """Name of the backing (big/slow) device of the cache (if any)"""
 


### PR DESCRIPTION
Only "read" support for now, we need libblockdev support to able
to create a writecache device. With this we at least won't crash
on systems with existing writecache.