### PR TITLE
Replace pocketlint by a custom script

### DIFF
--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -1,0 +1,202 @@
+# Pylint censorship -- The smart filtering of false positives for Pylint.
+#
+# Copyright (C) 2020  Red Hat, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Taken from:
+# https://github.com/jkonecny12/pylint_censorship
+
+"""
+This module is the main implementation. It contains configuration and linter classes.
+
+All the configuration should be handled by CensorshipConfig class instance. Linter class then
+use this configuration to run the pylint and filter the results.
+
+To be able to use this library correctly you have to add this to your pylint configuration file:
+msg-template='{msg_id}({symbol}):{path}:{line},{column}: {obj}: {msg}'
+"""
+
+__all__ = ["CensorshipLinter", "CensorshipConfig"]
+
+import sys
+import re
+import multiprocessing
+
+from io import StringIO
+
+import pylint.lint
+
+from pylint.reporters.text import TextReporter
+
+
+class FalsePositive():
+    """An object used in filtering out incorrect results from pylint.
+
+    Pass in a regular expression matching a pylint error message that should be ignored.
+    This object can also be used to keep track of how often it is used, for auditing
+    that false positives are still useful.
+    """
+    def __init__(self, regex):
+        self.regex = regex
+        self.used = 0
+
+
+class CensorshipConfig():
+    """Configuration of False Positives you want to run by Pylint."""
+    def __init__(self):
+        """Create a configuration object.
+
+        Attributes:
+
+        false_possitives: List of FalsePositive instances you want to filter out.
+
+        pylintrc_path: Path to the Pylint configuration file. Everything except false positives
+                       should be configured there. You can also pass pylintrc as argument to
+                       command_line_args in that case the command_line_args rc file will
+                       taken instead.
+
+        command_line_args: Pass this list of command_line_args to pylint.
+        """
+        self.false_positives = []
+        self.pylintrc_path = ""
+        self.command_line_args = []
+
+    @property
+    def check_paths(self):
+        """Get paths to check.
+
+        These can be python modules or files.
+
+        :return: list of paths
+        """
+        raise AttributeError("No test paths are specified. Please override "
+                             "CensorshipConfig.check_paths property!")
+
+
+class CensorshipLinter():
+    """Run pylint linter and modify it's output."""
+
+    def __init__(self, config):
+        """Create CenshoreshipLinter class.
+
+        :param config: configuration class for this Linter
+        :type config: CensorshipConfig class instance
+        """
+        self._stdout = StringIO()
+        self._config = config
+
+    def run(self):
+        """Run the pylint static linter.
+
+        :return: return code of the linter run
+        :rtype: int
+        """
+        args = self._prepare_args()
+
+        print("Pylint version: ", pylint.__version__)
+        print("Running pylint with args: ", args)
+
+        pylint.lint.Run(args,
+                        reporter=TextReporter(self._stdout),
+                        do_exit=False)
+
+        return self._process_output()
+
+    def _prepare_args(self):
+        args = []
+
+        if self._config.command_line_args:
+            args = self._config.command_line_args
+
+        if self._config.pylintrc_path and "--rcfile" not in args:
+            args.append("--rcfile")
+            args.append(self._config.pylintrc_path)
+
+        args.extend(self._config.check_paths)
+
+        return args
+
+    def _filter_false_positives(self, lines):
+        if not self._config.false_positives:
+            return lines
+
+        lines = lines.split("\n")
+
+        temp_line = ""
+        retval = []
+
+        for line in lines:
+
+            # This is not an error message.  Ignore it.
+            if line.startswith("Using config file"):
+                retval.append(line)
+            elif not line.strip():
+                retval.append(line)
+            elif line.startswith("*****"):
+                temp_line = line
+            else:
+                if self._check_false_positive(line):
+                    if temp_line:
+                        retval.append(temp_line)
+                        temp_line = ""
+
+                    retval.append(line)
+
+        return "\n".join(retval)
+
+    def _check_false_positive(self, line):
+        valid_error = True
+
+        for regex in self._config.false_positives:
+            if re.search(regex.regex, line):
+                # The false positive was hit, so record that and ignore
+                # the message from pylint.
+                regex.used += 1
+                valid_error = False
+                break
+
+        # If any false positive matched the error message, it's a valid
+        # error from pylint.
+        return valid_error
+
+    def _report_unused_false_positives(self):
+        unused = []
+
+        for fp in self._config.false_positives:
+            if fp.used == 0:
+                unused.append(fp.regex)
+
+        if unused:
+            print("************* Unused False Positives Found:")
+
+            for fp in unused:
+                print(fp)
+
+    def _process_output(self):
+        stdout = self._stdout.getvalue()
+        self._stdout.close()
+
+        rc = 0
+
+        if stdout:
+            filtered_stdout = self._filter_false_positives(stdout)
+            if filtered_stdout:
+                print(filtered_stdout)
+                sys.stdout.flush()
+                rc = 1
+
+        self._report_unused_false_positives()
+
+        return rc

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -1,0 +1,390 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=pocketlint.checkers.environ,
+             pocketlint.checkers.intl,
+             pocketlint.checkers.markup,
+             pocketlint.checkers.pointless-override,
+             pocketlint.checkers.preconf
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=yes
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=W0105,           # String statement has no effect
+        W0110,           # map/filter on lambda could be replaced by comprehension
+        W0141,           # Used builtin function %r
+        W0142,           # Used * or ** magic
+        W0212,           # Access to a protected member of a client class
+        W0511,           # Used when a warning note as FIXME or XXX is detected.
+        W0603,           # Using the global statement
+        W0614,           # Unused import %s from wildcard import
+        I0011,           # Locally disabling %s
+        W0707,           # Consider explicitly re-raising using the 'from' keyword
+        C,
+        R
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template='{msg_id}({symbol}):{path}:{line},{column}: {obj}: {msg}'
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           e,
+           ex,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_US (myspell), cs_CZ
+# (myspell), en_GB (myspell), en_AG (myspell), en_AU (myspell), en_BS
+# (myspell), en_BW (myspell), en_BZ (myspell), en_CA (myspell), en_DK
+# (myspell), en_GH (myspell), en_HK (myspell), en_IE (myspell), en_IN
+# (myspell), en_JM (myspell), en_MW (myspell), en_NA (myspell), en_NG
+# (myspell), en_NZ (myspell), en_PH (myspell), en_SG (myspell), en_TT
+# (myspell), en_ZA (myspell), en_ZM (myspell), en_ZW (myspell)..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=Popen
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      initialize,
+                      setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -1,52 +1,122 @@
 #!/usr/bin/python3
 
