### PR TITLE
Stratis support v2

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -31,6 +31,7 @@ from .storage_log import log_method_call, log_exception_info
 from .devices import BTRFSSubVolumeDevice, BTRFSVolumeDevice
 from .devices import LVMLogicalVolumeDevice, LVMVolumeGroupDevice
 from .devices import MDRaidArrayDevice, PartitionDevice, TmpFSDevice, device_path_to_name
+from .devices import StratisPoolDevice, StratisFilesystemDevice
 from .deviceaction import ActionCreateDevice, ActionCreateFormat, ActionDestroyDevice
 from .deviceaction import ActionDestroyFormat, ActionResizeDevice, ActionResizeFormat
 from .devicelibs.edd import get_edd_dict
@@ -770,6 +771,77 @@ class Blivet(object):
         kwargs["subvol"] = True
         return self.new_btrfs(*args, **kwargs)
 
+    def new_stratis_pool(self, *args, **kwargs):
+        """ Return a new StratisPoolDevice instance.
+
+            :returns: the new Stratis pool device
+            :rtype: :class:`~.devices.StratisPoolDevice`
+
+            All arguments are passed on to the
+            :class:`~.devices.StratisPoolDevice` constructor.
+
+            If a name is not specified, one will be generated based on the
+            hostname, and/or product name.
+        """
+        blockdevs = kwargs.pop("parents", [])
+
+        name = kwargs.pop("name", None)
+        if name:
+            safe_name = self.safe_device_name(name, devicefactory.DEVICE_TYPE_STRATIS)
+            if safe_name != name:
+                log.warning("using '%s' instead of specified name '%s'",
+                            safe_name, name)
+                name = safe_name
+        else:
+            name = self.suggest_container_name(container_type=devicefactory.DEVICE_TYPE_STRATIS)
+
+        if name in self.names:
+            raise ValueError("name '%s' is already in use" % name)
+
+        return StratisPoolDevice(name, parents=blockdevs, *args, **kwargs)
+
+    def new_stratis_filesystem(self, *args, **kwargs):
+        """ Return a new StratisFilesystemDevice instance.
+
+            :keyword mountpoint: mountpoint for filesystem
+            :type mountpoint: str
+            :returns: the new device
+            :rtype: :class:`~.devices.StratisFilesystemDevice`
+
+            All other arguments are passed on to the appropriate
+            :class:`~.devices.StratisFilesystemDevice` constructor.
+
+            If a name is not specified, one will be generated based on the
+            format type and/or mountpoint.
+        """
+        pool = kwargs.get("parents", [None])[0]
+
+        mountpoint = kwargs.pop("mountpoint", None)
+        name = kwargs.pop("name", None)
+        if name:
+            # make sure the specified name is sensible
+            full_name = "%s/%s" % (pool.name, name)
+            safe_name = self.safe_device_name(full_name, devicefactory.DEVICE_TYPE_STRATIS)
+            if safe_name != full_name:
+                new_name = safe_name[len(pool.name) + 1:]
+                log.warning("using '%s' instead of specified name '%s'",
+                            new_name, name)
+                name = new_name
+        else:
+            name = self.suggest_device_name(parent=pool,
+                                            mountpoint=mountpoint,
+                                            device_type=devicefactory.DEVICE_TYPE_STRATIS)
+
+        if "%s/%s" % (pool.name, name) in self.names:
+            raise ValueError("name '%s' is already in use" % name)
+
+        device = StratisFilesystemDevice(name, *args, **kwargs)
+
+        # XFS will be created automatically on the device so lets just add it here
+        device.format = get_format("stratis xfs", mountpoint=mountpoint)
+
+        return device
+
     def new_tmp_fs(self, *args, **kwargs):
         """ Return a new TmpFSDevice. """
         return TmpFSDevice(*args, **kwargs)
@@ -917,6 +989,8 @@ class Blivet(object):
             allowed = devicelibs.mdraid.safe_name_characters
         elif device_type == devicefactory.DEVICE_TYPE_BTRFS:
             allowed = devicelibs.btrfs.safe_name_characters
+        elif device_type == devicefactory.DEVICE_TYPE_STRATIS:
+            allowed = devicelibs.stratis.safe_name_characters
         else:
             allowed = "0-9a-zA-Z._-"
 
@@ -940,17 +1014,23 @@ class Blivet(object):
 
         return tmp
 
-    def unique_device_name(self, name, parent=None, name_set=True):
+    def unique_device_name(self, name, parent=None, name_set=True, device_type=None):
         """ Turn given name into a unique one by adding numeric suffix to it """
+
+        if device_type == devicefactory.DEVICE_TYPE_STRATIS:
+            parent_separator = "/"
+        else:
+            parent_separator = "-"
+
         if name_set:
-            if parent and "%s-%s" % (parent.name, name) not in self.names:
+            if parent and "%s%s%s" % (parent.name, parent_separator, name) not in self.names:
                 return name
             elif not parent and name not in self.names:
                 return name
 
         for suffix in range(100):
             if parent:
-                if "%s-%s%02d" % (parent.name, name, suffix) not in self.names:
+                if "%s%s%s%02d" % (parent.name, parent_separator, name, suffix) not in self.names:
                     return "%s%02d" % (name, suffix)
             else:
                 if "%s%02d" % (name, suffix) not in self.names:
@@ -974,7 +1054,7 @@ class Blivet(object):
         name = self._get_container_name_template(prefix=prefix)
         if name in self.names:
             try:
-                name = self.unique_device_name(name)
+                name = self.unique_device_name(name, device_type=container_type)
             except RuntimeError:
                 log.error("failed to create device name based on template '%s'", name)
                 raise
@@ -982,7 +1062,8 @@ class Blivet(object):
         return name
 
     def suggest_device_name(self, parent=None, swap=None,
-                            mountpoint=None, prefix=""):
+                            mountpoint=None, prefix="",
+                            device_type=None):
         """ Return a suitable, unused name for a new device.
 
             :keyword parent: the parent device
@@ -1008,12 +1089,18 @@ class Blivet(object):
         if prefix and body:
             body = "_" + body
 
-        name = self.safe_device_name(prefix + body)
-        full_name = "%s-%s" % (parent.name, name) if parent else name
+        name = self.safe_device_name(prefix + body, device_type)
+
+        if device_type == devicefactory.DEVICE_TYPE_STRATIS:
+            parent_separator = "/"
+        else:
+            parent_separator = "-"
+
+        full_name = "%s%s%s" % (parent.name, parent_separator, name) if parent else name
 
         if full_name in self.names or not body:
             try:
-                name = self.unique_device_name(name, parent, bool(body))
+                name = self.unique_device_name(name, parent, bool(body), device_type)
             except RuntimeError:
                 log.error("failed to create device name based on parent '%s', "
                           "prefix '%s', mountpoint '%s', swap '%s'",

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -315,6 +315,17 @@ class Blivet(object):
                       key=lambda d: d.name)
 
     @property
+    def stratis_pools(self):
+        """ A list of the Stratis pools in the device tree.
+
+            This is based on the current state of the device tree and
+            does not necessarily reflect the actual on-disk state of the
+            system's disks.
+        """
+        return sorted((d for d in self.devices if d.type == "stratis pool"),
+                      key=lambda d: d.name)
+
+    @property
     def swaps(self):
         """ A list of the swap devices in the device tree.
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -59,6 +59,7 @@ DEVICE_TYPE_BTRFS = 3
 DEVICE_TYPE_DISK = 4
 DEVICE_TYPE_LVM_THINP = 5
 DEVICE_TYPE_LVM_VDO = 6
+DEVICE_TYPE_STRATIS = 7
 
 
 def is_supported_device_type(device_type):

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -2079,10 +2079,6 @@ class StratisFactory(DeviceFactory):
         else:
             return self.container_size
 
-    def _get_device_space(self):
-        """ The total disk space required for the factory device. """
-        return Size(0)  # FIXME
-
     def _normalize_size(self):
         pass
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -28,6 +28,7 @@ from .devices import BTRFSDevice, DiskDevice
 from .devices import LUKSDevice, LVMLogicalVolumeDevice
 from .devices import PartitionDevice, MDRaidArrayDevice
 from .devices.lvm import LVMVDOPoolMixin, LVMVDOLogicalVolumeMixin, DEFAULT_THPOOL_RESERVE
+from .devices import StratisFilesystemDevice, StratisPoolDevice
 from .formats import get_format
 from .devicelibs import btrfs
 from .devicelibs import mdraid
@@ -84,6 +85,8 @@ def is_supported_device_type(device_type):
         devices = [MDRaidArrayDevice]
     elif device_type == DEVICE_TYPE_LVM_VDO:
         devices = [LVMLogicalVolumeDevice, LVMVDOPoolMixin, LVMVDOLogicalVolumeMixin]
+    elif device_type == DEVICE_TYPE_STRATIS:
+        devices = [StratisFilesystemDevice, StratisPoolDevice]
 
     return not any(c.unavailable_type_dependencies() for c in devices)
 
@@ -124,7 +127,8 @@ def get_device_type(device):
                     "lvmvdopool": DEVICE_TYPE_LVM,
                     "btrfs subvolume": DEVICE_TYPE_BTRFS,
                     "btrfs volume": DEVICE_TYPE_BTRFS,
-                    "mdarray": DEVICE_TYPE_MD}
+                    "mdarray": DEVICE_TYPE_MD,
+                    "stratis filesystem": DEVICE_TYPE_STRATIS}
 
     use_dev = device.raw_device
     if use_dev.is_disk:
@@ -143,7 +147,8 @@ def get_device_factory(blivet, device_type=DEVICE_TYPE_LVM, **kwargs):
                    DEVICE_TYPE_MD: MDFactory,
                    DEVICE_TYPE_LVM_THINP: LVMThinPFactory,
                    DEVICE_TYPE_LVM_VDO: LVMVDOFactory,
