### PR TITLE
Ignore ArithmeticError when trying to align partition size down

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -935,7 +935,13 @@ class PartitionDevice(StorageDevice):
         max_part_size = self._unaligned_max_part_size
         max_format_size = self.format.max_size
         unaligned_max = min(max_format_size, max_part_size) if max_format_size else max_part_size
-        return self.align_target_size(unaligned_max)
+        try:
+            max_size = self.align_target_size(unaligned_max)
+        except ArithmeticError:
+            log.debug("failed to align max size down; returning current size")
+            max_size = self.current_size
+
+        return max_size
 
     @property
     def resizable(self):


### PR DESCRIPTION
For 512 B partitions, pyparted throws ArithmeticError when trying
to align their size down which crashes the installer when trying
to get max size of such partitions.

Resolves: rhbz#1947985