### PR TITLE
Set both boot and ESP flag for EFIFS partitions (#1930486)

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -28,7 +28,13 @@ import tempfile
 import uuid as uuid_mod
 import random
 
-from parted import fileSystemType, PARTITION_BOOT
+from parted import fileSystemType
+
+try:
+    from parted import PARTITION_ESP
+except ImportError:
+    # this flag is sometimes not available in pyparted, see https://github.com/dcantrell/pyparted/issues/80
+    PARTITION_ESP = 18
 
 from ..tasks import fsck
 from ..tasks import fsinfo
@@ -941,7 +947,7 @@ class EFIFS(FATFS):
     _min_size = Size("50 MiB")
     _check = True
     _mount_class = fsmount.EFIFSMount
-    parted_flag = PARTITION_BOOT
+    parted_flag = PARTITION_ESP
 
     @property
     def supported(self):

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -33,7 +33,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
-%global partedver 1.8.1
+%global partedver 3.2
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
 %global libblockdevver 2.24


### PR DESCRIPTION
Parted automatically sets the ESP flag together with the boot flag
on GPT but not on MBR which means a wrong partition ID will be set
on MBR (FAT specific ID 0x6 instead of 0xef for EFI system
partition) because partition IDs are based on flags with parted.
To make sure the correct ID is set we need to set both flags
manually on both GPT and MBR.