### PR TITLE
Adapt to dosfstools 4.2 FAT label changes

### DIFF
--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -431,6 +431,14 @@ E2FSPROGS_INFO = AppVersionInfo(app_name="e2fsck",
                                 version_regex=r"e2fsck ([0-9+\.]+) .*")
 E2FSPROGS_VERSION = VersionMethod(E2FSPROGS_INFO)
 
+
+# new version of dosftools changed behaviour of many tools
+DOSFSTOOLS_INFO = AppVersionInfo(app_name="mkdosfs",
+                                 required_version="4.2",
+                                 version_opt="--help",
+                                 version_regex=r"mkfs\.fat ([0-9+\.]+) .*")
+DOSFSTOOLS_VERSION = VersionMethod(DOSFSTOOLS_INFO)
+
 # applications
 DEBUGREISERFS_APP = application("debugreiserfs")
 DF_APP = application("df")
@@ -444,6 +452,7 @@ HFORMAT_APP = application("hformat")
 JFSTUNE_APP = application("jfs_tune")
 KPARTX_APP = application("kpartx")
 MKDOSFS_APP = application("mkdosfs")
+MKDOSFS_NEW_APP = application_by_version("mkdosfs", DOSFSTOOLS_VERSION)
 MKE2FS_APP = application_by_version("mke2fs", E2FSPROGS_VERSION)
 MKFS_BTRFS_APP = application("mkfs.btrfs")
 MKFS_GFS2_APP = application("mkfs.gfs2")

--- a/blivet/tasks/fslabeling.py
+++ b/blivet/tasks/fslabeling.py
@@ -23,6 +23,8 @@ import abc
 
 from six import add_metaclass
 
+from . import availability
+
 
 @add_metaclass(abc.ABCMeta)
 class FSLabeling(object):
@@ -55,7 +57,7 @@ class Ext2FSLabeling(FSLabeling):
 
 class FATFSLabeling(FSLabeling):
 
-    default_label = "NO NAME"
+    default_label = "" if availability.MKDOSFS_NEW_APP.available else "NO NAME"
 
     @classmethod
     def label_format_ok(cls, label):

--- a/blivet/tasks/fswritelabel.py
+++ b/blivet/tasks/fswritelabel.py
@@ -66,7 +66,13 @@ class DosFSWriteLabel(FSWriteLabel):
 
     @property
     def args(self):
-        return [self.fs.device, self.fs.label]
+        if availability.MKDOSFS_NEW_APP.available:
+            if self.fs.label:
+                return [self.fs.device, self.fs.label]
+            else:
+                return [self.fs.device, "--reset"]
+        else:
+            return [self.fs.device, self.fs.label]
 
 
 class Ext2FSWriteLabel(FSWriteLabel):


### PR DESCRIPTION
The default "NO NAME" label is now not printed by the "dosfslabel"
tool and a new option "--reset" must be used to set empty label.