### PR TITLE
Make safe_device_name device type specific

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -847,7 +847,8 @@ class DeviceFactory(object):
                 swap=(self.fstype == "swap"),
                 mountpoint=self.mountpoint)
 
-        safe_new_name = self.storage.safe_device_name(self.device_name)
+        safe_new_name = self.storage.safe_device_name(self.device_name,
+                                                      get_device_type(self.device))
         if self.device.name != safe_new_name:
             if not safe_new_name:
                 log.error("not renaming '%s' to invalid name '%s'",
@@ -1468,7 +1469,7 @@ class LVMFactory(DeviceFactory):
                 mountpoint=self.mountpoint)
 
         lvname = "%s-%s" % (self.vg.name, self.device_name)
-        safe_new_name = self.storage.safe_device_name(lvname)
+        safe_new_name = self.storage.safe_device_name(lvname, DEVICE_TYPE_LVM)
         if self.device.name != safe_new_name:
             if safe_new_name in self.storage.names:
                 log.error("not renaming '%s' to in-use name '%s'",

--- a/blivet/devicelibs/btrfs.py
+++ b/blivet/devicelibs/btrfs.py
@@ -40,5 +40,8 @@ metadata_levels = raid.RAIDLevels(["raid0", "raid1", "raid10", "single", "dup"])
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_BTRFS_PLUGIN]
 
 
+safe_name_characters = "0-9a-zA-Z._@/-"
+
+
 def is_btrfs_name_valid(name):
     return '\x00' not in name

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -63,6 +63,8 @@ EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_LVM_PLUGIN]
 
 LVMETAD_SOCKET_PATH = "/run/lvm/lvmetad.socket"
 
+safe_name_characters = "0-9a-zA-Z._-"
+
 # Start config_args handling code
 #
 # Theoretically we can handle all that can be handled with the LVM --config

--- a/blivet/devicelibs/mdraid.py
+++ b/blivet/devicelibs/mdraid.py
@@ -31,6 +31,8 @@ log = logging.getLogger("blivet")
 MD_SUPERBLOCK_SIZE = Size("2 MiB")
 MD_CHUNK_SIZE = Size("512 KiB")
 
+safe_name_characters = "0-9a-zA-Z._-"
+
 
 class MDRaidLevels(raid.RAIDLevels):
 


### PR DESCRIPTION
This allows us to have a different safe device names for different
device types and for example allow characters like "@" and "/" for
btrfs only.