### PR TITLE
Remove the "encryption_passphrase" attribute from Blivet class

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -62,7 +62,6 @@ class Blivet(object):
         self.do_autopart = False
         self.clear_part_choice = None
         self.encrypted_autopart = False
-        self.encryption_passphrase = None
         self.encryption_cipher = None
         self.escrow_certificates = {}
         self.autopart_escrow_cert = None


### PR DESCRIPTION
We switched "encryption_passphrase" to property in 2.0 but the
removing of the attribute didn't make it to 3.0-devel probably
because of some merge conflict issue between 2.2-devel and
3.0-devel.

Related: https://github.com/storaged-project/blivet/pull/404