### PR TITLE
Provide better error message for LVM with inconsistent sector sizes

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -367,14 +367,14 @@ class LVMVolumeGroupDevice(ContainerDevice):
                 sector_sizes[ss].append(name)
             if len(sector_sizes.keys()) != 1:
                 if not self.exists:
-                    msg = "The specified volume group cannot be created because inconsistent " \
-                          "sector sizes have been detected on the following disks:\n"
+                    msg = "Cannot create volume group '%s'. "\
+                          "The following disks have inconsistent sector size:\n" % self.name
                     for sector_size in sector_sizes.keys():
-                        msg += "%d: %s\n" % (sector_size, ", ".join(sector_sizes[sector_size]))
+                        msg += "%s: %d\n" % (", ".join(sector_sizes[sector_size]), sector_size)
                 else:
                     msg = "Disk %s cannot be added to this volume group. LVM doesn't " \
                           "allow using physical volumes with inconsistent (logical) sector sizes." % parent.name
-                raise ValueError(msg)
+                raise errors.InconsistentPVSectorSize(msg)
 
         if (self.exists and parent.format.exists and
                 len(self.parents) + 1 == self.pv_count):

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -63,6 +63,10 @@ class DeviceTeardownError(DeviceError):
 class DeviceUserDeniedFormatError(DeviceError):
     pass
 
+
+class InconsistentPVSectorSize(DeviceError, ValueError):
+    pass
+
 # DeviceFormat
 
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -362,7 +362,7 @@ class LVMDeviceTest(unittest.TestCase):
 
         with patch("blivet.devices.StorageDevice.sector_size", new_callable=PropertyMock) as mock_property:
             mock_property.__get__ = lambda _mock, pv, _class: 512 if pv.name == "pv1" else 4096
-            with six.assertRaisesRegex(self, ValueError, "The volume group testvg cannot be created."):
+            with six.assertRaisesRegex(self, ValueError, "Cannot create volume group"):
                 LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
 
     def test_skip_activate(self):


### PR DESCRIPTION
List of pvs with sector sizes is now part of the error message. I've also added a new exception for Anaconda to catch so they can add more information in the UI (workarounds in kickstart etc.).