### PR TITLE
Timeshift for Fedora 32 made easy

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -898,7 +898,7 @@ class Blivet(object):
         max_len = 96    # No, you don't need longer names than this. Really.
         tmp = name.strip()
         tmp = tmp.replace("/", "_")
-        tmp = re.sub("[^0-9a-zA-Z._-]", "", tmp)
+        tmp = re.sub("[^0-9a-zA-Z._-@]", "", tmp)
 
         # Remove any '-' or '_' prefixes
         tmp = re.sub("^[-_]*", "", tmp)


### PR DESCRIPTION
Severity: Major: (Major loss of function.)

Summary: The Blivet code screens out the @ sign from device names causing Fedora to limit btrfs subvolume names. The design of the Ubuntu installer program, ubiquity, has made it normal and expected for btrfs subvolume names to consist of strings starting with a commercial at sign (e.g. @ and @home).  OpenSUSE and Manajaro teams have adopted this convention.  Notably the timeshift program requires this to support btrfs.  

Reproduce steps:
1. Install Fedora 32 via the Workstation or Server installer from getfedora.org.
2. Attempt to use blivet to put / on a btrfs subvolume named @

Expected result: You should have / on a btrfs subvolume named @

Actual result: / is on a btrfs subvolume named btrfs.1234 (or other digits).