### PR TITLE
set allowed disk labels for s390x as standard ones (msdos + gpt) plus…

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -230,7 +230,7 @@ class DiskLabel(DeviceFormat):
         elif arch.is_efi() and not arch.is_aarch64():
             label_types = ["gpt", "msdos"]
         elif arch.is_s390():
-            label_types = ["msdos", "dasd"]
+            label_types += ["dasd"]
 
         return label_types
 

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -95,7 +95,7 @@ class DiskLabelTestCase(unittest.TestCase):
         arch.is_arm.return_value = False
 
         arch.is_s390.return_value = True
-        self.assertEqual(disklabel_class.get_platform_label_types(), ["msdos", "dasd"])
+        self.assertEqual(disklabel_class.get_platform_label_types(), ["msdos", "gpt", "dasd"])
         arch.is_s390.return_value = False
 
     def test_label_type_size_check(self):


### PR DESCRIPTION
… dasd

This will solve issues when a SCSI or NVMe disk with GPT partition table
is used with a s390x machine (rhbz#1827066, rhbz#1854110).