### PR TITLE
Set device.original_format to the new format in ActionCreateFormat

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
+import copy
+
 from six import add_metaclass
 
 from . import util
@@ -669,6 +671,8 @@ class ActionCreateFormat(DeviceAction):
         if callbacks and callbacks.create_format_post:
             msg = _("Created %(type)s on %(device)s") % {"type": self.device.format.type, "device": self.device.path}
             callbacks.create_format_post(CreateFormatPostData(msg))
+
+        self.device.original_format = copy.deepcopy(self.device.format)
 
     def cancel(self):
         if not self._applied:


### PR DESCRIPTION
Original format should be always set to the "real" format for
existing devices. This normally happens in the StorageDevice
constructor but newly created devices have original_format always
set to DeviceFormat and require running reset to correct this which
can cause various issues when doing multiple do_it operations
without running reset between them.

Resolves: rhbz#1820888

----

This bug was really "fun" to debug. Removing an existing LUKS device that was created without running `reset` after `do_it` crashes because the LUKS is not closed. It is open because there is no LUKS format to run `teardown` on. Both `format` and `original_format` are set to the default `DeviceFormat` -- `format` is removed when scheduling the destroy action and `original_format` is not set.
This was originally reported against blivet-gui. I guess I could run `reset` after every `do_it` but I think it shouldn't be necessary.