+import atexit
+import shutil
 import sys
+import tempfile
+import os
 
-from pocketlint import FalsePositive, PocketLintConfig, PocketLinter
+from os import path
+
+from censorship import CensorshipConfig, CensorshipLinter, FalsePositive
 
 
-class BlivetLintConfig(PocketLintConfig):
-
+class BlivetLintConfig(CensorshipConfig):
     def __init__(self):
-        PocketLintConfig.__init__(self)
+        super().__init__()
 
-        self.falsePositives = [FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|Utils|G)Error$"),
-                               FalsePositive(r"Instance of 'int' has no .* member"),
-                               FalsePositive(r"Method 'do_task' is abstract in class 'Task' but is not overridden"),
-                               FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
-                               FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
-                               FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
-                               FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
-                               FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify)'"),
-                               FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$"),
-                               FalsePositive(r"Instance of 'GError' has no 'message' member")  # overriding currently broken local pylint disable
-                               ]
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+
+        self.pylintrc_path = os.path.join(current_dir, "pylintrc")
+
+        self.false_positives = [
+            FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|Utils|G)Error$"),
+            FalsePositive(r"Instance of 'int' has no .* member"),
+            FalsePositive(r"Method 'do_task' is abstract in class 'Task' but is not overridden"),
+            FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
+            FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
+            FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
+            FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
+            FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify)'"),
+            FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$"),
+            FalsePositive(r"Instance of 'GError' has no 'message' member")  # overriding currently broken local pylint disable
+        ]
+
+    def _files(self):
+        srcdir = os.environ.get("top_srcdir", os.getcwd())
+
+        retval = self._get_py_paths(srcdir)
+
+        return sorted(retval)
+
+    def _get_py_paths(self, directory):
+        retval = []
+
+        for (root, dirnames, files) in os.walk(directory):
+
+            # skip scanning of already added python modules
+            skip = False
+            for i in retval:
+                if root.startswith(i):
+                    skip = True
+                    break
+
+            if skip:
+                continue
+
+            if "__init__.py" in files:
+                retval.append(root)
+                continue
+
+            for f in files:
+                try:
+                    with open(root + "/" + f) as fo:
+                        lines = fo.readlines()
+                except UnicodeDecodeError:
+                    # If we couldn't open this file, just skip it.  It wasn't
+                    # going to be valid python anyway.
+                    continue
+
+                # Test any file that either ends in .py or contains #!/usr/bin/python
+                # in the first line.
+                if f.endswith(".py") or (lines and str(lines[0]).startswith("#!/usr/bin/python")):
+                    retval.append(root + "/" + f)
+
+        return retval
 
     @property
