### PR TITLE
Close fd if it fails to read the device

### DIFF
--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -679,6 +679,8 @@ def collect_mbrs(devices, root=None):
             testdata_log.debug("device %s data[440:443] raised %s", path, e)
             log.error("edd: could not read mbrsig from disk %s: %s",
                       dev.name, str(e))
+            if fd:
+                os.close(fd)
             continue
 
         mbrsig_str = "0x%08x" % mbrsig


### PR DESCRIPTION
If the device is unmapped from the storage side, the os.read will fail with i/o error. However, here it's not closing the fd and hence any process using the blivet module will hold the device indefinitely. This prevents administrator from removing the device from multipath layer.

```
10078 10:38:25.869889 open("/dev/mapper/36001405097fdbe4d6e04e3b9bdc97014", O_RDONLY <unfinished ...>
10078 10:38:25.870015 <... open resumed>) = 25
10078 10:38:25.870415 lseek(25, 440, SEEK_SET <unfinished ...>
10078 10:38:25.870600 read(25,  <unfinished ...>
10078 10:38:25.870759 <... read resumed>0x7f865c0ec984, 4) = -1 EIO (Input/output error)

< --  jumped to next device without closing the fd 25 -->

10078 10:38:25.871192 open("/dev/sda", O_RDONLY <unfinished ...>

< -- device is in hold by the supervdsm process which uses blivet -->

lsof |grep supervdsm |grep 25r
supervdsm  9592                  root   25r      BLK             253,22     0t440             58811969 /dev/dm-22

```
Also please refer RHBZ 1875554.