### PR TITLE
Do not log entire exception when trying to get ISCSI initiator name

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -159,8 +159,8 @@ class iSCSI(object):
             try:
                 initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")[0]
                 self._initiator = initiatorname
-            except Exception:  # pylint: disable=broad-except
-                log_exception_info(fmt_str="failed to get initiator name from iscsi firmware")
+            except Exception as e:  # pylint: disable=broad-except
+                log.info("failed to get initiator name from iscsi firmware: %s", str(e))
 
     # So that users can write iscsi() to get the singleton instance
     def __call__(self):


### PR DESCRIPTION
We do this every time and in most cases the call will fail
because there is no ISCSI firmware. Having the entire exception
logged is not useful for us (it will always be the same backtrace
for a failed DBus call) and it confuses users when reporting bugs
because it's the first error message in the log.