### PR TITLE
Update LUKS device name after parent partition name change

### DIFF
--- a/blivet/devices/luks.py
+++ b/blivet/devices/luks.py
@@ -150,6 +150,17 @@ class LUKSDevice(DMCryptDevice):
 
         StorageDevice._post_teardown(self, recursive=recursive)
 
+    def update_name(self):
+        if self.exists:
+            return
+
+        if self.parents and self.parents[0].type == "partition" and not self.name.endswith(self.parents[0].name):
+            # partition this LUKS device is on was renamed
+            new_name = "luks-%s" % self.parents[0].name
+            log.debug("updating luks name after partition name change from %s to %s",
+                      self.name, new_name)
+            self.name = new_name
+
     def dracut_setup_args(self):
         return set(["rd.luks.uuid=luks-%s" % self.raw_device.format.uuid])
 

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -440,11 +440,16 @@ class PartitionDevice(StorageDevice):
 
     def update_name(self):
         if self.disk and not self.disklabel_supported:
-            pass
+            return
         elif self.parted_partition is None:
             self.name = self.req_name
         else:
             self.name = device_path_to_name(self.parted_partition.path)
+
+        if self.children and self.children[0].type == "luks/dm-crypt" and not self.children[0].exists:
+            # non-existing LUKS devices name is based on the partition name ("luks-<name>")
+            # so we need to update it too
+            self.children[0].update_name()
 
     def depends_on(self, dep):
         """ Return True if this device depends on dep. """


### PR DESCRIPTION
When adding two partitions we can end up with two LUKS devices
with the same name because the name of the underlying partition
changed after adding the second one but the LUKS device name
didn't change.

Resolves: rhbz#188355