-                   DEVICE_TYPE_DISK: DeviceFactory}
+                   DEVICE_TYPE_DISK: DeviceFactory,
+                   DEVICE_TYPE_STRATIS: StratisFactory}
 
     factory_class = class_table[device_type]
     log.debug("instantiating %s: %s, %s, %s", factory_class,
@@ -598,6 +603,8 @@ class DeviceFactory(object):
                 container = device.volume
             elif hasattr(device, "subvolumes"):
                 container = device
+            elif device.type == "stratis filesystem":
+                container = device.pool
         elif name:
             for c in self.storage.devices:
                 if c.name == name and c in self.container_list:
@@ -2014,3 +2021,142 @@ class BTRFSFactory(DeviceFactory):
             return
 
         super(BTRFSFactory, self)._reconfigure_device()
+
+
+class StratisFactory(DeviceFactory):
+
+    """ Factory for creating Stratis filesystems with partition block devices. """
+    child_factory_class = PartitionSetFactory
+    child_factory_fstype = "stratis"
+    size_set_class = TotalSizeSet
+
+    def __init__(self, storage, **kwargs):
+        # override default size policy, AUTO doesn't make sense for Stratis
+        self._default_settings["container_size"] = SIZE_POLICY_MAX
+        super(StratisFactory, self).__init__(storage, **kwargs)
+
+    @property
+    def pool(self):
+        return self.container
+
+    @property
+    def container_list(self):
+        return self.storage.stratis_pools[:]
+
+    def _reconfigure_container(self):
+        """ Reconfigure a defined container required by this factory device. """
+        if getattr(self.container, "exists", False):
+            return
+
+        self._set_container_members()
+
+    #
+    # methods related to device size and disk space requirements
+    #
+    def _get_total_space(self):
+        """ Return the total space need for this factory's device/container.
+
+            This is used for the size argument to the child factory constructor
+            and also to construct the size set in PartitionSetFactory.configure.
+        """
+
+        if self.container_size == SIZE_POLICY_AUTO:
+            raise DeviceFactoryError("Automatic size is not support for Stratis pools")
+        elif self.container_size == SIZE_POLICY_MAX:
+            space = Size(0)
+            # grow the container as large as possible
+            if self.pool:
+                space += sum(p.size for p in self.pool.parents)
+                log.debug("size bumped to %s to include Stratis pool parents", space)
+
+            space += self._get_free_disk_space()
+            log.debug("size bumped to %s to include free disk space", space)
+
+            return space
+        else:
+            return self.container_size
+
+    def _get_device_space(self):
+        """ The total disk space required for the factory device. """
+        return Size(0)  # FIXME
+
+    def _normalize_size(self):
+        pass
+
+    def _handle_no_size(self):
+        """ Set device size so that it grows to the largest size possible. """
+
+    def _get_new_container(self, *args, **kwargs):
+        return self.storage.new_stratis_pool(*args, **kwargs)
+
+    #
+    # methods to configure the factory's device
+    #
+    def _create_device(self):
+        """ Create the factory device. """
+        if self.device_name:
+            kwa = {"name": self.device_name}
+        else:
+            kwa = {}
+
+        parents = self._get_parent_devices()
+        try:
+            # pylint: disable=assignment-from-no-return
+            device = self._get_new_device(parents=parents,
+                                          mountpoint=self.mountpoint,
+                                          **kwa)
+        except (StorageError, ValueError) as e:
+            log.error("device instance creation failed: %s", e)
+            raise
+
+        self.storage.create_device(device)
+        try:
+            self._post_create()
+        except (StorageError, blockdev.BlockDevError) as e:
+            log.error("device post-create method failed: %s", e)
+            self.storage.destroy_device(device)
+            raise_from(StorageError(e), e)
+        else:
+            if not device.size:
+                self.storage.destroy_device(device)
+                raise StorageError("failed to create device")
+
+        self.device = device
+
+    def _get_new_device(self, *args, **kwargs):
+        """ Create and return the factory device as a StorageDevice. """
+
+        name = kwargs.pop("name", "")
+        kwargs["name"] = self.storage.unique_device_name(name, parent=self.pool, name_set=True)
+
+        return self.storage.new_stratis_filesystem(*args, **kwargs)
+
+    def _set_name(self):
+        if not self.device_name:
+            #  pylint: disable=attribute-defined-outside-init
+            self.device_name = self.storage.suggest_device_name(
+                parent=self.pool,
+                swap=False,
+                mountpoint=self.mountpoint)
+
+        fsname = "%s/%s" % (self.pool.name, self.device_name)
+        safe_new_name = self.storage.safe_device_name(fsname, DEVICE_TYPE_STRATIS)
+        if self.device.name != safe_new_name:
+            if safe_new_name in self.storage.names:
+                log.error("not renaming '%s' to in-use name '%s'",
+                          self.device.name, safe_new_name)
+                return
+
+            if not safe_new_name.startswith(self.pool.name):
+                log.error("device rename failure (%s)", safe_new_name)
+                return
+
+            # strip off the vg name before setting
+            safe_new_name = safe_new_name[len(self.pool.name) + 1:]
+            log.debug("renaming device '%s' to '%s'",
+                      self.device.name, safe_new_name)
+            self.raw_device.name = safe_new_name
+
+    def _configure(self):
+        self._set_container()  # just sets self.container based on the specs
+        super(StratisFactory, self)._configure()

--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -1,0 +1,26 @@
+#
+# stratis.py
+# stratis functions
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+from ..size import Size
+
+
+STRATIS_FS_SIZE = Size("1 TiB")

--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -131,6 +131,23 @@ def set_key(key_desc, passphrase, key_file):
             os.close(write)
 
 
+def unlock_pool(pool_uuid):
+    if not safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH):
+        raise StratisError("Stratis DBus service not available")
+
+    try:
+        (succ, err, _blockdevs) = safe_dbus.call_sync(STRATIS_SERVICE,
+                                                      STRATIS_PATH,
+                                                      STRATIS_MANAGER_INTF,
+                                                      "UnlockPool",
+                                                      GLib.Variant("(ss)", (pool_uuid, "keyring")))
+    except safe_dbus.DBusCallError as e:
+        raise StratisError("Failed to unlock pool: %s" % str(e))
+    else:
+        if not succ:
+            raise StratisError("Failed to unlock pool: %s" % err)
+
+
 def create_pool(name, devices, encrypted, passphrase, key_file):
     if not safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH):
         raise StratisError("Stratis DBus service not available")

--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -37,10 +37,13 @@ STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool"
 STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
 STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
 STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
-STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager"
+STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r2"
 
 
 STRATIS_FS_SIZE = Size("1 TiB")
+
+
+safe_name_characters = "0-9a-zA-Z._-"
 
 
 def remove_pool(pool_uuid):
@@ -94,3 +97,55 @@ def remove_filesystem(pool_uuid, fs_uuid):
     else:
         if not succ:
             raise StratisError("Failed to remove stratis filesystem: %s (%d)" % (err, rc))
+
+
+def create_pool(name, devices):
+    if not safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH):
+        raise StratisError("Stratis DBus service not available")
+
+    raid_opt = GLib.Variant("(bq)", (False, 0))
+    key_opt = GLib.Variant("(bs)", (False, ""))
+
+    try:
+        ((succ, _paths), rc, err) = safe_dbus.call_sync(STRATIS_SERVICE,
+                                                        STRATIS_PATH,
+                                                        STRATIS_MANAGER_INTF,
+                                                        "CreatePool",
+                                                        GLib.Variant("(s(bq)as(bs))", (name, raid_opt,
+                                                                                       devices, key_opt)))
+    except safe_dbus.DBusCallError as e:
+        raise StratisError("Failed to create stratis pool: %s" % str(e))
+    else:
+        if not succ:
+            raise StratisError("Failed to create stratis pool: %s (%d)" % (err, rc))
+
+    # repopulate the stratis info cache so the new pool will be added
+    stratis_info.drop_cache()
+
+
+def create_filesystem(name, pool_uuid):
+    if not safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH):
+        raise StratisError("Stratis DBus service not available")
+
+    # repopulate the stratis info cache just to be sure all values are still valid
+    stratis_info.drop_cache()
+
+    if pool_uuid not in stratis_info.pools.keys():
+        raise StratisError("Stratis pool with UUID %s not found" % pool_uuid)
+
+    pool_info = stratis_info.pools[pool_uuid]
+
+    try:
+        ((succ, _paths), rc, err) = safe_dbus.call_sync(STRATIS_SERVICE,
+                                                        pool_info.object_path,
+                                                        STRATIS_POOL_INTF,
+                                                        "CreateFilesystems",
+                                                        GLib.Variant("(as)", ([name],)))
+    except safe_dbus.DBusCallError as e:
+        raise StratisError("Failed to create stratis filesystem on '%s': %s" % (pool_info.name, str(e)))
+    else:
+        if not succ:
+            raise StratisError("Failed to create stratis filesystem on '%s': %s (%d)" % (pool_info.name, err, rc))
+
+    # repopulate the stratis info cache so the new filesystem will be added
+    stratis_info.drop_cache()

--- a/blivet/devices/__init__.py
+++ b/blivet/devices/__init__.py
@@ -35,3 +35,4 @@ from .optical import OpticalDevice
 from .nodev import NoDevice, TmpFSDevice
 from .network import NetworkStorageDevice
 from .nfs import NFSDevice
+from .stratis import StratisPoolDevice, StratisFilesystemDevice

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -91,8 +91,8 @@ class StratisPoolDevice(StorageDevice):
         return ((self.__passphrase not in ["", None]) or
                 (self._key_file and os.access(self._key_file, os.R_OK)))
 
-    def _pre_create(self, **kwargs):
-        super(StratisPoolDevice, self)._pre_create(**kwargs)
+    def _pre_create(self):
+        super(StratisPoolDevice, self)._pre_create()
 
         if self.encrypted and not self.has_key:
             raise StratisError("cannot create encrypted stratis pool without key")

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -25,6 +25,8 @@ log = logging.getLogger("blivet")
 from .storage import StorageDevice
 from ..static_data import stratis_info
 from ..size import Size
+from ..storage_log import log_method_call
+from .. import devicelibs
 
 
 class StratisPoolDevice(StorageDevice):
@@ -39,8 +41,12 @@ class StratisPoolDevice(StorageDevice):
         size = Size(0)
         if self.exists and self.uuid in stratis_info.pools.keys():
             size = stratis_info.pools[self.uuid].physical_size
-
         return size
+
+    def _destroy(self):
+        """ Destroy the device. """
+        log_method_call(self, self.name, status=self.status)
+        devicelibs.stratis.remove_pool(self.uuid)
 
 
 class StratisFilesystemDevice(StorageDevice):
@@ -70,3 +76,8 @@ class StratisFilesystemDevice(StorageDevice):
             return None
 
         return self.parents[0]
+
+    def _destroy(self):
+        """ Destroy the device. """
+        log_method_call(self, self.name, status=self.status)
+        devicelibs.stratis.remove_filesystem(self.pool.uuid, self.uuid)

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -36,6 +36,7 @@ class StratisPoolDevice(StorageDevice):
     _resizable = False
     _packages = ["stratisd", "stratis-cli"]
     _dev_dir = "/dev/stratis"
+    _format_immutable = True
 
     @property
     def size(self):

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -56,6 +56,11 @@ class StratisPoolDevice(StorageDevice):
         super(StratisPoolDevice, self).__init__(*args, **kwargs)
 
     @property
