### PR TITLE
Add __repr__ and __str__ methods to ParentList

### DIFF
--- a/blivet/devices/lib.py
+++ b/blivet/devices/lib.py
@@ -199,6 +199,12 @@ class ParentList(object):
     def __len__(self):
         return len(self.items)
 
+    def __str__(self):
+        return str(self.items)
+
+    def __repr__(self):
+        return repr(self.items)
+
     def append(self, y):
         """ Add an item to the list after running a callback. """
         if y in self.items:


### PR DESCRIPTION
It makes development and debugging easier and makes output of
device.parents and device.children (which is a simple list) same.

Before:
```
In [3]: sde1.parents
Out[3]: <blivet.devices.lib.ParentList at 0x7efe56aa7430>
```

After:
```
In [3]: sde1.parents
Out[3]: 
[DiskDevice instance (0x7f32cbd4f940) --
  name = sde  status = True  id = 17
  children = []
  parents = []
  uuid = None  size = 1024 MiB
  format = existing msdos disklabel
  major = 8  minor = 64  exists = True  protected = False
  sysfs path = /sys/devices/pci0000:00/0000:00:07.0/host9/target9:0:1/9:0:1:0/block/sde
  target size = 1024 MiB  path = /dev/sde
  format args = []  original_format = disklabel  removable = False  wwn = None]
```