### PR TITLE
Do not propagate ped exception from add_partition

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -28,6 +28,7 @@ import gi
 gi.require_version("BlockDev", "2.0")
 
 import parted
+import _ped
 
 from .errors import DeviceError, PartitioningError, AlignmentError
 from .flags import flags
@@ -466,8 +467,13 @@ def add_partition(disklabel, free, part_type, size, start=None, end=None):
                                  type=part_type,
                                  geometry=new_geom)
     constraint = parted.Constraint(exactGeom=new_geom)
-    disklabel.parted_disk.addPartition(partition=partition,
-                                       constraint=constraint)
+
+    try:
+        disklabel.parted_disk.addPartition(partition=partition,
+                                           constraint=constraint)
+    except _ped.PartitionException as e:
+        raise PartitioningError(_("failed to add partition to disk: %s") % str(e))
+
     return partition
 
 

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -27,6 +27,8 @@ from blivet.devices import DiskFile
 from blivet.devices import PartitionDevice
 from blivet.devices.lvm import LVMCacheRequest
 
+from blivet.errors import PartitioningError
+
 from tests.imagebackedtestcase import ImageBackedTestCase
 from blivet.blivet import Blivet
 from blivet.util import sparsetmpfile
@@ -254,7 +256,7 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a logical partition to a primary free region
             #
-            with six.assertRaisesRegex(self, parted.PartitionException,
+            with six.assertRaisesRegex(self, PartitioningError,
                                        "no extended partition"):
                 part = add_partition(disk.format, free, parted.PARTITION_LOGICAL,
                                      Size("10 MiB"))
@@ -286,7 +288,7 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a primary partition to an extended free region
             #
-            with six.assertRaisesRegex(self, parted.PartitionException, "overlap"):
+            with six.assertRaisesRegex(self, PartitioningError, "overlap"):
                 part = add_partition(disk.format, all_free[1],
                                      parted.PARTITION_NORMAL,
                                      Size("10 MiB"), all_free[1].start)


### PR DESCRIPTION
Our users shouldn't need to catch parted exception, we should use
our PartitioningError where possible.

Related: rhbz#1855386