+    def blockdevs(self):
+        """ A list of this pool block devices """
+        return self.parents[:]
+
+    @property
     def size(self):
         """ The size of this pool """
         # sum up the sizes of the block devices

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -1,0 +1,72 @@
+# devices/stratis.py
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+import logging
+log = logging.getLogger("blivet")
+
+from .storage import StorageDevice
+from ..static_data import stratis_info
+from ..size import Size
+
+
+class StratisPoolDevice(StorageDevice):
+    """ A stratis pool device """
+
+    _type = "stratis pool"
+    _resizable = False
+    _packages = ["stratisd", "stratis-cli"]
+    _dev_dir = "/dev/stratis"
+
+    def read_current_size(self):
+        size = Size(0)
+        if self.exists and self.uuid in stratis_info.pools.keys():
+            size = stratis_info.pools[self.uuid].physical_size
+
+        return size
+
+
+class StratisFilesystemDevice(StorageDevice):
+    """ A stratis pool device """
+
+    _type = "stratis filesystem"
+    _resizable = False
+    _packages = ["stratisd", "stratis-cli"]
+    _dev_dir = "/dev/stratis"
+
+    def _get_name(self):
+        """ This device's name. """
+        if self.pool is not None:
+            return "%s/%s" % (self.pool.name, self._name)
+        else:
+            return super(StratisFilesystemDevice, self)._get_name()
+
+    @property
+    def fsname(self):
+        """ The Stratis filesystem name (not including pool name). """
+        return self._name
+
+    @property
+    def pool(self):
+        if not self.parents:
+            # this should never happen but just to be sure
+            return None
+
+        return self.parents[0]

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -193,6 +193,8 @@ class StratisFilesystemDevice(StorageDevice):
             raise DeviceError("Failed to get information about newly created filesystem %s" % self.name)
         self.uuid = fs_info.uuid
 
+        self.format.pool_uuid = fs_info.pool_uuid
+
     def _destroy(self):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -120,6 +120,23 @@ class StratisPoolDevice(StorageDevice):
         log_method_call(self, self.name, status=self.status)
         devicelibs.stratis.remove_pool(self.uuid)
 
+    def add_hook(self, new=True):
+        super(StratisPoolDevice, self).add_hook(new=new)
+        if new:
+            return
+
+        for parent in self.parents:
+            parent.format.pool_name = self.name
+            parent.format.pool_uuid = self.uuid
+
+    def remove_hook(self, modparent=True):
+        if modparent:
+            for parent in self.parents:
+                parent.format.pool_name = None
+                parent.format.pool_uuid = None
+
+        super(StratisPoolDevice, self).remove_hook(modparent=modparent)
+
     def dracut_setup_args(self):
         return set(["stratis.rootfs.pool_uuid=%s" % self.uuid])
 

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -48,6 +48,9 @@ class StratisPoolDevice(StorageDevice):
         log_method_call(self, self.name, status=self.status)
         devicelibs.stratis.remove_pool(self.uuid)
 
+    def dracut_setup_args(self):
+        return set(["stratis.rootfs.pool_uuid=%s" % self.uuid])
+
 
 class StratisFilesystemDevice(StorageDevice):
     """ A stratis pool device """
@@ -81,3 +84,6 @@ class StratisFilesystemDevice(StorageDevice):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
         devicelibs.stratis.remove_filesystem(self.pool.uuid, self.uuid)
+
+    def dracut_setup_args(self):
+        return set(["root=%s" % self.path])

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -24,8 +24,8 @@ log = logging.getLogger("blivet")
 
 from .storage import StorageDevice
 from ..static_data import stratis_info
-from ..size import Size
 from ..storage_log import log_method_call
+from ..errors import DeviceError
 from .. import devicelibs
 
 
@@ -37,11 +37,30 @@ class StratisPoolDevice(StorageDevice):
     _packages = ["stratisd", "stratis-cli"]
     _dev_dir = "/dev/stratis"
 
-    def read_current_size(self):
-        size = Size(0)
-        if self.exists and self.uuid in stratis_info.pools.keys():
-            size = stratis_info.pools[self.uuid].physical_size
-        return size
+    @property
+    def size(self):
+        """ The size of this pool """
+        # sum up the sizes of the block devices
+        return sum(parent.size for parent in self.parents)
+
+    def _create(self):
+        """ Create the device. """
+        log_method_call(self, self.name, status=self.status)
+        bd_list = [bd.path for bd in self.parents]
+        devicelibs.stratis.create_pool(self.name, bd_list)
+
+    def _post_create(self):
+        super(StratisPoolDevice, self)._post_create()
+        self.format.exists = True
+
+        pool_info = stratis_info.get_pool_info(self.name)
+        if not pool_info:
+            raise DeviceError("Failed to get information about newly created pool %s" % self.name)
+        self.uuid = pool_info.uuid
+
+        for parent in self.parents:
+            parent.format.pool_name = self.name
+            parent.format.pool_uuid = self.uuid
 
     def _destroy(self):
         """ Destroy the device. """
@@ -59,6 +78,12 @@ class StratisFilesystemDevice(StorageDevice):
     _resizable = False
     _packages = ["stratisd", "stratis-cli"]
     _dev_dir = "/dev/stratis"
+
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("size") is None and not kwargs.get("exists"):
+            kwargs["size"] = devicelibs.stratis.STRATIS_FS_SIZE
+
+        super(StratisFilesystemDevice, self).__init__(*args, **kwargs)
 
     def _get_name(self):
         """ This device's name. """
@@ -79,6 +104,19 @@ class StratisFilesystemDevice(StorageDevice):
             return None
 
         return self.parents[0]
+
+    def _create(self):
+        """ Create the device. """
+        log_method_call(self, self.name, status=self.status)
+        devicelibs.stratis.create_filesystem(self.fsname, self.pool.uuid)
+
+    def _post_create(self):
+        super(StratisFilesystemDevice, self)._post_create()
+
+        fs_info = stratis_info.get_filesystem_info(self.pool.name, self.fsname)
+        if not fs_info:
+            raise DeviceError("Failed to get information about newly created filesystem %s" % self.name)
+        self.uuid = fs_info.uuid
 
     def _destroy(self):
         """ Destroy the device. """

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -62,6 +62,26 @@ class StratisPoolDevice(StorageDevice):
         return sum(parent.size for parent in self.parents)
 
     @property
+    def encrypted(self):
+        """ True if this device is encrypted. """
+        return self._encrypted
+
+    @encrypted.setter
+    def encrypted(self, encrypted):
+        self._encrypted = encrypted
+
+    @property
+    def key_file(self):
+        """ Path to key file to be used in /etc/crypttab """
+        return self._key_file
+
+    def _set_passphrase(self, passphrase):
+        """ Set the passphrase used to access this device. """
+        self.__passphrase = passphrase
+
+    passphrase = property(fset=_set_passphrase)
+
+    @property
     def has_key(self):
         return ((self.__passphrase not in ["", None]) or
                 (self._key_file and os.access(self._key_file, os.R_OK)))
@@ -69,7 +89,7 @@ class StratisPoolDevice(StorageDevice):
     def _pre_create(self, **kwargs):
         super(StratisPoolDevice, self)._pre_create(**kwargs)
 
-        if self._encrypted and not self.has_key:
+        if self.encrypted and not self.has_key:
             raise StratisError("cannot create encrypted stratis pool without key")
 
     def _create(self):
@@ -78,7 +98,7 @@ class StratisPoolDevice(StorageDevice):
         bd_list = [bd.path for bd in self.parents]
         devicelibs.stratis.create_pool(name=self.name,
                                        devices=bd_list,
-                                       encrypted=self._encrypted,
+                                       encrypted=self.encrypted,
                                        passphrase=self.__passphrase,
                                        key_file=self._key_file)
 

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -185,6 +185,11 @@ class BTRFSError(StorageError):
 class BTRFSValueError(BTRFSError, ValueError):
     pass
 
+
+class StratisError(StorageError):
+    pass
+
+
 # DeviceTree
 
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -742,4 +742,4 @@ class DeviceFormat(ObjectID):
 register_device_format(DeviceFormat)
 
 # import the format modules (which register their device formats)
-from . import biosboot, disklabel, dmraid, fslib, fs, luks, lvmpv, mdraid, multipath, prepboot, swap
+from . import biosboot, disklabel, dmraid, fslib, fs, luks, lvmpv, mdraid, multipath, prepboot, swap, stratis

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1132,6 +1132,30 @@ class XFS(FS):
 register_device_format(XFS)
 
 
+class StratisXFS(XFS):
+    """ XFS on top of Stratis filesystem device """
+
+    _type = "stratis xfs"
+
+    _resize_class = fsresize.UnimplementedFSResize
+    _size_info_class = fssize.UnimplementedFSSize
+    _info_class = fsinfo.UnimplementedFSInfo
+    _minsize_class = fsminsize.UnimplementedFSMinSize
+    _writelabel_class = fswritelabel.UnimplementedFSWriteLabel
+    _writeuuid_class = fswriteuuid.UnimplementedFSWriteUUID
+
+    def _create(self, **kwargs):   # pylint: disable=unused-argument
+        # format is created together with the stratis filesystem device
+        pass
+
+    def _destroy(self, **kwargs):   # pylint: disable=unused-argument
+        # format is destroyed together with the stratis filesystem device
+        pass
+
+
+register_device_format(StratisXFS)
+
+
 class HFS(FS):
     _type = "hfs"
     _modules = ["hfs"]

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1145,6 +1145,20 @@ class StratisXFS(XFS):
     _writelabel_class = fswritelabel.UnimplementedFSWriteLabel
     _writeuuid_class = fswriteuuid.UnimplementedFSWriteUUID
 
+    def __init__(self, **kwargs):
+        super(StratisXFS, self).__init__(**kwargs)
+        self.pool_uuid = kwargs.pop("pool_uuid", None)
+
+    def _get_options(self):
+        opts = super(StratisXFS, self)._get_options()
+        if self.mountpoint != "/":
+            stratis_opts = "x-systemd.requires=stratis-fstab-setup@%s," \
+                           "x-systemd.after=stratis-fstab-setup@%s" % (self.pool_uuid,
+                                                                       self.pool_uuid)
+        else:
+            stratis_opts = None
+        return ",".join(o for o in (opts, stratis_opts) if o)
+
     def _create(self, **kwargs):   # pylint: disable=unused-argument
         # format is created together with the stratis filesystem device
         pass

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1137,6 +1137,7 @@ class StratisXFS(XFS):
 
     _type = "stratis xfs"
 
+    _mount_class = fsmount.StratisXFSMount
     _resize_class = fsresize.UnimplementedFSResize
     _size_info_class = fssize.UnimplementedFSSize
     _info_class = fsinfo.UnimplementedFSInfo

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -35,7 +35,7 @@ class StratisBlockdev(DeviceFormat):
     _type = "stratis"
     _name = N_("Stratis block device")
     _udev_types = ["stratis"]
