### PR TITLE
spec: Add 'make' to BuildRequires

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -49,6 +49,7 @@ storage configuration.
 %package -n %{realname}-data
 Summary: Data for the %{realname} python module.
 
+BuildRequires: make
 BuildRequires: systemd
 
 Conflicts: python-blivet < 1:2.0.0


### PR DESCRIPTION
make is no longer present in the Fedora build environment by
default.

----

We already have this in dist-git and on 3.4-release (see https://github.com/storaged-project/blivet/commit/bb0dc95a59b8e69f83dbf07d0267b015154c68f6) but we also need make in spec here on the devel branch for packit builds.