### PR TITLE
Make sure LV names are unique in device factory

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -925,8 +925,23 @@ class Blivet(object):
 
         return tmp
 
-    def _get_container_name_template(self, prefix=None):
-        return prefix or ""
+    def unique_device_name(self, name, parent=None, name_set=True):
+        """ Turn given name into a unique one by adding numeric suffix to it """
+        if name_set:
+            if parent and "%s-%s" % (parent.name, name) not in self.names:
+                return name
+            elif not parent and name not in self.names:
+                return name
+
+        for suffix in range(100):
+            if parent:
+                if "%s-%s%02d" % (parent.name, name, suffix) not in self.names:
+                    return "%s%02d" % (name, suffix)
+            else:
+                if "%s%02d" % (name, suffix) not in self.names:
+                    return "%s%02d" % (name, suffix)
+
+        raise RuntimeError("unable to find suitable device name")
 
     def suggest_container_name(self, prefix="", container_type=None):
         """ Return a reasonable, unused device name.
@@ -938,20 +953,13 @@ class Blivet(object):
         if not prefix:
             prefix = self.safe_device_name(self.short_product_name, container_type)
 
-        template = self._get_container_name_template(prefix=prefix)
-        names = self.names
-        name = template
-        if name in names:
-            name = None
-            for i in range(100):
-                tmpname = "%s%02d" % (template, i,)
-                if tmpname not in names:
-                    name = tmpname
-                    break
-
-            if not name:
-                log.error("failed to create device name based on template '%s'", template)
-                raise RuntimeError("unable to find suitable device name")
+        name = prefix or ""
+        if name in self.names:
+            try:
+                name = self.unique_device_name(name)
+            except RuntimeError:
+                log.error("failed to create device name based on template '%s'", name)
+                raise
 
         return name
 
@@ -982,33 +990,17 @@ class Blivet(object):
         if prefix and body:
             body = "_" + body
 
-        template = self.safe_device_name(prefix + body)
-        names = self.names
-        name = template
+        name = self.safe_device_name(prefix + body)
+        full_name = "%s-%s" % (parent.name, name) if parent else name
 
-        def full_name(name, parent):
-            full = ""
-            if parent:
-                full = "%s-" % parent.name
-            full += name
-            return full
-
-        # also include names of any lvs in the parent for the case of the
-        # temporary vg in the lvm dialogs, which can contain lvs that are
-        # not yet in the devicetree and therefore not in self.names
-        if full_name(name, parent) in names or not body:
-            for i in range(100):
-                name = "%s%02d" % (template, i)
-                if full_name(name, parent) not in names:
-                    break
-                else:
-                    name = ""
-
-            if not name:
+        if full_name in self.names or not body:
+            try:
+                name = self.unique_device_name(name, parent, bool(body))
+            except RuntimeError:
                 log.error("failed to create device name based on parent '%s', "
                           "prefix '%s', mountpoint '%s', swap '%s'",
                           parent.name, prefix, mountpoint, swap)
-                raise RuntimeError("unable to find suitable device name")
+                raise
 
         return name
 

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -556,7 +556,7 @@ class Blivet(object):
             name = self.suggest_container_name(container_type=devicefactory.DEVICE_TYPE_LVM)
 
         if name in self.names:
-            raise ValueError("name already in use")
+            raise ValueError("name '%s' is already in use" % name)
 
         return LVMVolumeGroupDevice(name, pvs, *args, **kwargs)
 
@@ -634,7 +634,7 @@ class Blivet(object):
                                             prefix=prefix)
 
         if "%s-%s" % (vg.name, name) in self.names:
-            raise ValueError("name already in use")
+            raise ValueError("name '%s' is already in use" % name)
 
         if thin_pool or thin_volume:
             cache_req = kwargs.pop("cache_request", None)

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1471,6 +1471,10 @@ class LVMFactory(DeviceFactory):
 
     def _get_new_device(self, *args, **kwargs):
         """ Create and return the factory device as a StorageDevice. """
+
+        name = kwargs.pop("name", "")
+        kwargs["name"] = self.storage.unique_device_name(name, parent=self.vg, name_set=True)
+
         return self.storage.new_lv(*args, **kwargs)
 
     def _set_name(self):

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -536,6 +536,26 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
     def test_normalize_size(self, *args):  # pylint: disable=unused-argument
         super(LVMFactoryTestCase, self).test_normalize_size()
 
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    def test_lv_unique_name(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        device_type = self.device_type
+        kwargs = {"disks": self.b.disks,
+                  "size": Size("400 MiB"),
+                  "fstype": 'ext4',
+                  "mountpoint": "/factorytest",
+                  "device_name": "name"}
+
+        device1 = self._factory_device(device_type, **kwargs)
+        self.assertEqual(device1.lvname, "name")
+
+        # second device with same name should be automatically renamed
+        device2 = self._factory_device(device_type, **kwargs)
+        self.assertEqual(device2.lvname, "name00")
+
 
 class LVMThinPFactoryTestCase(LVMFactoryTestCase):
     # TODO: check that the LV we get is a thin pool

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,0 +1,51 @@
+import unittest
+
+import test_compat  # pylint: disable=unused-import
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
+
+import blivet
+
+
+class SuggestNameTestCase(unittest.TestCase):
+
+    def test_suggest_container_name(self):
+        b = blivet.Blivet()
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            name = b.suggest_container_name(prefix="blivet")
+            self.assertEqual(name, "blivet")
+
+        with patch("blivet.devicetree.DeviceTree.names", ["blivet"]):
+            name = b.suggest_container_name(prefix="blivet")
+            self.assertEqual(name, "blivet00")
+
+        with patch("blivet.devicetree.DeviceTree.names", ["blivet"] + ["blivet%02d" % i for i in range(100)]):
+            with self.assertRaises(RuntimeError):
+                b.suggest_container_name(prefix="blivet")
+
+    def test_suggest_device_name(self):
+        b = blivet.Blivet()
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            name = b.suggest_device_name()
+            self.assertEqual(name, "00")
+
+            name = b.suggest_device_name(prefix="blivet")
+            self.assertEqual(name, "blivet00")
+
+            name = b.suggest_device_name(mountpoint="/")
+            self.assertEqual(name, "root")
+
+            name = b.suggest_device_name(prefix="blivet", mountpoint="/")
+            self.assertEqual(name, "blivet_root")
+
+            name = b.suggest_device_name(parent=blivet.devices.Device(name="parent"), mountpoint="/")
+            self.assertEqual(name, "root")
+
+        with patch("blivet.devicetree.DeviceTree.names", ["00"]):
+            name = b.suggest_device_name()
+            self.assertEqual(name, "01")
+
+        with patch("blivet.devicetree.DeviceTree.names", ["parent-root"]):
+            name = b.suggest_device_name(parent=blivet.devices.Device(name="parent"), mountpoint="/")
+            self.assertEqual(name, "root00")


### PR DESCRIPTION
This fixes issue that happens when trying to add a new LV to an existing VG. This is not possible to do directly, new VG is always created for the new LV so user needs to move it to the existing VG after that. The problem here is we recommend a name that is unique in the new VG (for example `root` for `/`) but it might not be unique in the existing VG so user would need to rename the LV before moving it. Technically this is correct behaviour -- Anaconda tells us to use name that is not unique (that we recommended for a different VG) but it's not really user friendly to recommend a name and tell user it isn't unique in the next step.
I also tried to clean the suggest name functions a little and reuse the code that adds `00` to the name to make it unique.