### PR TITLE
apply directory's SELinux context to freshly created mount points

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -27,6 +27,7 @@ import os
 import tempfile
 import uuid as uuid_mod
 import random
+import stat
 
 from parted import fileSystemType, PARTITION_BOOT
 
@@ -582,7 +583,7 @@ class FS(DeviceFormat):
         mountpoint = kwargs.get("mountpoint") or self.mountpoint
 
         if self._selinux_supported and flags.selinux and "ro" not in self._mount.mount_options(options).split(",") and flags.selinux_reset_fcon:
-            ret = util.reset_file_context(mountpoint, chroot)
+            ret = util.reset_file_context(mountpoint, chroot, stat.S_IFDIR)
             if not ret:
                 log.warning("Failed to reset SElinux context for newly mounted filesystem root directory to default.")
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -448,11 +448,11 @@ def get_cow_sysfs_path(dev_path, dev_sysfsPath):
 ##
 
 
-def match_path_context(path):
+def match_path_context(path, mode=0):
     """ Return the default SELinux context for the given path. """
     context = None
     try:
-        context = selinux.matchpathcon(os.path.normpath(path), 0)[1]
+        context = selinux.matchpathcon(os.path.normpath(path), mode)[1]
     except OSError as e:
         log.info("failed to get default SELinux context for %s: %s", path, e)
 
@@ -491,7 +491,7 @@ def set_file_context(path, context, root=None):
     return rc
 
 
-def reset_file_context(path, root=None):
+def reset_file_context(path, root=None, mode=0):
     """ Restore the SELinux context of a file to its default value.
 
         Arguments:
@@ -501,12 +501,13 @@ def reset_file_context(path, root=None):
         Keyword Arguments:
 
             root        an optional chroot string
+            mode        an optional mode to use
 
         Return Value:
 
             If successful, returns the file's new/default context.
     """
-    context = match_path_context(path)
+    context = match_path_context(path, mode)
     if context:
         if set_file_context(path, context, root=root):
             return context


### PR DESCRIPTION
When installing a system with non-standard mount points such as `/apps`, the mount point is created with `etc_runtime_t` label instead of `default_t`.

This is due to using the **0** parameter as mode in `matchpatchcon()` instead of explicitly specifying it's a directory.
Indeed, in the SELinux database, there are 2 rules for `/apps` and related:
~~~
/.*                                                all files          system_u:object_r:default_t:s0 
/[^/]+                                             regular file       system_u:object_r:etc_runtime_t:s0 
~~~
