### PR TITLE
Allow removing LVM VDO devices without VDO support

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -392,6 +392,14 @@ class ActionDestroyDevice(DeviceAction):
             # the device, but use wipefs to destroy format on its parents so we
             # don't need btrfs plugin or btrfs-progs for this
             return
+        elif self.device.type in ("lvmvdopool", "lvmvdolv"):
+            # XXX only "normal" LVM tools are needed to destroy LVM VDO devices
+            # vdo and kvdo is needed only for creating and managing
+            unavailable_dependencies = LVMLogicalVolumeDevice.unavailable_type_dependencies()
+            if unavailable_dependencies:
+                dependencies_str = ", ".join(str(d) for d in unavailable_dependencies)
+                raise DependencyError("device type %s requires unavailable_dependencies: %s" % (self.device.type, dependencies_str))
+            return
 
         super(ActionDestroyDevice, self)._check_device_dependencies()
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -820,6 +820,15 @@ class BlivetLVMVDODependenciesTest(unittest.TestCase):
 
                 b.create_device(normallv)
 
+        with patch("blivet.devices.lvm.LVMVDOPoolMixin._external_dependencies", new=[]):
+            with patch("blivet.devices.lvm.LVMVDOLogicalVolumeMixin._external_dependencies", new=[]):
+                b.create_device(vdopool)
+                b.create_device(vdolv)
+
+        # LVM VDO specific dependencies shouldn't be needed for removing, "normal" LVM is enough
+        b.destroy_device(vdolv)
+        b.destroy_device(vdopool)
+
     def test_vdo_dependencies_devicefactory(self):
         with patch("blivet.devices.lvm.LVMVDOPoolMixin._external_dependencies",
                    new=[blivet.tasks.availability.unavailable_resource("VDO unavailability test")]):


### PR DESCRIPTION
We don't need VDO to be able to remove these.

Resolves: rhbz#1933611