### PR TITLE
Close fd if it fails to read the device

### DIFF
--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -158,6 +158,7 @@ def collect_mbrs(devices):
     """
     mbr_dict = {}
     for dev in devices:
+        fd = -1
         try:
             fd = os.open(dev.path, os.O_RDONLY)
             # The signature is the unsigned integer at byte 440:
@@ -167,7 +168,7 @@ def collect_mbrs(devices):
         except OSError as e:
             log.warning("edd: error reading mbrsig from disk %s: %s",
                         dev.name, str(e))
-            if fd:
+            if fd > 0:
                 os.close(fd)
             continue
 

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -167,6 +167,8 @@ def collect_mbrs(devices):
         except OSError as e:
             log.warning("edd: error reading mbrsig from disk %s: %s",
                         dev.name, str(e))
+            if fd:
+                os.close(fd)
             continue
 
         mbrsig_str = "0x%08x" % mbrsig


### PR DESCRIPTION
If the device is unmapped from the storage side, the os.read will
fail with i/o error. However, it's not closing the fd and any
process using the blivet module will hold the device indefeniely. This
prevents administrator from removing the device from multipath
layer.

Resolves: rhbz#1879920

--------

Backport of #899 to rhel7-branch