### PR TITLE
Try to get Btrfs volume UUID using libblockdev if UDev lookup fails

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -430,6 +430,14 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
         else:
             self.format.vol_uuid = udev.device_get_uuid(info)
 
+        if not self.format.vol_uuid:
+            try:
+                bd_info = blockdev.btrfs.filesystem_info(self.parents[0].path)
+            except blockdev.BtrfsError as e:
+                log.error("failed to get filesystem info for new btrfs volume %s", e)
+            else:
+                self.format.vol_uuid = bd_info.uuid
+
         self.format.exists = True
         self.original_format.exists = True
 


### PR DESCRIPTION
Resolves: rhbz#1860602

-----

This isn't really a fix, just a workaround. @dwlehman mentioned similar issue happening in the [store role](https://github.com/linux-system-roles/storage) too, we should consider reading the UUID and similar properties we gather in `_post_create` from other sources than UDev. We run `udev.settle()` but it doesn't help.