### PR TITLE
Avoid AttributeError for DiskLabel formats without disklabel type

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -292,8 +292,11 @@ class DiskLabel(DeviceFormat):
             if self._label_type:
                 lt = self._label_type
             else:
-                lt = self._get_best_label_type()
-
+                try:
+                    lt = self._get_best_label_type()
+                except Exception:  # pylint: disable=broad-except
+                    log_exception_info()
+                    lt = self._label_type
             return lt
 
         try:
@@ -313,13 +316,14 @@ class DiskLabel(DeviceFormat):
 
     @property
     def name(self):
+        if not self.label_type:
+            return "%(name)s" % {"name": _(self._name)}
+
         if self.supported:
-            _str = "%(name)s (%(type)s)"
+            return "%(name)s (%(type)s)" % {"name": _(self._name), "type": self.label_type.upper()}
         else:
             # Translators: Name for an unsupported disklabel; e.g. "Unsupported partition table"
-            _str = _("Unsupported %(name)s")
-
-        return _str % {"name": _(self._name), "type": self.label_type.upper()}
+            return _("Unsupported %(name)s") % {"name": _(self._name)}
 
     @property
     def size(self):


### PR DESCRIPTION
Simple instance of DiskLabel without label_type specified in the
constructor results in a AttributeError when trying to print the
format name. This makes sure the name is always valid.

Resolves: rhbz#1945914

------

Anaconda hits this when it's gathering format types for some DBus shenanigans. Simple reproducer is to get disklabel without specifying type `blivet.formats.get_format("disklabel")` and it will fail when printing the disklabel info (because `__repr__` prints `name`). Alternatively we could make sure the `_default_label_type` is never `None` but that might break more things. It might be also better to have a special `name` for this "disklabel without type" but I wasn't able to come up with something that makes sense, so feel free to suggest something better.