### PR TITLE
Use UnusableConfigurationError for patially hidden multipath devices

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -32,7 +32,7 @@ from gi.repository import BlockDev as blockdev
 
 from .actionlist import ActionList
 from .callbacks import callbacks
-from .errors import DeviceError, DeviceTreeError, StorageError, DuplicateUUIDError
+from .errors import DeviceError, DeviceTreeError, StorageError, DuplicateUUIDError, InvalidMultideviceSelection
 from .deviceaction import ActionDestroyDevice, ActionDestroyFormat
 from .devices import BTRFSDevice, NoDevice, PartitionDevice
 from .devices import LVMLogicalVolumeDevice, LVMVolumeGroupDevice
@@ -963,7 +963,7 @@ class DeviceTreeBase(object):
             if is_ignored:
                 if len(disk.children) == 1:
                     if not all(self._is_ignored_disk(d) for d in disk.children[0].parents):
-                        raise DeviceTreeError("Including only a subset of raid/multipath member disks is not allowed.")
+                        raise InvalidMultideviceSelection("Including only a subset of raid/multipath member disks is not allowed.")
 
                     # and also children like fwraid or mpath
                     self.hide(disk.children[0])

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -233,6 +233,12 @@ class DuplicateVGError(UnusableConfigurationError):
                     "Hint 2: You can get the VG UUIDs by running "
                     "'pvs -o +vg_uuid'.")
 
+
+class InvalidMultideviceSelection(UnusableConfigurationError):
+    suggestion = N_("All parent devices must be selected when choosing exclusive "
+                    "or ignored disks for a multipath or firmware RAID device.")
+
+
 # DeviceAction
 
 

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -6,7 +6,7 @@ import six
 import unittest
 
 from blivet.actionlist import ActionList
-from blivet.errors import DeviceTreeError, DuplicateUUIDError
+from blivet.errors import DeviceTreeError, DuplicateUUIDError, InvalidMultideviceSelection
 from blivet.deviceaction import ACTION_TYPE_DESTROY, ACTION_OBJECT_DEVICE
 from blivet.devicelibs import lvm
 from blivet.devices import DiskDevice
@@ -541,5 +541,5 @@ class DeviceTreeIgnoredExclusiveMultipathTestCase(unittest.TestCase):
         self.tree.ignored_disks = ["sda", "sdb"]
         self.tree.exclusive_disks = []
 
-        with self.assertRaises(DeviceTreeError):
+        with self.assertRaises(InvalidMultideviceSelection):
             self.tree._hide_ignored_disks()


### PR DESCRIPTION
Follow-up for https://github.com/storaged-project/blivet/pull/883
to make Anaconda show a error message instead of crashing.