-    _formattable = False                 # can be formatted
+    _formattable = True                  # can be formatted
     _supported = True                    # is supported
     _linux_native = True                 # for clearpart
     _min_size = Size("1 GiB")

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -1,0 +1,81 @@
+# stratis.py
+# Device format classes for anaconda's storage configuration module.
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+from ..storage_log import log_method_call
+from ..i18n import N_
+from ..size import Size
+from . import DeviceFormat, register_device_format
+
+import logging
+log = logging.getLogger("blivet")
+
+
+class StratisBlockdev(DeviceFormat):
+    """ A Stratis block device """
+
+    _type = "stratis"
+    _name = N_("Stratis block device")
+    _udev_types = ["stratis"]
+    _formattable = False                 # can be formatted
+    _supported = True                    # is supported
+    _linux_native = True                 # for clearpart
+    _min_size = Size("1 GiB")
+    _packages = ["stratisd"]             # required packages
+    _resizable = False
+
+    def __init__(self, **kwargs):
+        """
+            :keyword device: path to the block device node
+            :keyword uuid: this Stratis block device UUID (not the pool UUID)
+            :keyword exists: indicates whether this is an existing format
+            :type exists: bool
+            :keyword pool_name: the name of the pool this block device belongs to
+            :keyword pool_uuid: the UUID of the pool this block device belongs to
+
+            .. note::
+
+                The 'device' kwarg is required for existing formats. For non-
+                existent formats, it is only necessary that the :attr:`device`
+                attribute be set before the :meth:`create` method runs. Note
+                that you can specify the device at the last moment by specifying
+                it via the 'device' kwarg to the :meth:`create` method.
+        """
+        log_method_call(self, **kwargs)
+        DeviceFormat.__init__(self, **kwargs)
+
+        self.pool_name = kwargs.get("pool_name")
+        self.pool_uuid = kwargs.get("pool_uuid")
+
+    def __repr__(self):
+        s = DeviceFormat.__repr__(self)
+        s += ("  pool_name = %(pool_name)s  pool_uuid = %(pool_uuid)s" %
+              {"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
+        return s
+
+    @property
+    def dict(self):
+        d = super(StratisBlockdev, self).dict
+        d.update({"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
+        return d
+
+
+register_device_format(StratisBlockdev)

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -20,9 +20,13 @@
 # Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
 #
 
+import os
+
 from ..storage_log import log_method_call
 from ..i18n import N_
 from ..size import Size
+from ..errors import StratisError
+from ..devicelibs import stratis
 from . import DeviceFormat, register_device_format
 
 import logging
@@ -50,6 +54,14 @@ class StratisBlockdev(DeviceFormat):
             :type exists: bool
             :keyword pool_name: the name of the pool this block device belongs to
             :keyword pool_uuid: the UUID of the pool this block device belongs to
+            :keyword locked_pool: whether this block device belongs to a locked pool or not
+            :type locked_pool: bool
+            :keyword locked_pool_key_desc: kernel keyring description for locked pool
+            :type locked_pool_key_desc: str
+            :keyword passphrase: passphrase for the locked pool
+            :type passphrase: str
+            :keyword key_file: path to a file containing a key
+            :type key_file: str
 
             .. note::
 
@@ -64,11 +76,17 @@ class StratisBlockdev(DeviceFormat):
 
         self.pool_name = kwargs.get("pool_name")
         self.pool_uuid = kwargs.get("pool_uuid")
+        self.locked_pool = kwargs.get("locked_pool")
+        self.locked_pool_key_desc = kwargs.get("locked_pool_key_desc")
+
+        self.__passphrase = kwargs.get("passphrase")
+        self._key_file = kwargs.get("key_file")
 
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
-        s += ("  pool_name = %(pool_name)s  pool_uuid = %(pool_uuid)s" %
-              {"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
+        s += ("  pool_name = %(pool_name)s  pool_uuid = %(pool_uuid)s  locked_pool = %(locked_pool)s" %
+              {"pool_name": self.pool_name, "pool_uuid": self.pool_uuid,
+               "locked_pool": self.locked_pool})
         return s
 
     @property
@@ -76,6 +94,32 @@ class StratisBlockdev(DeviceFormat):
         d = super(StratisBlockdev, self).dict
         d.update({"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
         return d
+
+    @property
+    def key_file(self):
+        """ Path to key file to be used in /etc/crypttab """
+        return self._key_file
+
+    def _set_passphrase(self, passphrase):
+        """ Set the passphrase used to access this device. """
+        self.__passphrase = passphrase
+
+    passphrase = property(fset=_set_passphrase)
+
+    @property
+    def has_key(self):
+        return ((self.__passphrase not in ["", None]) or
+                (self._key_file and os.access(self._key_file, os.R_OK)))
+
+    def unlock_pool(self):
+        if not self.locked_pool:
+            raise StratisError("This device doesn't contain a locked Stratis pool")
+
+        if not self.has_key:
+            raise StratisError("No passphrase/key file for the locked Stratis pool")
+
+        stratis.set_key(self.locked_pool_key_desc, self.__passphrase, self.key_file)
+        stratis.unlock_pool(self.pool_uuid)
 
 
 register_device_format(StratisBlockdev)

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -90,6 +90,10 @@ class StratisBlockdev(DeviceFormat):
         return s
 
     @property
+    def status(self):
+        return self.exists and (self.pool_name or self.pool_uuid)
+
+    @property
     def dict(self):
         d = super(StratisBlockdev, self).dict
         d.update({"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -17,6 +17,7 @@ from .mdraid import MDDevicePopulator, MDFormatPopulator
 from .multipath import MultipathDevicePopulator, MultipathFormatPopulator
 from .optical import OpticalDevicePopulator
 from .partition import PartitionDevicePopulator
+from .stratis import StratisFormatPopulator
 
 __all__ = ["get_device_helper", "get_format_helper"]
 

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -17,7 +17,7 @@ from .mdraid import MDDevicePopulator, MDFormatPopulator
 from .multipath import MultipathDevicePopulator, MultipathFormatPopulator
 from .optical import OpticalDevicePopulator
 from .partition import PartitionDevicePopulator
-from .stratis import StratisFormatPopulator
+from .stratis import StratisFormatPopulator, StratisXFSFormatPopulator
 
 __all__ = ["get_device_helper", "get_format_helper"]
 

--- a/blivet/populator/helpers/dm.py
+++ b/blivet/populator/helpers/dm.py
@@ -40,7 +40,8 @@ class DMDevicePopulator(DevicePopulator):
                 not udev.device_is_dm_integrity(data) and
                 not udev.device_is_dm_lvm(data) and
                 not udev.device_is_dm_mpath(data) and
-                not udev.device_is_dm_raid(data))
+                not udev.device_is_dm_raid(data) and
+                not udev.device_is_dm_stratis(data))
 
     def run(self):
         name = udev.device_get_name(self.data)

--- a/blivet/populator/helpers/formatpopulator.py
+++ b/blivet/populator/helpers/formatpopulator.py
@@ -45,7 +45,10 @@ class FormatPopulator(PopulatorHelper):
             :returns: whether this class is appropriate for the specified device
             :rtype: bool
         """
-        ret = False
+        if device.type == "stratis filesystem":
+            # XFS on stratis filesystem device handled in StratisXFSFormatPopulator
+            return False
+
         if cls is FormatPopulator:
             ret = True
         else:

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -81,6 +81,15 @@ class LUKSFormatPopulator(FormatPopulator):
             if device.path in pool.devices:
                 return False
 
+        # unlocked stratis pools are also managed in the StratisFormatPopulator
+        holders = udev.device_get_holders(data)
+        if holders:
+            fs = udev.device_get_format(holders[0])
+            if fs == "stratis":
+                log.debug("ignoring LUKS format on %s, it appears to be an encrypted Stratis pool",
+                          device.name)
+                return False
+
         return True
 
     def _get_kwargs(self):

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -31,7 +31,7 @@ from ...errors import DeviceError, LUKSError
 from ...flags import flags
 from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
-from ...static_data import luks_data
+from ...static_data import luks_data, stratis_info
 
 import logging
 log = logging.getLogger("blivet")
@@ -70,6 +70,18 @@ class IntegrityDevicePopulator(DevicePopulator):
 class LUKSFormatPopulator(FormatPopulator):
     priority = 100
     _type_specifier = "luks"
+
+    @classmethod
+    def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
+        if not super(LUKSFormatPopulator, cls).match(data, device):
+            return False
+
+        # locked stratis pools are managed in the StratisFormatPopulator
+        for pool in stratis_info.locked_pools:
+            if device.path in pool.devices:
+                return False
+
+        return True
 
     def _get_kwargs(self):
         kwargs = super(LUKSFormatPopulator, self)._get_kwargs()

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -85,7 +85,8 @@ class StratisFormatPopulator(FormatPopulator):
                                             parents=[self.device],
                                             uuid=pool_info.uuid,
                                             size=pool_info.physical_size,
-                                            exists=True)
+                                            exists=True,
+                                            encrypted=pool_info.encrypted)
             self._devicetree._add_device(pool_device)
 
         # now add filesystems on this pool

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -186,5 +186,6 @@ class StratisXFSFormatPopulator(FormatPopulator):
     def run(self):
         """ Create a format instance and associate it with the device instance. """
         kwargs = self._get_kwargs()
+        kwargs["pool_uuid"] = self.device.pool.uuid
         log.info("type detected on '%s' is '%s'", self.device.name, self.type_spec)
         self.device.format = get_format(self.type_spec, **kwargs)

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -50,6 +50,14 @@ class StratisFormatPopulator(FormatPopulator):
             if device.path in pool.devices:
                 return True
 
+        # unlocked encrypted pools are also managed here
+        if udev.device_get_format(data) == "crypto_LUKS":
+            holders = udev.device_get_holders(data)
+            if holders:
+                fs = udev.device_get_format(holders[0])
+                if fs == cls._type_specifier:
+                    return True
+
         return False
 
     def _get_blockdev_uuid(self):

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -24,6 +24,7 @@ import copy
 
 from ...callbacks import callbacks
 from ... import udev
+from ...formats import get_format
 from ...devices.stratis import StratisPoolDevice, StratisFilesystemDevice
 from ...devicelibs.stratis import STRATIS_FS_SIZE
 from ...storage_log import log_method_call
@@ -119,3 +120,29 @@ class StratisFormatPopulator(FormatPopulator):
         log_method_call(self, pv=self.device.name)
         super(StratisFormatPopulator, self).run()
         self._add_pool_device()
+
+
+class StratisXFSFormatPopulator(FormatPopulator):
+    priority = 100
+    _type_specifier = "stratis xfs"
+
+    @classmethod
+    def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
+        """ Return True if this helper is appropriate for the given device.
+
+            :param :class:`pyudev.Device` data: udev data describing a device
+            :param device: device instance corresponding to the udev data
+            :type device: :class:`~.devices.StorageDevice`
+            :returns: whether this class is appropriate for the specified device
+            :rtype: bool
+        """
+        if device.type == "stratis filesystem" and udev.device_get_format(data) == "xfs":
+            return True
+
+        return False
+
+    def run(self):
+        """ Create a format instance and associate it with the device instance. """
+        kwargs = self._get_kwargs()
+        log.info("type detected on '%s' is '%s'", self.device.name, self.type_spec)
+        self.device.format = get_format(self.type_spec, **kwargs)

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -40,12 +40,43 @@ class StratisFormatPopulator(FormatPopulator):
     priority = 100
     _type_specifier = "stratis"
 
+    @classmethod
+    def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
+        if super(StratisFormatPopulator, cls).match(data, device):
+            return True
+
+        # locked stratis pools are managed here
+        for pool in stratis_info.locked_pools:
+            if device.path in pool.devices:
+                return True
+
+        return False
+
+    def _get_blockdev_uuid(self):
+        if udev.device_get_format(self.data) == "crypto_LUKS":
+            holders = udev.device_get_holders(self.data)
+            if holders:
+                return udev.device_get_uuid(holders[0])
+
+        return udev.device_get_uuid(self.data)
+
     def _get_kwargs(self):
         kwargs = super(StratisFormatPopulator, self)._get_kwargs()
 
-        bd_info = stratis_info.blockdevs.get(self.device.path)
-
         name = udev.device_get_name(self.data)
+        uuid = self._get_blockdev_uuid()
+        kwargs["uuid"] = uuid
+
+        # stratis block device hosting an encrypted pool
+        kwargs["locked_pool"] = False
+        for pool in stratis_info.locked_pools:
+            if self.device.path in pool.devices:
+                kwargs["locked_pool"] = True
+                kwargs["pool_uuid"] = pool.uuid
+                kwargs["locked_pool_key_desc"] = pool.key_desc
+                return kwargs
+
+        bd_info = stratis_info.blockdevs.get(uuid)
         if bd_info:
             if bd_info.pool_name:
                 kwargs["pool_name"] = bd_info.pool_name
@@ -120,7 +151,9 @@ class StratisFormatPopulator(FormatPopulator):
     def run(self):
         log_method_call(self, pv=self.device.name)
         super(StratisFormatPopulator, self).run()
-        self._add_pool_device()
+
+        if not self.device.format.locked_pool:
+            self._add_pool_device()
 
 
 class StratisXFSFormatPopulator(FormatPopulator):

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -1,0 +1,121 @@
+# populator/helpers/stratis.py
+# Stratis backend code for populating a DeviceTree.
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+import copy
+
+from ...callbacks import callbacks
+from ... import udev
+from ...devices.stratis import StratisPoolDevice, StratisFilesystemDevice
+from ...devicelibs.stratis import STRATIS_FS_SIZE
+from ...storage_log import log_method_call
+from .formatpopulator import FormatPopulator
+
+from ...static_data import stratis_info
+
+import logging
+log = logging.getLogger("blivet")
+
+
+class StratisFormatPopulator(FormatPopulator):
+    priority = 100
+    _type_specifier = "stratis"
+
+    def _get_kwargs(self):
+        kwargs = super(StratisFormatPopulator, self)._get_kwargs()
+
+        bd_info = stratis_info.blockdevs.get(self.device.path)
+
+        name = udev.device_get_name(self.data)
+        if bd_info:
+            if bd_info.pool_name:
+                kwargs["pool_name"] = bd_info.pool_name
+            else:
+                log.warning("Stratis block device %s has no pool_name", name)
+            if bd_info.pool_uuid:
+                kwargs["pool_uuid"] = bd_info.pool_uuid
+            else:
+                log.warning("Stratis block device %s has no pool_uuid", name)
+
+        return kwargs
+
+    def _add_pool_device(self):
+        bd_info = stratis_info.blockdevs.get(self.device.format.uuid)
+        if not bd_info:
+            # no info about the stratis block device -> we're done
+            return
+
+        if not bd_info.pool_name:
+            log.info("stratis block device %s has no pool", self.device.name)
+            return
+
+        pool_info = stratis_info.pools.get(bd_info.pool_uuid)
+        if pool_info is None:
+            log.warning("Failed to get information about Stratis pool %s (%s)",
+                        bd_info.pool_name, bd_info.pool_uuid)
+            return
+
+        pool_device = self._devicetree.get_device_by_uuid(bd_info.pool_uuid)
+        if pool_device and self.device not in pool_device.parents:
+            pool_device.parents.append(self.device)
+            callbacks.parent_added(device=pool_device, parent=self.device)
+        elif pool_device is None:
+            # TODO: stratis duplicate pool name
+
+            pool_device = StratisPoolDevice(pool_info.name,
+                                            parents=[self.device],
+                                            uuid=pool_info.uuid,
+                                            size=pool_info.physical_size,
+                                            exists=True)
+            self._devicetree._add_device(pool_device)
+
+        # now add filesystems on this pool
+        for fs_info in stratis_info.filesystems.values():
+            if fs_info.pool_uuid != pool_info.uuid:
+                continue
+
+            fs_device = self._devicetree.get_device_by_uuid(fs_info.uuid)
+            if fs_device is not None:
+                log.debug("stratis filesystem already added %s", fs_info.name)
+                continue
+
+            pool_device = self._devicetree.get_device_by_uuid(fs_info.pool_uuid)
+            if not pool_device:
+                log.info("stratis pool %s has not been added yet", fs_info.pool_name)
+                return
+
+            fs_device = StratisFilesystemDevice(fs_info.name, parents=[pool_device],
+                                                uuid=fs_info.uuid, size=STRATIS_FS_SIZE,
+                                                exists=True)
+            self._devicetree._add_device(fs_device)
+
+            # do format handling now
+            udev_info = udev.get_device(fs_device.sysfs_path)
+            if not udev_info:
+                return
+
+            self._devicetree.handle_format(udev_info, fs_device)
+            fs_device.original_format = copy.deepcopy(fs_device.format)
+
+    def run(self):
+        log_method_call(self, pv=self.device.name)
+        super(StratisFormatPopulator, self).run()
+        self._add_pool_device()

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -253,6 +253,10 @@ class PopulatorMixin(object):
             log.info("device %s is marked as hidden in sysfs, ignoring", name)
             return
 
+        if udev.device_is_private(info):
+            log.info("device %s is private, ignoring", name)
+            return
+
         # make sure we note the name of every device we see
         self._add_name(name)
         device = self.get_device_by_name(name)

--- a/blivet/safe_dbus.py
+++ b/blivet/safe_dbus.py
@@ -186,6 +186,33 @@ def get_property_sync(service, obj_path, iface, prop_name,
     return ret
 
 
+def get_properties_sync(service, obj_path, iface, connection=None):
+    """
+    Get all properties of a given object provided by a given service.
+
+    :param service: DBus service to use
+    :type service: str
+    :param obj_path: object path
+    :type obj_path: str
+    :param iface: interface to use
+    :type iface: str
+    :param connection: connection to use (if None, a new connection is
+                       established)
+    :type connection: Gio.DBusConnection
+    :return: unpacked value of the property
+    :rtype: tuple with elements that depend on the type of the property
+    :raise DBusCallError: when the internal dbus_call_safe_sync invocation
+                          raises an exception
+
+    """
+
+    args = GLib.Variant('(s)', (iface,))
+    ret = call_sync(service, obj_path, DBUS_PROPS_IFACE, "GetAll", args,
+                    connection)
+
+    return ret
+
+
 def check_object_available(service, obj_path, iface=None):
     intro_data = call_sync(service, obj_path, DBUS_INTRO_IFACE, "Introspect", None)
     node_info = Gio.DBusNodeInfo.new_for_xml(intro_data[0])

--- a/blivet/safe_dbus.py
+++ b/blivet/safe_dbus.py
@@ -100,7 +100,7 @@ def get_new_session_connection():
 
 
 def call_sync(service, obj_path, iface, method, args,
-              connection=None):
+              connection=None, fds=None):
     """
     Safely call a given method on a given object of a given service over DBus
     passing given arguments. If a connection is given, it is used, otherwise a
@@ -120,6 +120,8 @@ def call_sync(service, obj_path, iface, method, args,
     :param connection: connection to use (if None, a new connection is
                        established)
     :type connection: Gio.DBusConnection
+    :param fds: list of file descriptors for the call
+    :type: Gio.UnixFDList
     :return: unpacked value returned by the method
     :rtype: tuple with elements that depend on the method
     :raise DBusCallError: if some DBus related error appears
@@ -136,9 +138,9 @@ def call_sync(service, obj_path, iface, method, args,
         raise DBusCallError("Connection is closed")
 
     try:
-        ret = connection.call_sync(service, obj_path, iface, method, args,
-                                   None, Gio.DBusCallFlags.NONE,
-                                   DEFAULT_DBUS_TIMEOUT, None)
+        ret = connection.call_with_unix_fd_list_sync(service, obj_path, iface, method, args,
+                                                     None, Gio.DBusCallFlags.NONE,
+                                                     DEFAULT_DBUS_TIMEOUT, fds, None)
     except GLib.GError as gerr:
         msg = "Failed to call %s method on %s with %s arguments: %s" % \
               (method, obj_path, args, gerr.message)  # pylint: disable=no-member
@@ -148,7 +150,7 @@ def call_sync(service, obj_path, iface, method, args,
         msg = "No return from %s method on %s with %s arguments" % (method, obj_path, args)
         raise DBusCallError(msg)
 
-    return ret.unpack()
+    return ret[0].unpack()
 
 
 def get_property_sync(service, obj_path, iface, prop_name,

--- a/blivet/static_data/__init__.py
+++ b/blivet/static_data/__init__.py
@@ -2,3 +2,4 @@ from .lvm_info import lvs_info, pvs_info, vgs_info
 from .luks_data import luks_data
 from .mpath_info import mpath_members
 from .nvdimm import nvdimm
+from .stratis_info import stratis_info

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -24,10 +24,19 @@ from collections import namedtuple
 
 from .. import safe_dbus
 from ..size import Size
-from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH, STRATIS_POOL_INTF, STRATIS_FILESYSTEM_INTF, STRATIS_BLOCKDEV_INTF, STRATIS_PROPS_INTF
 
 import logging
 log = logging.getLogger("blivet")
+
+
+# XXX we can't import these from devicelibs.stratis, circular imports make python mad
+STRATIS_SERVICE = "org.storage.stratis2"
+STRATIS_PATH = "/org/storage/stratis2"
+STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool"
+STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
+STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
+STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
+STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r2"
 
 
 StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "object_path"])

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -34,14 +34,14 @@ log = logging.getLogger("blivet")
 # XXX we can't import these from devicelibs.stratis, circular imports make python mad
 STRATIS_SERVICE = "org.storage.stratis2"
 STRATIS_PATH = "/org/storage/stratis2"
-STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool"
+STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool.r1"
 STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
 STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
 STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
 STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r2"
 
 
-StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "object_path"])
+StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "object_path", "encrypted"])
 StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "pool_name", "pool_uuid", "object_path"])
 StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
 
@@ -84,7 +84,8 @@ class StratisInfo(object):
             pool_size = 0
 
         return StratisPoolInfo(name=properties["Name"], uuid=properties["Uuid"],
-                               physical_size=Size(pool_size), object_path=pool_path)
+                               physical_size=Size(pool_size), object_path=pool_path,
+                               encrypted=properties["Encrypted"])
 
     def _get_filesystem_info(self, filesystem_path):
         try:

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -24,22 +24,15 @@ from collections import namedtuple
 
 from .. import safe_dbus
 from ..size import Size
+from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH, STRATIS_POOL_INTF, STRATIS_FILESYSTEM_INTF, STRATIS_BLOCKDEV_INTF, STRATIS_PROPS_INTF
 
 import logging
 log = logging.getLogger("blivet")
 
 
-STRATIS_SERVICE = "org.storage.stratis2"
-STRATIS_PATH = "/org/storage/stratis2"
-STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool"
-STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
-STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
-STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
-
-
-StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size"])
-StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "pool_name", "pool_uuid"])
-StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid"])
+StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "object_path"])
+StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "pool_name", "pool_uuid", "object_path"])
+StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
 
 
 class StratisInfo(object):
