### PR TITLE
Fix excessive logging in udev.__is_ignored_blockdev

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -185,12 +185,14 @@ def __is_ignored_blockdev(dev_name):
         if any(re.search(expr, dev_name) for expr in ignored_device_names):
             return True
 
-    model = util.get_sysfs_attr("/sys/class/block/%s" % dev_name, "device/model")
-    if model:
-        for bad in ("IBM *STMF KERNEL", "SCEI Flash-5", "DGC LUNZ"):
-            if model.find(bad) != -1:
-                log.info("ignoring %s with model %s", dev_name, model)
-                return True
+    dev_path = "/sys/class/block/%s" % dev_name
+    if os.path.exists(os.path.join(dev_path, "device/model")):
+        model = util.get_sysfs_attr(dev_path, "device/model")
+        if model:
+            for bad in ("IBM *STMF KERNEL", "SCEI Flash-5", "DGC LUNZ"):
+                if model.find(bad) != -1:
+                    log.info("ignoring %s with model %s", dev_name, model)
+                    return True
 
     return False
 


### PR DESCRIPTION
We swiched to util.get_sysfs_attr when reading device model in
e8afad15aee5a85aaaa59abcff8b1b58539c748e which logs warning for
non-existing sysfs attributes which leads to excessive logging
because we are checking all devices including those that don't
have model attribute. This adds additional check to prevent this.

Related: rhbz#1849326