### PR TITLE
Start the iscsi-init service (#1880673)

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -364,6 +364,9 @@ class iSCSI(object):
         if not has_iscsi():
             return
 
+        # make sure that the file /etc/iscsi/initiatorname.iscsi exists
+        util.run_program(["systemctl", "start", "iscsi-init.service"])
+
         if self._initiator == "":
             log.info("no initiator set")
             return


### PR DESCRIPTION
The startup method of the iSCSI class should start the iscsi-init service that
generates the /etc/iscsi/initiatorname.iscsi file. Otherwise, the file might
not exist and the getter of the initiator property might raise an exception.

Resolves: rhbz#1880673