@@ -80,7 +73,7 @@ class StratisInfo(object):
             pool_size = 0
 
         return StratisPoolInfo(name=properties["Name"], uuid=properties["Uuid"],
-                               physical_size=Size(pool_size))
+                               physical_size=Size(pool_size), object_path=pool_path)
 
     def _get_filesystem_info(self, filesystem_path):
         try:
@@ -100,7 +93,8 @@ class StratisInfo(object):
             return None
 
         return StratisFilesystemInfo(name=properties["Name"], uuid=properties["Uuid"],
-                                     pool_name=pool_info.name, pool_uuid=pool_info.uuid)
+                                     pool_name=pool_info.name, pool_uuid=pool_info.uuid,
+                                     object_path=filesystem_path)
 
     def _get_blockdev_info(self, blockdev_path):
         try:
@@ -125,7 +119,8 @@ class StratisInfo(object):
             pool_name = pool_info.name
 
         return StratisBlockdevInfo(path=properties["Devnode"], uuid=properties["Uuid"],
-                                   pool_name=pool_name, pool_uuid=pool_info.uuid)
+                                   pool_name=pool_name, pool_uuid=pool_info.uuid,
+                                   object_path=blockdev_path)
 
     def _get_stratis_info(self):
         self._info_cache = dict()

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
 #
 
