### PR TITLE
edd: Fix UnboundLocalError when trying to close fd in collect_mbrs

### DIFF
--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -664,6 +664,7 @@ def collect_mbrs(devices, root=None):
     """
     mbr_dict = {}
     for dev in devices:
+        fd = -1
         try:
             path = util.Path("/dev", root=root) + dev.name
             fd = os.open(path.ondisk, os.O_RDONLY)
@@ -679,7 +680,7 @@ def collect_mbrs(devices, root=None):
             testdata_log.debug("device %s data[440:443] raised %s", path, e)
             log.error("edd: could not read mbrsig from disk %s: %s",
                       dev.name, str(e))
-            if fd:
+            if fd > 0:
                 os.close(fd)
             continue
 


### PR DESCRIPTION
The "fd" variable is not defined when the "os.open" fails (e.g.
when the device we try to open doesn't exist).

Follow up for #899 