### PR TITLE
Add exFAT to filesystems we recognize

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1223,6 +1223,13 @@ class NTFS(FS):
 register_device_format(NTFS)
 
 
+class ExFATFS(FS):
+    _type = "exfat"
+
+
+register_device_format(ExFATFS)
+
+
 # if this isn't going to be mountable it might as well not be here
 class NFS(FS):
 


### PR DESCRIPTION
exFAT support is slowly coming to Fedora so we should be able to
recognize it instead of marking is as an unknown "DeviceFormat".