### PR TITLE
Fix blivet dependencies on Debian in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To install these dependencies use following commands:
        # dnf install python3-blockdev libblockdev-plugins-all python3-bytesize libbytesize python3-pyparted parted libselinux-python3
  * On Debian and Ubuntu based distributions:
 
-       # apt-get install python3-blockdev python3-bytesize python3-parted python3-selinux gir1.2-blockdev-2.0 libblockdev-lvm2 libblockdev-btrfs2 libblockdev-swap2 libblockdev-loop2 libblockdev-crypto2 libblockdev-mpath2 libblockdev-dm2 libblockdev-mdraid2 libblockdev-nvdimm2
+       # apt-get install python3-blockdev python3-bytesize python3-parted python3-selinux gir1.2-blockdev-2.0 libblockdev-lvm2 libblockdev-btrfs2 libblockdev-swap2 libblockdev-loop2 libblockdev-crypto2 libblockdev-mpath2 libblockdev-dm2 libblockdev-mdraid2 libblockdev-nvdimm2 libblockdev-part2
 
 ### Development
 


### PR DESCRIPTION
libblockdev-part2 was missing from the list of libblockdev plugins.