+import os
+
 from collections import namedtuple
 
 from .. import safe_dbus
@@ -191,6 +193,21 @@ class StratisInfo(object):
 
     def drop_cache(self):
         self._info_cache = None
+
+    def get_pool_info(self, pool_name):
+        for pool in self.pools.values():
+            if pool.name == pool_name:
+                return pool
+
+    def get_filesystem_info(self, pool_name, fs_name):
+        for fs in self.filesystems.values():
+            if fs.pool_name == pool_name and fs.name == fs_name:
+                return fs
+
+    def get_blockdev_info(self, bd_path):
+        for bd in self.blockdevs.values():
+            if bd.path == bd_path or bd.path == os.path.realpath(bd_path):
+                return bd
 
 
 stratis_info = StratisInfo()

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -20,6 +20,11 @@
 # Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
 #
 
+import gi
+gi.require_version("GLib", "2.0")
+
+from gi.repository import GLib
+
 import os
 
 from collections import namedtuple
@@ -37,13 +42,14 @@ STRATIS_PATH = "/org/storage/stratis2"
 STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool.r1"
 STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
 STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
-STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
+STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties.r4"
 STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r2"
 
 
 StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "object_path", "encrypted"])
 StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "pool_name", "pool_uuid", "object_path"])
 StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
+StratisLockedPoolInfo = namedtuple("StratisLockedPoolInfo", ["uuid", "key_desc", "devices"])
 
 
 class StratisInfo(object):
@@ -134,11 +140,36 @@ class StratisInfo(object):
                                    pool_name=pool_name, pool_uuid=pool_info.uuid,
                                    object_path=blockdev_path)
 
+    def _get_locked_pools_info(self):
+        locked_pools = []
+
+        try:
+            props = safe_dbus.call_sync(STRATIS_SERVICE,
+                                        STRATIS_PATH,
+                                        STRATIS_PROPS_INTF,
+                                        "GetProperties",
+                                        GLib.Variant("(as)", (["LockedPoolsWithDevs"],)))[0]
+        except safe_dbus.DBusCallError as e:
+            log.error("Failed to get list of locked Stratis pools: %s", str(e))
+            return locked_pools
+
+        if props and "LockedPoolsWithDevs" in props.keys():
+            valid, pools_info = props["LockedPoolsWithDevs"]
+            if valid:
+                for pool_uuid in pools_info.keys():
+                    info = StratisLockedPoolInfo(uuid=pool_uuid,
+                                                 key_desc=pools_info[pool_uuid]["key_description"],
+                                                 devices=[d["devnode"] for d in pools_info[pool_uuid]["devs"]])
+                    locked_pools.append(info)
+
+        return locked_pools
+
     def _get_stratis_info(self):
         self._info_cache = dict()
         self._info_cache["pools"] = dict()
         self._info_cache["blockdevs"] = dict()
         self._info_cache["filesystems"] = dict()
+        self._info_cache["locked_pools"] = []
 
         try:
             ret = safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH)
@@ -171,6 +202,8 @@ class StratisInfo(object):
                 if bd_info:
                     self._info_cache["blockdevs"][bd_info.uuid] = bd_info
 
+        self._info_cache["locked_pools"] = self._get_locked_pools_info()
+
     @property
     def pools(self):
         if self._info_cache is None:
@@ -191,6 +224,13 @@ class StratisInfo(object):
             self._get_stratis_info()
 
         return self._info_cache["blockdevs"]
+
+    @property
+    def locked_pools(self):
+        if self._info_cache is None:
+            self._get_stratis_info()
+
+        return self._info_cache["locked_pools"]
 
     def drop_cache(self):
         self._info_cache = None

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -1,0 +1,192 @@
+# stratis_info.py
+# Backend code for populating a DeviceTree.
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+from collections import namedtuple
+
+from .. import safe_dbus
+from ..size import Size
+
+import logging
+log = logging.getLogger("blivet")
+
+
+STRATIS_SERVICE = "org.storage.stratis2"
+STRATIS_PATH = "/org/storage/stratis2"
+STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool"
+STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem"
+STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev"
+STRATIS_PROPS_INTF = STRATIS_SERVICE + ".FetchProperties"
+
+
+StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size"])
+StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "pool_name", "pool_uuid"])
+StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid"])
+
+
+class StratisInfo(object):
+    """ Class to be used as a singleton.
+        Maintains the Stratis devices info cache.
+    """
+
+    def __init__(self):
+        self._info_cache = None
+
+    def _get_pool_info(self, pool_path):
+        try:
+            properties = safe_dbus.get_properties_sync(STRATIS_SERVICE,
+                                                       pool_path,
+                                                       STRATIS_POOL_INTF)[0]
+        except safe_dbus.DBusPropertyError as e:
+            log.error("Error when getting DBus properties of '%s': %s",
+                      pool_path, str(e))
+
+        if not properties:
+            log.error("Failed to get DBus properties of '%s'", pool_path)
+            return None
+
+        all_props = safe_dbus.call_sync(STRATIS_SERVICE,
+                                        pool_path,
+                                        STRATIS_PROPS_INTF,
+                                        "GetAllProperties",
+                                        None)[0]
+        if all_props:
+            valid, pool_size = all_props.get("TotalPhysicalSize",
+                                             (False, "TotalPhysicalSize not available"))
+            if not valid:
+                log.warning("Failed to get Stratis pool physical size for %s: %s",
+                            properties["Name"], pool_size)
+                pool_size = 0
+        else:
+            log.error("Failed to get Stratis pool properties for %s.", properties["Name"])
+            pool_size = 0
+
+        return StratisPoolInfo(name=properties["Name"], uuid=properties["Uuid"],
+                               physical_size=Size(pool_size))
+
+    def _get_filesystem_info(self, filesystem_path):
+        try:
+            properties = safe_dbus.get_properties_sync(STRATIS_SERVICE,
+                                                       filesystem_path,
+                                                       STRATIS_FILESYSTEM_INTF)[0]
+        except safe_dbus.DBusPropertyError as e:
+            log.error("Error when getting DBus properties of '%s': %s",
+                      filesystem_path, str(e))
+
+        if not properties:
+            log.error("Failed to get DBus properties of '%s'", filesystem_path)
+            return None
+
+        pool_info = self._get_pool_info(properties["Pool"])
+        if not pool_info:
+            return None
+
+        return StratisFilesystemInfo(name=properties["Name"], uuid=properties["Uuid"],
+                                     pool_name=pool_info.name, pool_uuid=pool_info.uuid)
+
+    def _get_blockdev_info(self, blockdev_path):
+        try:
+            properties = safe_dbus.get_properties_sync(STRATIS_SERVICE,
+                                                       blockdev_path,
+                                                       STRATIS_BLOCKDEV_INTF)[0]
+        except safe_dbus.DBusPropertyError as e:
+            log.error("Error when getting DBus properties of '%s': %s",
+                      blockdev_path, str(e))
+
+        if not properties:
+            log.error("Failed to get DBus properties of '%s'", blockdev_path)
+            return None
+
+        pool_path = properties["Pool"]
+        if pool_path == "/":
+            pool_name = ""
+        else:
+            pool_info = self._get_pool_info(properties["Pool"])
+            if not pool_info:
+                return None
+            pool_name = pool_info.name
+
+        return StratisBlockdevInfo(path=properties["Devnode"], uuid=properties["Uuid"],
+                                   pool_name=pool_name, pool_uuid=pool_info.uuid)
+
+    def _get_stratis_info(self):
+        self._info_cache = dict()
+        self._info_cache["pools"] = dict()
+        self._info_cache["blockdevs"] = dict()
+        self._info_cache["filesystems"] = dict()
+
+        try:
+            ret = safe_dbus.check_object_available(STRATIS_SERVICE, STRATIS_PATH)
+        except safe_dbus.DBusCallError:
+            log.warning("Stratis DBus service is not running")
+            return
+        else:
+            if not ret:
+                log.warning("Stratis DBus service is not available")
+
+        objects = safe_dbus.call_sync(STRATIS_SERVICE,
+                                      STRATIS_PATH,
+                                      "org.freedesktop.DBus.ObjectManager",
+                                      "GetManagedObjects",
+                                      None)[0]
+
+        for path, interfaces in objects.items():
+            if STRATIS_POOL_INTF in interfaces.keys():
+                pool_info = self._get_pool_info(path)
+                if pool_info:
+                    self._info_cache["pools"][pool_info.uuid] = pool_info
+
+            if STRATIS_FILESYSTEM_INTF in interfaces.keys():
+                fs_info = self._get_filesystem_info(path)
+                if fs_info:
+                    self._info_cache["filesystems"][fs_info.uuid] = fs_info
+
+            if STRATIS_BLOCKDEV_INTF in interfaces.keys():
+                bd_info = self._get_blockdev_info(path)
+                if bd_info:
+                    self._info_cache["blockdevs"][bd_info.uuid] = bd_info
+
+    @property
+    def pools(self):
+        if self._info_cache is None:
+            self._get_stratis_info()
+
+        return self._info_cache["pools"]
+
+    @property
+    def filesystems(self):
+        if self._info_cache is None:
+            self._get_stratis_info()
+
+        return self._info_cache["filesystems"]
+
+    @property
+    def blockdevs(self):
+        if self._info_cache is None:
+            self._get_stratis_info()
+
+        return self._info_cache["blockdevs"]
+
+    def drop_cache(self):
+        self._info_cache = None
+
+
+stratis_info = StratisInfo()

