### PR TITLE
Fix Failed to instantiate MDRAID Paritions in Reclaim Space Tool, RHBZ#1862904

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -203,7 +203,7 @@ def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
+    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info)):
         mdname = udev_info["MD_DEVNAME"]
         if device_is_partition(udev_info):
             # for partitions on named RAID we want to use the raid name, not


### PR DESCRIPTION
Sysfs path for MDRAID Partitions need not have "/md" existing. For example, the sysfs path for the md127p3 partition would be
/sys/devices/virtual/block/md127/md127p3 and /sys/devices/virtual/block/md127/md127p3/md need not exist.

Due to the below condition in device_get_name() function it returns SYS NAME instead of MD_DEVNAME for MDRAID Partitions

```
elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
       mdname = udev_info["MD_DEVNAME"]
else:
        name = udev_info["SYS_NAME"]
```

This causes existing MDRAID partitions fail to be instantiated because, in function getPartitionByPath(self.path) self.path will be of format SYS NAME: /dev/md/**md**127pX and self.partitions will be a list of partitions in MD_DEVNAME format i.e. /dev/md/**127pX**, and the "partition.path == path" condition fails resulting in returning None object and thereby exceptions.