### PR TITLE
Fix resizable property for partitions

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -934,9 +934,11 @@ class PartitionDevice(StorageDevice):
 
     @property
     def resizable(self):
-        if self.disk.type == 'dasd' or not self.disklabel_supported:
+        if not self.exists:
             return False
-        elif self.is_extended and self.exists:
+        elif self.disk.type == 'dasd' or not self.disklabel_supported:
+            return False
+        elif self.is_extended:
             return True
         else:
             return super(PartitionDevice, self).resizable


### PR DESCRIPTION
This fixes isses in anaconda unit tests where some non-existing
partitions can have disk set to None. We don't allow resizing of
non-existing devices so it is safe to return False here.