### PR TITLE
Use real paths to Python site packages

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -85,7 +85,7 @@ def doGitDiff(tag, args=None):
 
     return out.split('\n')
 
-def copyUpdatedFiles(tag, updates):
+def copyUpdatedFiles(tag, updates, python_version):
     def install_to_dir(fname, relpath):
         sys.stdout.write("Including %s\n" % fname)
         outdir = os.path.join(updates, relpath)
@@ -93,12 +93,8 @@ def copyUpdatedFiles(tag, updates):
             os.makedirs(outdir)
         shutil.copy2(fname, outdir)
 
-    # Updates get overlaid onto the runtime filesystem. Anaconda expects them
-    # to be in /run/install/updates, so put them in
-    # $updatedir/run/install/updates.
-    tmpupdates = updates.rstrip('/')
-    if not tmpupdates.endswith("/run/install/updates"):
-        tmpupdates = os.path.join(tmpupdates, "run/install/updates")
+    site_packages_path = "./usr/lib/python{}/site-packages/".format(python_version)
+    sys.stdout.write("Using site-packages path: %s\n" % site_packages_path)
 
     lines = doGitDiff(tag)
     for line in lines:
@@ -119,12 +115,8 @@ def copyUpdatedFiles(tag, updates):
             continue
 
         if gitfile.startswith('blivet/'):
-            # blivet stuff goes into /tmp/updates/[path]
-            dirname = os.path.join(tmpupdates, os.path.dirname(gitfile))
+            dirname = os.path.join(site_packages_path, os.path.dirname(gitfile))
             install_to_dir(gitfile, dirname)
-        else:
-            sys.stdout.write("Including %s\n" % (gitfile,))
-            install_to_dir(gitfile, tmpupdates)
 
 def addRpms(updates, add_rpms):
     for rpm in add_rpms:
@@ -145,6 +137,7 @@ def usage(cmd):
     sys.stdout.write("    -t, --tag        Make image from TAG to HEAD.\n")
     sys.stdout.write("    -o, --offset     Make image from (latest_tag - OFFSET) to HEAD.\n")
     sys.stdout.write("    -a, --add        Add contents of rpm to the update\n")
+    sys.stdout.write("    -p, --python     Version of python (for example, 3.9)\n")
 
 def main(argv):
     prog = os.path.basename(argv[0])
@@ -156,11 +149,12 @@ def main(argv):
     opts = []
     offset = 0
     add_rpms = []
+    python_version = None
 
     try:
-        opts, _args = getopt.getopt(argv[1:], 'a:t:o:k?',
+        opts, _args = getopt.getopt(argv[1:], 'a:t:o:k?p:',
                                    ['add=', 'tag=', 'offset=',
-                                    'keep', 'help'])
+                                    'keep', 'help', 'python='])
     except getopt.GetoptError:
         show_help = True
 
@@ -175,6 +169,8 @@ def main(argv):
             offset = int(a)
         elif o in ('-a', '--add'):
             add_rpms.append(os.path.abspath(a))
+        elif o in ('-p', '--python'):
+            python_version = a
         else:
             unknown = True
 
@@ -184,6 +180,10 @@ def main(argv):
     elif unknown:
         sys.stderr.write("%s: extra operand `%s'" % (prog, argv[1],))
         sys.stderr.write("Try `%s --help' for more information." % (prog,))
+        sys.exit(1)
+
+    if not python_version:
+        sys.stderr.write("You must specify the python version.\n")
         sys.exit(1)
 
     if not os.path.isfile(spec):
@@ -200,7 +200,7 @@ def main(argv):
     if not os.path.isdir(updates):
         os.makedirs(updates)
 
-    copyUpdatedFiles(tag, updates)
+    copyUpdatedFiles(tag, updates, python_version)
 
     if add_rpms:
         addRpms(updates, add_rpms)


### PR DESCRIPTION
Anaconda is not going to support Python site packages in `/run/install/updates`.

**Related to:** https://github.com/rhinstaller/anaconda/pull/3127 (but it doesn't depend on it)