### PR TITLE
Add support for renaming devices using ActionConfigureDevice

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -1139,7 +1139,10 @@ class ActionConfigureDevice(DeviceAction):
         self.old_value = getattr(self.device, self.attr)
 
         if self._execute:
-            self._execute(dry_run=True)
+            kwargs = {"old_%s" % self.attr: self.old_value,
+                      "new_%s" % self.attr: self.new_value,
+                      "dry_run": True}
+            self._execute(**kwargs)
 
     def apply(self):
         if self._applied:
@@ -1158,4 +1161,7 @@ class ActionConfigureDevice(DeviceAction):
         super(ActionConfigureDevice, self).execute(callbacks=callbacks)
 
         if self._execute is not None:
-            self._execute(dry_run=False)
+            kwargs = {"old_%s" % self.attr: self.old_value,
+                      "new_%s" % self.attr: self.new_value,
+                      "dry_run": False}
+            self._execute(**kwargs)

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -53,6 +53,7 @@ class StorageDevice(Device):
     """
     _resizable = False
     """Whether this type of device is inherently resizable."""
+    _renamable = False
 
     _type = "blivet"
     _dev_dir = "/dev"
@@ -60,6 +61,8 @@ class StorageDevice(Device):
     _partitionable = False
     _is_disk = False
     _encrypted = False
+
+    config_actions_map = {"name": "_rename"}
 
     def __init__(self, name, fmt=None, uuid=None,
                  size=None, major=None, minor=None,
@@ -351,6 +354,29 @@ class StorageDevice(Device):
             raise NotImplementedError("method not implemented for device type %s" % self.type)
         else:
             raise errors.DeviceError("device type %s is not resizable" % self.type)
+
+    def _rename(self, old_name, new_name, dry_run=False):  # pylint: disable=unused-argument
+        """ Rename this device.
+
+            :param old_name: current name of this device
+            :type old_name: str
+            :param new_name: new name for this device
+            :type new_name: str
+            :param dry_run: whether to only run checks and not perform the rename
+            :type dry_run: bool
+
+            Note: This method should only be invoked via the
+                  ActionConfigureDevice.execute method. All the pre-conditions
+                  enforced by ActionConfigureDevice.__init__ are assumed to hold.
+                  self.name value is chaged by the ActionConfigureDevice.apply method.
+
+                  Caller must make sure the name is unique, this method cannot check
+                  the name uniqueness.
+        """
+        if not self._renamable:
+            raise errors.DeviceError("device type %s is not renamable" % self.type)
+        else:
+            raise NotImplementedError("method not implemented for device type %s" % self.type)
 
     @property
     def readonly(self):

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1320,7 +1320,8 @@ class ConfigurationActionsTest(unittest.TestCase):
         # set 'conf1' attribute to 'new_value'
         # action is created and right configuration function was called with 'dry_run=True'
         ac = ActionConfigureDevice(mock_device, "conf1", "new_value")
-        mock_device.do_conf1.assert_called_once_with(dry_run=True)
+        mock_device.do_conf1.assert_called_once_with(old_conf1="old_value", new_conf1="new_value",
+                                                     dry_run=True)
         mock_device.reset_mock()
 
         # try to apply, cancel and execute the action
@@ -1331,7 +1332,8 @@ class ConfigurationActionsTest(unittest.TestCase):
         self.assertEqual(mock_device.conf1, "old_value")
 
         ac.execute()
-        mock_device.do_conf1.assert_called_once_with(dry_run=False)
+        mock_device.do_conf1.assert_called_once_with(old_conf1="old_value", new_conf1="new_value",
+                                                     dry_run=False)
 
     def test_format_configuration(self):
 


### PR DESCRIPTION
Currently only volume groups and logical volumes can be renamed.

----

The internal implementation for LVs is a little messier because of the difference between `name` and `lvname`, but I think it makes more sense making the API for users simpler (changing `name` for all devices) even thought the implementation is a little bit uglier.