### PR TITLE
Ignore devices marked as hidden in sysfs (#1856974)

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -247,6 +247,9 @@ class PopulatorMixin(object):
             return
 
         log.info("scanning %s (%s)...", name, sysfs_path)
+        if udev.device_is_hidden(info):
+            log.info("device %s is marked as hidden in sysfs, ignoring")
+            return
 
         # make sure we note the name of every device we see
         self._add_name(name)

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -1006,3 +1006,9 @@ def device_is_nvdimm_namespace(info):
     devname = info.get("DEVNAME", "")
     ninfo = blockdev.nvdimm_namespace_get_devname(devname)
     return ninfo is not None
+
+
+def device_is_hidden(info):
+    sysfs_path = device_get_sysfs_path(info)
+    hidden = util.get_sysfs_attr(sysfs_path, "hidden")
+    return bool(hidden)


### PR DESCRIPTION
NVMe multipath devices have a special internal hidden devices that
are visible in /sys/block but not directly usable so we should
ignore these as well as all devices with the hidden attribute.