### PR TITLE
[btrfs] add new `FSMount` subclass for BTRFS (#1926892)

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -953,6 +953,7 @@ class BTRFS(FS):
     _min_size = Size("256 MiB")
     _max_size = Size("16 EiB")
     _mkfs_class = fsmkfs.BTRFSMkfs
+    _mount_class = fsmount.BTRFSMount
     _metadata_size_factor = 0.80  # btrfs metadata may take 20% of space
     # FIXME parted needs to be taught about btrfs so that we can set the
     # partition table type correctly for btrfs partitions

--- a/blivet/tasks/fsmount.py
+++ b/blivet/tasks/fsmount.py
@@ -143,6 +143,10 @@ class BindFSMount(FSMount):
         return ",".join(["bind", options])
 
 
+class BTRFSMount(FSMount):
+    options = ["compress=zstd:1"]
+
+
 class DevPtsFSMount(FSMount):
     options = ["gid=5", "mode=620"]
 


### PR DESCRIPTION
We need to use this to allow overriding the filesystem mount options
from the default. Ideally this can be overridden in configuration,
but short of having such a mechanism we can hardcode it for now.

Context: https://fedoraproject.org/wiki/Changes/BtrfsTransparentCompression

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storaged-project/blivet/931)
<!-- Reviewable:end -->