--- a/blivet/tasks/fsmount.py
+++ b/blivet/tasks/fsmount.py
@@ -191,6 +191,10 @@ class SELinuxFSMount(NoDevFSMount):
         return errors
 
 
+class StratisXFSMount(FSMount):
+    fstype = "xfs"
+
+
 class TmpFSMount(NoDevFSMount):
 
     def _modify_options(self, options):

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -1042,10 +1042,10 @@ def device_is_stratis_filesystem(info):
 
 
 def device_is_stratis_private(info):
-    if not device_is_dm_stratis(info):
+    if not (device_is_dm_stratis(info) or device_is_dm_luks(info)):
         return False
     try:
-        return info.get("DM_UUID", "").split("-")[2] == "private"
+        return info.get("DM_NAME", "").split("-")[2] == "private"
     except IndexError:
         return False
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -710,6 +710,11 @@ def device_is_dm_livecd(info):
             device_get_name(info).startswith("live"))
 
 
+def device_is_dm_stratis(info):
+    """ Return True if the device is a Stratis pool or filesystem. """
+    return device_dm_subsystem_match(info, "stratis")
+
+
 def device_is_biosraid_member(info):
     # Note that this function does *not* identify raid sets.
     # Tests to see if device is part of a dmraid set.
@@ -1024,3 +1029,18 @@ def device_is_hidden(info):
         return False
 
     return bool(int(hidden))
+
+
+def device_is_stratis_private(info):
+    if not device_is_dm_stratis(info):
+        return False
+    try:
+        return info.get("DM_UUID", "").split("-")[2] == "private"
+    except IndexError:
+        return False
+
+
+def device_is_private(info):
+    if device_is_dm_stratis(info):
+        return device_is_stratis_private(info)
+    return False

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -373,6 +373,7 @@ def device_is_disk(info):
                  device_is_dm_partition(info) or
                  device_is_dm_lvm(info) or
                  device_is_dm_crypt(info) or
+                 device_is_dm_stratis(info) or
                  (device_is_md(info) and
                   (not device_get_md_container(info) and not all(device_is_disk(d) for d in device_get_parents(info))))))
 
@@ -1029,6 +1030,15 @@ def device_is_hidden(info):
         return False
 
     return bool(int(hidden))
+
+
+def device_is_stratis_filesystem(info):
+    if not device_is_dm_stratis(info):
+        return False
+    try:
+        return info.get("DM_UUID", "").split("-")[4] == "fs"
+    except IndexError:
+        return False
 
 
 def device_is_stratis_private(info):

--- a/doc/api/blivet.rst
+++ b/doc/api/blivet.rst
@@ -48,6 +48,8 @@ blivet
         * :meth:`~blivet.blivet.Blivet.new_lv_from_lvs`
         * :meth:`~blivet.blivet.Blivet.new_mdarray`
         * :meth:`~blivet.blivet.Blivet.new_partition`
+        * :meth:`~blivet.blivet.Blivet.new_stratis_filesystem`
+        * :meth:`~blivet.blivet.Blivet.new_stratis_pool`
         * :meth:`~blivet.blivet.Blivet.new_tmp_fs`
         * :meth:`~blivet.blivet.Blivet.new_vg`
         * :attr:`~blivet.blivet.Blivet.partitioned`
@@ -61,6 +63,7 @@ blivet
         * :meth:`~blivet.blivet.Blivet.save_passphrase`
         * :meth:`~blivet.blivet.Blivet.set_default_fstype`
         * :meth:`~blivet.blivet.Blivet.shutdown`
+        * :attr:`~blivet.blivet.Blivet.stratis_pools`
         * :meth:`~blivet.blivet.Blivet.suggest_container_name`
         * :meth:`~blivet.blivet.Blivet.suggest_device_name`
         * :attr:`~blivet.blivet.Blivet.swaps`
@@ -86,6 +89,7 @@ blivet
     * :const:`~blivet.devicefactory.DEVICE_TYPE_DISK`
     * :const:`~blivet.devicefactory.DEVICE_TYPE_LVM_THINP`
     * :const:`~blivet.devicefactory.DEVICE_TYPE_LVM_VDO`
+    * :const:`~blivet.devicefactory.DEVICE_TYPE_STRATIS`
     * :func:`~blivet.devicefactory.is_supported_device_type`
     * :func:`~blivet.devicefactory.get_device_factory`
     * :func:`~blivet.devicefactory.get_device_type`
@@ -179,6 +183,7 @@ blivet
     * :class:`~blivet.errors.SinglePhysicalVolumeError`
     * :class:`~blivet.errors.SizePlacesError`
     * :class:`~blivet.errors.StorageError`
+    * :class:`~blivet.errors.StratisError`
     * :class:`~blivet.errors.SwapSpaceError`
     * :class:`~blivet.errors.ThreadError`
     * :class:`~blivet.errors.UdevError`

--- a/doc/api/devices.rst
+++ b/doc/api/devices.rst
@@ -137,3 +137,8 @@ devices
         * :attr:`~blivet.devices.storage.StorageDevice.target_size`
         * :meth:`~blivet.devices.storage.StorageDevice.teardown`
         * :attr:`~blivet.devices.storage.StorageDevice.uuid`
+
+* :mod:`~blivet.devices.stratis`
+    * :class:`~blivet.devices.stratis.StratisPoolDevice` (see :ref:`inherited public API <StorageDeviceAPI>`)
+        * :attr:`~blivet.devices.stratis.StratisPoolDevice.encrypted`
+    * :class:`~blivet.devices.stratis.StratisFilesystemDevice` (see :ref:`inherited public API <StorageDeviceAPI>`)

--- a/doc/api/formats.rst
+++ b/doc/api/formats.rst
@@ -110,5 +110,10 @@ formats
 * :mod:`~blivet.formats.prepboot`
     * :class:`~blivet.formats.prepboot.PPCPRePBoot` (see :ref:`inherited public API <DeviceFormatAPI>`)
 
+* :mod:`~blivet.formats.stratis`
+    * :class:`~blivet.formats.stratis.StratisBlockdev` (see :ref:`inherited public API <DeviceFormatAPI>`)
+        * :attr:`~blivet.formats.stratis.StratisBlockdev.has_key`
+        * :meth:`~blivet.formats.stratis.StratisBlockdev.unlock_pool`
+
 * :mod:`~blivet.formats.swap`
     * :class:`~blivet.formats.swap.SwapSpace` (see :ref:`inherited public API <DeviceFormatAPI>`)

--- a/examples/stratis.py
+++ b/examples/stratis.py
@@ -1,0 +1,50 @@
+import os
+
+import blivet
+from blivet.size import Size
+from blivet.util import set_up_logging, create_sparse_tempfile
+
+set_up_logging()
+b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
+
+# create a disk image file on which to create new devices
+disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
+b.disk_images["disk1"] = disk1_file
+disk2_file = create_sparse_tempfile("disk2", Size("100GiB"))
+b.disk_images["disk2"] = disk2_file
+
+b.reset()
+
+try:
+    disk1 = b.devicetree.get_device_by_name("disk1")
+    disk2 = b.devicetree.get_device_by_name("disk2")
+
+    b.initialize_disk(disk1)
+    b.initialize_disk(disk2)
+
+    bd = b.new_partition(size=Size("50GiB"), fmt_type="stratis", parents=[disk1])
+    b.create_device(bd)
+    bd2 = b.new_partition(size=Size("50GiB"), fmt_type="stratis", parents=[disk2])
+    b.create_device(bd2)
+
+    # allocate the partitions (decide where and on which disks they'll reside)
+    blivet.partitioning.do_partitioning(b)
+
+    pool = b.new_stratis_pool(name="stratis_pool", parents=[bd, bd2])
+    b.create_device(pool)
+
+    fs = b.new_stratis_filesystem(name="stratis_filesystem", parents=[pool])
+    b.create_device(fs)
+
+    print(b.devicetree)
+
+    # write the new partitions to disk and format them as specified
+    b.do_it()
+    print(b.devicetree)
+    input("Check the state and hit ENTER to trigger cleanup")
+finally:
+    b.devicetree.recursive_remove(pool)
+    b.do_it()
+    b.devicetree.teardown_disk_images()
+    os.unlink(disk1_file)
+    os.unlink(disk2_file)

--- a/examples/stratis.py
+++ b/examples/stratis.py
@@ -33,6 +33,11 @@ try:
     pool = b.new_stratis_pool(name="stratis_pool", parents=[bd, bd2])
     b.create_device(pool)
 
+    # # encrypted stratis pool can be created by adding "encrypted" and "passphrase"
+    # # keywords, only the entire pool can be encrypted:
+    # pool = b.new_stratis_pool(name="stratis_pool", parents=[bd, bd2], encrypted=True, passphrase="secret")
+    # b.create_device(pool)
+
     fs = b.new_stratis_filesystem(name="stratis_filesystem", parents=[pool])
     b.create_device(fs)
 

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -12,13 +12,14 @@ except ImportError:
 import blivet
 
 from blivet import devicefactory
