### PR TITLE
TFT is still broken so let's avoid failures by just doing a build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ actions:
     - "make local"
     - 'bash -c "ls *.tar*"'
 jobs:
-- job: tests
+- job: copr_build
   metadata:
     targets:
     - fedora-all


### PR DESCRIPTION
Testing Farm Team cluster does not work reliably. It should be fine during
January but until then let's avoid these constant tests failures.