### PR TITLE
Do not use FSAVAIL and FSUSE% options when running lsblk

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -77,7 +77,7 @@ class Blivet(object):
         self._dump_file = "%s/storage.state" % tempfile.gettempdir()
 
         try:
-            options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,FSAVAIL,FSUSE%,MOUNTPOINT"
+            options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,MOUNTPOINT"
             out = capture_output(["lsblk", "--bytes", "-a", "-o", options])
         except Exception:  # pylint: disable=broad-except
             pass


### PR DESCRIPTION
These options were added in util-linux 2.33 which is not available
on older systems so we should not use these.

Fixes: #864