### PR TITLE
Fix running tests as non-root

### DIFF
--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -350,7 +350,12 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
                 self.assertEqual(pv.slave.format.luks_version,
                                  kwargs.get("luks_version", crypto.DEFAULT_LUKS_VERSION))
 
-    def test_device_factory(self):
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_device_factory(self, *args):  # pylint: disable=unused-argument,arguments-differ
         super(LVMFactoryTestCase, self).test_device_factory()
 
         ##
@@ -465,6 +470,14 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         device = self._factory_device(device_type, **kwargs)
         self._validate_factory_device(device, device_type, **kwargs)
 
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_factory_defaults(self, *args):  # pylint: disable=unused-argument
+        super(LVMFactoryTestCase, self).test_factory_defaults()
+
     def _get_size_delta(self, devices=None):
         if not devices:
             delta = Size("2 MiB") * len(self.b.disks)
@@ -473,7 +486,12 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
 
         return delta
 
-    def test_get_container(self):
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_get_container(self, *args):  # pylint: disable=unused-argument
         for disk in self.b.disks:
             self.b.format_device(disk, get_format("lvmpv"))
 
@@ -494,6 +512,22 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         vg._complete = True
         self.assertEqual(factory.get_container(), None)
         self.assertEqual(factory.get_container(allow_existing=True), vg)
+
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_get_free_disk_space(self, *args):
+        super(LVMFactoryTestCase, self).test_get_free_disk_space()
+
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_normalize_size(self, *args):  # pylint: disable=unused-argument
+        super(LVMFactoryTestCase, self).test_normalize_size()
 
 
 class LVMThinPFactoryTestCase(LVMFactoryTestCase):
@@ -533,7 +567,7 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
     device_class = MDRaidArrayDevice
 
     @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
-    def test_device_factory(self, *args):  # pylint: disable=unused-argument
+    def test_device_factory(self, *args):  # pylint: disable=unused-argument,arguments-differ
         # RAID0 across two disks
         device_type = self.device_type
         kwargs = {"disks": self.b.disks,

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -4,6 +4,9 @@ import unittest
 from decimal import Decimal
 import os
 
+import test_compat  # pylint: disable=unused-import
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
+
 import blivet
 
 from blivet import devicefactory
@@ -179,7 +182,8 @@ class DeviceFactoryTestCase(unittest.TestCase):
         """
         return Size("1 MiB")
 
-    def test_get_free_disk_space(self):
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    def test_get_free_disk_space(self, *args):  # pylint: disable=unused-argument
         # get_free_disk_space should return the total free space on disks
         kwargs = self._get_test_factory_args()
         kwargs["size"] = Size("500 MiB")
@@ -206,7 +210,8 @@ class DeviceFactoryTestCase(unittest.TestCase):
                                sum(d.size for d in self.b.disks) - device_space,
                                delta=self._get_size_delta(devices=[device]))
 
-    def test_normalize_size(self):
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    def test_normalize_size(self, *args):  # pylint: disable=unused-argument
         # _normalize_size should adjust target size to within the format limits
         fstype = "ext2"
         ext2 = get_format(fstype)
@@ -258,7 +263,8 @@ class DeviceFactoryTestCase(unittest.TestCase):
         factory = devicefactory.get_device_factory(self.b)
         self.assertIsInstance(factory, devicefactory.LVMFactory)
 
-    def test_factory_defaults(self):
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    def test_factory_defaults(self, *args):  # pylint: disable=unused-argument
         ctor_kwargs = self._get_test_factory_args()
         factory = devicefactory.get_device_factory(self.b, self.device_type, **ctor_kwargs)
         for setting, value in factory._default_settings.items():
@@ -526,7 +532,8 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
     device_type = devicefactory.DEVICE_TYPE_MD
     device_class = MDRaidArrayDevice
 
-    def test_device_factory(self):
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    def test_device_factory(self, *args):  # pylint: disable=unused-argument
         # RAID0 across two disks
         device_type = self.device_type
         kwargs = {"disks": self.b.disks,
@@ -614,7 +621,8 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
        initial commit message for this file for further details.
     """
 
-    def test_mdfactory(self):
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    def test_mdfactory(self, *args):  # pylint: disable=unused-argument
         factory1 = devicefactory.get_device_factory(self.b,
                                                     devicefactory.DEVICE_TYPE_MD,
                                                     size=Size("1 GiB"),

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -336,13 +336,15 @@ class LVMLogicalVolumeDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     def destroy_calls_udev_settle(self):
         return False
 
-    def test_setup(self):
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_setup(self, *args):  # pylint: disable=unused-argument,arguments-differ
         super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_setup()
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._setup()
             self.assertTrue(lvm.lvactivate.called)
 
-    def test_teardown(self):
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_teardown(self, *args):  # pylint: disable=unused-argument,arguments-differ
         with patch("blivet.devicelibs.lvm.lvmetad_socket_exists", return_value=False):
             super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_teardown()
 

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -145,6 +145,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertEqual(dt.edd_dict, dict())
 
     @patch.object(StorageDevice, "add_hook")
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
     def test_add_device(self, *args):  # pylint: disable=unused-argument
         dt = DeviceTree()
 
@@ -186,6 +187,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertTrue(dev3.name in dt.names)
 
     @patch.object(StorageDevice, "remove_hook")
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
     def test_remove_device(self, *args):  # pylint: disable=unused-argument
         dt = DeviceTree()
 

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -1,6 +1,7 @@
 import test_compat  # pylint: disable=unused-import
 
 from six.moves.mock import Mock, patch, PropertyMock, sentinel  # pylint: disable=no-name-in-module,import-error
+import os
 import six
 import unittest
 
@@ -107,6 +108,7 @@ class DeviceTreeTestCase(unittest.TestCase):
             tree._remove_device(lv)
             self.assertFalse(lv.name in tree.names)
 
+    @unittest.skipUnless(os.geteuid() == 0, "requires root privileges")
     def test_reset(self):
         dt = DeviceTree()
         names = ["fakedev1", "fakedev2"]

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -138,7 +138,9 @@ class UnsupportedDiskLabelTestCase(unittest.TestCase):
         self.assertFalse(self.partition1.exists)
         self.assertFalse(self.partition2.exists)
 
-    def test_recursive_remove(self):
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    def test_recursive_remove(self, *args):  # pylint: disable=unused-argument
         devicetree = DeviceTree()
         devicetree._add_device(self.disk1)
         devicetree._add_device(self.partition1)


### PR DESCRIPTION
Fixes: #870 

The biggest issue here is LVM, we need root just to query LVM DBus API. We could also simply skip these tests when running as a non-root user, but I think these patches shouldn't affect the tests.