### PR TITLE
Fix Failed to instantiate MDRAID Paritions in Reclaim Space Tool RHBZ#1862904

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -201,11 +201,14 @@ def __is_blacklisted_blockdev(dev_name):
 
 def device_get_name(udev_info):
     """ Return the best name for a device based on the udev db data. """
+    dev_is_partition = device_is_partition(udev_info)
+    dev_sysfs_path = device_get_sysfs_path(udev_info)
     if "DM_NAME" in udev_info:
         name = udev_info["DM_NAME"]
-    elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
+    elif "MD_DEVNAME" in udev_info and (os.path.exists(dev_sysfs_path + "/md")
+                                        or (dev_is_partition and os.path.exists(dev_sysfs_path))):
         mdname = udev_info["MD_DEVNAME"]
-        if device_is_partition(udev_info):
+        if dev_is_partition:
             # for partitions on named RAID we want to use the raid name, not
             # the node, e.g. "raid1" instead of "md127p1"
             partnum = udev_info["ID_PART_ENTRY_NUMBER"]


### PR DESCRIPTION
Sysfs path for MDRAID Partitions need not have "/md" existing. For example, the sysfs path for the md127p3 partition would be
/sys/devices/virtual/block/md127/md127p3 and /sys/devices/virtual/block/md127/md127p3/md need not exist.

Due to the below condition in device_get_name() function it returns SYS NAME instead of MD_DEVNAME for MDRAID Partitions

```
elif "MD_DEVNAME" in udev_info and os.path.exists(device_get_sysfs_path(udev_info) + "/md"):
       mdname = udev_info["MD_DEVNAME"]
else:
        name = udev_info["SYS_NAME"]
```

This causes existing MDRAID partitions fail to be instantiated because, in function getPartitionByPath(self.path) self.path will be of format SYS NAME: /dev/md/md127pX and self.partitions will be a list of partitions in MD_DEVNAME format i.e. /dev/md/127pX, and the "partition.path == path" condition fails resulting in returning None object and thereby exceptions.