-    def disabledOptions(self):
-        return ["W0105",           # String statement has no effect
-                "W0110",           # map/filter on lambda could be replaced by comprehension
-                "W0141",           # Used builtin function %r
-                "W0142",           # Used * or ** magic
-                "W0212",           # Access to a protected member of a client class
-                "W0511",           # Used when a warning note as FIXME or XXX is detected.
-                "W0603",           # Using the global statement
-                "W0614",           # Unused import %s from wildcard import
-                "I0011",           # Locally disabling %s
-                "W0707",           # Consider explicitly re-raising using the 'from' keyword
-                ]
+    def check_paths(self):
+        return self._files()
 
-    @property
-    def ignoreNames(self):
-        return {"translation-canary"}
 
-    @property
-    def extraArgs(self):
-        return ["--unsafe-load-any-extension=yes"]
+def setup_environment():
+    # We need top_builddir to be set so we know where to put the pylint analysis
+    # stuff.  Usually this will be set up if we are run via "make test" but if
+    # not, hope that we are at least being run out of the right directory.
+    builddir = os.environ.get("top_builddir", os.getcwd())
+
+    # XDG_RUNTIME_DIR is "required" to be set, so make one up in case something
+    # actually tries to do something with it.
+    if "XDG_RUNTIME_DIR" not in os.environ:
+        d = tempfile.mkdtemp()
+        os.environ["XDG_RUNTIME_DIR"] = d
+        atexit.register(_del_xdg_runtime_dir)
+
+    # Unset TERM so that things that use readline don't output terminal garbage.
+    if "TERM" in os.environ:
+        os.environ.pop("TERM")
+
+    # Don't try to connect to the accessibility socket.
+    os.environ["NO_AT_BRIDGE"] = "1"
+
+    # Force the GDK backend to X11.  Otherwise if no display can be found, Gdk
+    # tries every backend type, which includes "broadway", which prints an error
+    # and keeps changing the content of said error.
+    os.environ["GDK_BACKEND"] = "x11"
+
+    # Save analysis data in the pylint directory.
+    os.environ["PYLINTHOME"] = builddir + "/tests/pylint/.pylint.d"
+    if not os.path.exists(os.environ["PYLINTHOME"]):
+        os.mkdir(os.environ["PYLINTHOME"])
+
+
+def _del_xdg_runtime_dir():
+    shutil.rmtree(os.environ["XDG_RUNTIME_DIR"])
 
 
 if __name__ == "__main__":
+    setup_environment()
     conf = BlivetLintConfig()
-    linter = PocketLinter(conf)
+    linter = CensorshipLinter(conf)
     rc = linter.run()
     sys.exit(rc)

--- a/translation-canary/translation_canary/translated/test_markup.py
+++ b/translation-canary/translation_canary/translated/test_markup.py
@@ -30,6 +30,7 @@ except ImportError:
 from pocketlint.pangocheck import is_markup, markup_match
 import xml.etree.ElementTree as ET
 
+
 def test_markup(pofile):
     po = polib.pofile(pofile)
 
@@ -48,16 +49,21 @@ def test_markup(pofile):
                     ET.fromstring('<markup>%s</markup>' % msgstr)
                 except ET.ParseError:
                     if entry.msgid_plural:
-                        raise AssertionError("Invalid markup translation for %d translation of msgid %s\n%s" %
-                                (plural_id, entry.msgid, msgstr))
+                        raise AssertionError(
+                            "Invalid markup translation for {} translation of msgid {}\n{}".
+                            format(plural_id, entry.msgid, msgstr))
                     else:
-                        raise AssertionError("Invalid markup translation for msgid %s\n%s" %
-                                (entry.msgid, msgstr))
+                        raise AssertionError(
+                            "Invalid markup translation for msgid {}\n{}".
+                            format(entry.msgid, msgstr))
 
                 # Check if the markup has the same number and kind of tags
                 if not markup_match(entry.msgid, msgstr):
                     if entry.msgid_plural:
-                        raise AssertionError("Markup does not match for %d translation of msgid %s\n%s" %
-                                (plural_id, entry.msgid, msgstr))
+                        raise AssertionError(
+                            "Markup does not match for {} translation of msgid {}\n{}".
+                            format(plural_id, entry.msgid, msgstr))
                     else:
-                        raise AssertionError("Markup does not match for msgid %s\n%s" % (entry.msgid, msgstr))
+                        raise AssertionError(
+                            "Markup does not match for msgid {}\n{}".
+                            format(entry.msgid, msgstr))


### PR DESCRIPTION
This is based on similar change Anaconda did recently, see
rhinstaller/anaconda#2289

Using pylint directly is much faster than pocketlint. And pocketlint
doesn't really add that much functionality, we currently only use
the option to skip false positive reports based on a regex and this
can be done with pylint too.

pocketlint:
real    1m55,183s
user    9m4,957s
sys     0m23,387s

pylint:
real    0m39,922s
user    4m38,094s
sys     0m4,393s