### PR TITLE
Avoid using unnecessary udev.settle calls

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -425,7 +425,6 @@ class StorageDevice(Device):
             self.original_format.teardown()
         if self.format.exists:
             self.format.teardown()
-        udev.settle()
         return True
 
     def _teardown(self, recursive=None):

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -614,6 +614,8 @@ class FS(DeviceFormat):
         if mountpoint == self._chrooted_mountpoint:
             self._chrooted_mountpoint = None
 
+        udev.settle()
+
     def read_label(self):
         """Read this filesystem's label.
 

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -36,6 +36,7 @@ from ..i18n import _, N_
 from ..tasks import availability, lukstasks
 from ..size import Size, KiB
 from ..static_data import luks_data
+from .. import udev
 
 import logging
 log = logging.getLogger("blivet")
@@ -275,6 +276,8 @@ class LUKS(DeviceFormat):
         log.debug("unmapping %s", self.map_name)
         blockdev.crypto.luks_close(self.map_name)
 
+        udev.settle()
+
     def _pre_resize(self):
         if self.luks_version == "luks2" and not self.has_key:
             raise LUKSError("Passphrase or key needs to be set before resizing LUKS2 format.")
@@ -441,6 +444,8 @@ class Integrity(DeviceFormat):
         # it's safe to use luks_close here, it uses crypt_deactivate which works
         # for all devices supported by cryptsetup
         blockdev.crypto.luks_close(self.map_name)
+
+        udev.settle()
 
 
 register_device_format(Integrity)

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -29,6 +29,7 @@ from ..tasks import availability
 from ..tasks import fsuuid
 from . import DeviceFormat, register_device_format
 from ..size import Size
+from .. import udev
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -205,6 +206,8 @@ class SwapSpace(DeviceFormat):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
         blockdev.swap.swapoff(self.device)
+
+        udev.settle()
 
     def _create(self, **kwargs):
         log_method_call(self, device=self.device,

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -27,6 +27,8 @@ from .devicelibs import btrfs
 import logging
 log = logging.getLogger("blivet")
 
+import os
+
 
 class _MountinfoCache(object):
 
@@ -113,6 +115,12 @@ class MountsCache(object):
 
         # devspec == None means "get 'nodev' mount points"
         if devspec not in (None, "tmpfs"):
+            if devspec.startswith("/dev"):
+                # try to avoid using resolve_devspec if possible
+                name = os.path.realpath(devspec).split("/")[-1]
+                if (name, subvolspec) in self.mountpoints.keys():
+                    return self.mountpoints[(name, subvolspec)]
+
             # use the canonical device path (if available)
             canon_devspec = resolve_devspec(devspec, sysname=True)
             if canon_devspec is not None:

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -161,7 +161,6 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
 
         self.assertFalse(self.device.exists)
         self.assertEqual(self.device.update_sysfs_path.called, self.destroy_updates_sysfs_path)
-        self.assertEqual(self.patches["udev"].settle.called, self.destroy_calls_udev_settle)
         self.patches["udev"].reset_mock()
         self.device.update_sysfs_path.reset_mock()
 
@@ -228,7 +227,6 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
             self.device.teardown()
             self.assertTrue(self.teardown_method_mock.called)
 
-        self.assertEqual(self.patches["udev"].settle.called, self.teardown_calls_udev_settle)
         self.assertEqual(self.device.update_sysfs_path.called, self.teardown_updates_sysfs_path)
         self.patches["udev"].reset_mock()
         self.device.update_sysfs_path.reset_mock()


### PR DESCRIPTION
Apparently it is completely normal to have hundreds of btrfs snapshots and blivet is currently not very good in handling this situation. `reset` is relatively fast, but `teardown_all` (which anaconda runs multiple times during installation) can take more than 10 minutes on systems with 500 snapshots ([rhbz#1876162](https://bugzilla.redhat.com/show_bug.cgi?id=1876162)).

I was able to find two issues in our code:
- `MountsCache` uses `udev.resolve_device` for every mountpoint query. `resolve_device` itself uses `udev.settle` and also iterates over all devices in the UDev database.
- `StorageDevice._pre_teardown` always runs `udev.settle` even when the `teardown` is no-op. This means we run `udev.settle` 3 times for every snapshot during `teardown_all`.