### PR TITLE
Ignore new pylint warning W0707 "raise-missing-from"

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -33,6 +33,7 @@ class BlivetLintConfig(PocketLintConfig):
                 "W0603",           # Using the global statement
                 "W0614",           # Unused import %s from wildcard import
                 "I0011",           # Locally disabling %s
+                "W0707",           # Consider explicitly re-raising using the 'from' keyword
                 ]
 
     @property


### PR DESCRIPTION
This warns about not using the "raise ... from" syntax which is
not available in Python 2 so we can't use it.