### PR TITLE
Fix possible UnicodeDecodeError when reading model from sysfs

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -185,9 +185,8 @@ def __is_ignored_blockdev(dev_name):
         if any(re.search(expr, dev_name) for expr in ignored_device_names):
             return True
 
-    model_path = "/sys/class/block/%s/device/model" % dev_name
-    if os.path.exists(model_path):
-        model = open(model_path, encoding="utf-8", errors="replace").read()
+    model = util.get_sysfs_attr("/sys/class/block/%s" % dev_name, "device/model")
+    if model:
         for bad in ("IBM *STMF KERNEL", "SCEI Flash-5", "DGC LUNZ"):
             if model.find(bad) != -1:
                 log.info("ignoring %s with model %s", dev_name, model)

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -379,7 +379,7 @@ def get_sysfs_attr(path, attr, root=None):
         log.warning("%s is not a valid attribute", attr)
         return None
 
-    f = open(fullattr, "r")
+    f = open(fullattr, "r", encoding="utf-8", errors="replace")
     data = f.read()
     f.close()
     sdata = "".join(["%02x" % (ord(x),) for x in data])


### PR DESCRIPTION
I unfortunately fixed only one place where we read device model in #861, we also do it from `DiskDevicePopulator`. Lets just ignore (replace) all weird unicode characters we get when reading from sysfs.

Resolves: rhbz#1903793
Related: rhbz#1849326