### PR TITLE
Let parted fix fixable issues with partition table

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -64,6 +64,9 @@ def parted_exn_handler(exn_type, exn_options, exn_msg):
     if exn_type == parted.EXCEPTION_TYPE_ERROR and \
        exn_options == parted.EXCEPTION_OPT_YES_NO:
         ret = parted.EXCEPTION_RESOLVE_YES
+    elif exn_type == parted.EXCEPTION_TYPE_WARNING and \
+            exn_options & parted.EXCEPTION_RESOLVE_FIX:
+        ret = parted.EXCEPTION_RESOLVE_FIX
     return ret
 
 


### PR DESCRIPTION
This will automatically fix issues like GPT partition table not
covering whole device after disk size change.

Resolves: rhbz#1846869

-----

I'd like to know your opinion about this change. I'm not sure if this is the best way to fix the problem (blivet crashing when trying to add partition to such disk). There is no way to tell what issue is being fixed (other than exception message) and this also means we'll do partition table changes during populate without asking. On the other hand, there is no way to detect this problem, so we can't mark the disk as "broken" and avoid using it in autopart.