### PR TITLE
[btrfs] apply compression settings from blivet.flags.btrfs_compression (#1926892)

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -494,11 +494,18 @@ class BTRFSSubVolumeDevice(BTRFSDevice):
 
         # propagate mount options specified for members via kickstart
         opts = "subvol=%s" % self.name
+        has_compress = False
         if self.volume.format.mountopts:
             for opt in self.volume.format.mountopts.split(","):
                 # do not add members subvol spec
                 if not opt.startswith("subvol"):
                     opts += ",%s" % opt
+                if opt.startswith("compress"):
+                    has_compress = True
+
+        # add default compression settings
+        if flags.btrfs_compression and not has_compress:
+            opts += ",compress=%s" % flags.btrfs_compression
 
         self.format.mountopts = opts
 

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -81,6 +81,10 @@ class Flags(object):
 
         self.update_from_boot_cmdline()
         self.allow_imperfect_devices = True
+
+        # compression option for btrfs filesystems
+        self.btrfs_compression = None
+
         self.debug_threads = False
 
     def get_boot_cmdline(self):


### PR DESCRIPTION
If `blivet.flags.btrfs_compression` is set, and unless `compress=` is
already explicitly set, apply it to mount options.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/storaged-project/blivet/932)
<!-- Reviewable:end -->