-from blivet.devicelibs import raid, crypto
+from blivet.devicelibs import raid, crypto, stratis
 from blivet.devices import DiskDevice
 from blivet.devices import DiskFile
 from blivet.devices import LUKSDevice
 from blivet.devices import LVMLogicalVolumeDevice
 from blivet.devices import MDRaidArrayDevice
 from blivet.devices import PartitionDevice
+from blivet.devices import StratisFilesystemDevice
 from blivet.devices.lvm import DEFAULT_THPOOL_RESERVE
 from blivet.errors import RaidError
 from blivet.formats import get_format
@@ -893,3 +894,106 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
         self.assertEqual(factory2.container_list, [])
 
         self.assertIsNone(factory2.get_container())
+
+
+class StratisFactoryTestCase(DeviceFactoryTestCase):
+    device_class = StratisFilesystemDevice
+    device_type = devicefactory.DEVICE_TYPE_STRATIS
+    encryption_supported = False
+    factory_class = devicefactory.StratisFactory
+
+    # pylint: disable=unused-argument
+    def _get_size_delta(self, devices=None):
+        """ Return size delta for a specific factory type.
+
+            :keyword devices: list of factory-managed devices or None
+            :type devices: list(:class:`blivet.devices.StorageDevice`) or NoneType
+        """
+        return Size("2 MiB")
+
+    def _validate_factory_device(self, *args, **kwargs):
+        device = args[0]
+
+        self.assertEqual(device.type, "stratis filesystem")
+        self.assertEqual(device.size, stratis.STRATIS_FS_SIZE)
+        self.assertTrue(hasattr(device, "pool"))
+        self.assertIsNotNone(device.pool)
+        self.assertEqual(device.pool.type, "stratis pool")
+        self.assertIsNotNone(device.format)
+        self.assertEqual(device.format.type, "stratis xfs")
+        self.assertEqual(device.format.mountpoint, kwargs.get("mountpoint"))
+
+        if kwargs.get("name"):
+            self.assertEqual(device.fsname, kwargs.get("name"))
+
+        self.assertTrue(set(device.disks).issubset(kwargs["disks"]))
+
+        if kwargs.get("container_size"):
+            self.assertAlmostEqual(device.pool.size,
+                                   kwargs.get("container_size"),
+                                   delta=self._get_size_delta())
+        else:
+            # if container size is not specified, we'll use all available space (not counting size taken by partitions)
+            self.assertAlmostEqual(device.pool.size,
+                                   sum(d.size - Size("2 MiB") for d in self.b.disks),
+                                   delta=self._get_size_delta())
+
+        return device
+
+    @patch("blivet.devices.stratis.StratisFilesystemDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.stratis.StratisPoolDevice.type_external_dependencies", return_value=set())
+    def test_device_factory(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        device_type = self.device_type
+        kwargs = {"disks": self.b.disks,
+                  "mountpoint": "/factorytest"}
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # rename the device
+        kwargs["name"] = "stratisfs"
+        kwargs["device"] = device
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # new mountpoint
+        kwargs["mountpoint"] = "/a/different/dir"
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # change container size
+        kwargs = {"disks": self.b.disks,
+                  "mountpoint": "/factorytest",
+                  "container_size": Size("2.5 GiB")}
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+    @patch("blivet.devices.stratis.StratisFilesystemDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.stratis.StratisPoolDevice.type_external_dependencies", return_value=set())
+    def test_normalize_size(self, *args):  # pylint: disable=unused-argument
+        # size normalization doesn't make sense for stratis -- filesystems are always 1 TiB
+        pass
+
+    @patch("blivet.devices.stratis.StratisFilesystemDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.stratis.StratisPoolDevice.type_external_dependencies", return_value=set())
+    def test_get_free_disk_space(self, *args):  # pylint: disable=unused-argument
+        # get_free_disk_space should return the total free space on disks
+        kwargs = self._get_test_factory_args()
+        factory = devicefactory.get_device_factory(self.b,
+                                                   self.device_type,
+                                                   disks=self.b.disks,
+                                                   **kwargs)
+        # disks contain empty disklabels, so free space is sum of disk sizes
+        self.assertAlmostEqual(factory._get_free_disk_space(),
+                               sum(d.size for d in self.b.disks),
+                               delta=self._get_size_delta())
+
+        factory.configure()
+        factory = devicefactory.get_device_factory(self.b,
+                                                   self.device_type,
+                                                   disks=self.b.disks,
+                                                   **kwargs)
+        # default container size policy for Stratis factory is SIZE_POLICY_MAX so there should
+        # be (almost) no free space on the disks
+        self.assertAlmostEqual(factory._get_free_disk_space(),
+                               Size("2 MiB"),
+                               delta=self._get_size_delta())

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -938,6 +938,8 @@ class StratisFactoryTestCase(DeviceFactoryTestCase):
                                    sum(d.size - Size("2 MiB") for d in self.b.disks),
                                    delta=self._get_size_delta())
 
+        self.assertEqual(device.pool.encrypted, kwargs.get("container_encrypted", False))
+
         return device
 
     @patch("blivet.devices.stratis.StratisFilesystemDevice.type_external_dependencies", return_value=set())
@@ -964,6 +966,16 @@ class StratisFactoryTestCase(DeviceFactoryTestCase):
         kwargs = {"disks": self.b.disks,
                   "mountpoint": "/factorytest",
                   "container_size": Size("2.5 GiB")}
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # enable encryption on the container
+        kwargs["container_encrypted"] = True
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
+
+        # disable encryption on the container
+        kwargs["container_encrypted"] = False
         device = self._factory_device(device_type, **kwargs)
         self._validate_factory_device(device, device_type, **kwargs)
 

--- a/tests/devices_test/stratis_test.py
+++ b/tests/devices_test/stratis_test.py
@@ -1,6 +1,7 @@
 import test_compat  # pylint: disable=unused-import
 
 import unittest
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 
 import blivet
 
@@ -24,6 +25,8 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
         bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
                            size=Size("1 GiB"), exists=True)
 
+        b.devicetree._add_device(bd)
+
         pool = b.new_stratis_pool(name="testpool", parents=[bd])
         self.assertEqual(pool.name, "testpool")
         self.assertEqual(pool.size, bd.size)
@@ -35,3 +38,51 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
         self.assertEqual(fs.size, Size("1 TiB"))
         self.assertEqual(fs.pool, pool)
         self.assertEqual(fs.format.type, "stratis xfs")
+
+        b.create_device(pool)
+        b.create_device(fs)
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(pool, "_pre_create"):
+                with patch.object(pool, "_post_create"):
+                    pool.create()
+                    stratis_dbus.create_pool.assert_called_with(name='testpool',
+                                                                devices=['/dev/bd1'],
+                                                                encrypted=False,
+                                                                passphrase=None,
+                                                                key_file=None)
+
+        # we would get this from pool._post_create
+        pool.uuid = "c4fc9ebe-e173-4cab-8d81-cc6abddbe02d"
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(fs, "_pre_create"):
+                with patch.object(fs, "_post_create"):
+                    fs.create()
+                    stratis_dbus.create_filesystem.assert_called_with("testfs",
+                                                                      "c4fc9ebe-e173-4cab-8d81-cc6abddbe02d")
+
+    def test_new_encryted_stratis(self):
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("1 GiB"), exists=True)
+
+        b.devicetree._add_device(bd)
+
+        pool = b.new_stratis_pool(name="testpool", parents=[bd], encrypted=True, passphrase="secret")
+        self.assertEqual(pool.name, "testpool")
+        self.assertEqual(pool.size, bd.size)
+        self.assertTrue(pool.encrypted)
+        self.assertTrue(pool.has_key)
+
+        b.create_device(pool)
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(pool, "_pre_create"):
+                with patch.object(pool, "_post_create"):
+                    pool.create()
+                    stratis_dbus.create_pool.assert_called_with(name='testpool',
+                                                                devices=['/dev/bd1'],
+                                                                encrypted=True,
+                                                                passphrase="secret",
+                                                                key_file=None)

--- a/tests/devices_test/stratis_test.py
+++ b/tests/devices_test/stratis_test.py
@@ -1,7 +1,9 @@
-import test_compat  # pylint: disable=unused-import
-
 import unittest
-from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 import blivet
 

--- a/tests/devices_test/stratis_test.py
+++ b/tests/devices_test/stratis_test.py
@@ -1,0 +1,37 @@
+import test_compat  # pylint: disable=unused-import
+
+import unittest
+
+import blivet
+
+from blivet.devices import StorageDevice
+from blivet.devices import StratisPoolDevice
+from blivet.devices import StratisFilesystemDevice
+from blivet.size import Size
+
+
+DEVICE_CLASSES = [
+    StratisPoolDevice,
+    StratisFilesystemDevice,
+    StorageDevice
+]
+
+
+@unittest.skipUnless(not any(x.unavailable_type_dependencies() for x in DEVICE_CLASSES), "some unsupported device classes required for this test")
+class BlivetNewStratisDeviceTest(unittest.TestCase):
+    def test_new_stratis(self):
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("1 GiB"), exists=True)
+
+        pool = b.new_stratis_pool(name="testpool", parents=[bd])
+        self.assertEqual(pool.name, "testpool")
+        self.assertEqual(pool.size, bd.size)
+
+        fs = b.new_stratis_filesystem(name="testfs", parents=[pool])
+
+        self.assertEqual(fs.name, "testpool/testfs")
+        self.assertEqual(fs.path, "/dev/stratis/%s" % fs.name)
+        self.assertEqual(fs.size, Size("1 TiB"))
+        self.assertEqual(fs.pool, pool)
+        self.assertEqual(fs.format.type, "stratis xfs")

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -40,6 +40,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)
     @patch("blivet.udev.device_is_dm_raid", return_value=False)
+    @patch("blivet.udev.device_is_dm_stratis", return_value=False)
     @patch("blivet.udev.device_is_dm", return_value=True)
     def test_match(self, *args):
         """Test matching of dm device populator."""
@@ -60,6 +61,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)
     @patch("blivet.udev.device_is_dm_raid", return_value=False)
+    @patch("blivet.udev.device_is_dm_stratis", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)
     @patch("blivet.udev.device_is_loop", return_value=False)
     @patch("blivet.udev.device_is_dm", return_value=True)


### PR DESCRIPTION
New version of #915 I made some smaller changes in the code, the biggest difference are names of the Stratis devices, I've removed the underscore in `stratis pool` and `stratis filesystem` to make it more consistent with our other names. This now includes support for both "normal" and encrypted pools.

I've also moved this to 3.5-devel to make 3.4.0 release a little bit smaller and to have more time for testing and review here.

You can use blivet-gui for testing (everything except devicefactory support), I have a PR with experimental Stratis support here https://github.com/storaged-project/blivet-gui/pull/277