### PR TITLE
Use device ID instead of name for LUKS devices in device factory

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -745,7 +745,7 @@ class DeviceFactory(object):
             fmt = get_format(self.fstype,
                              mountpoint=self.mountpoint,
                              **fmt_args)
-            luks_device = LUKSDevice("luks-" + device.name,
+            luks_device = LUKSDevice("luks-%d" % device.id,
                                      parents=[device], fmt=fmt)
             self.storage.create_device(luks_device)
             ret = luks_device
@@ -832,7 +832,7 @@ class DeviceFactory(object):
                                                                luks_version=self.luks_version,
                                                                pbkdf_args=self.pbkdf_args,
                                                                luks_sector_size=self.luks_sector_size))
-            luks_device = LUKSDevice("luks-%s" % self.device.name,
+            luks_device = LUKSDevice("luks-%d" % self.device.id,
                                      fmt=leaf_format,
                                      parents=self.device)
             self.storage.create_device(luks_device)
@@ -1181,7 +1181,7 @@ class PartitionSetFactory(PartitionFactory):
                                                               luks_version=self.luks_version,
                                                               pbkdf_args=self.pbkdf_args,
                                                               luks_sector_size=self.luks_sector_size))
-                luks_member = LUKSDevice("luks-%s" % member.name,
+                luks_member = LUKSDevice("luks-%d" % member.id,
                                          parents=[member],
                                          fmt=get_format(self.fstype))
                 self.storage.create_device(luks_member)
@@ -1235,7 +1235,7 @@ class PartitionSetFactory(PartitionFactory):
             self.storage.create_device(member)
             if self.encrypted:
                 fmt = get_format(self.fstype)
-                member = LUKSDevice("luks-%s" % member.name,
+                member = LUKSDevice("luks-%d" % member.id,
                                     parents=[member], fmt=fmt)
                 self.storage.create_device(member)
 


### PR DESCRIPTION
Names cause issues with partitions -- PartitionFactory calls
do_partitioning after every factory (re)configure which can change
name of all non-existing partitions. When adding tow partitions
we can end up with two LUKS devices with same name because the
name of the underlying partition changed after adding the second
one but the LUKS device name didn't change. The LUKS devuce name
is never used, it's just our internal name so we can set it to
anything and device ID is unique and won't change.

Resolves: rhbz#1883557