### PR TITLE
Add LVM VDO to public API

### DIFF
--- a/doc/api/blivet.rst
+++ b/doc/api/blivet.rst
@@ -85,6 +85,7 @@ blivet
     * :const:`~blivet.devicefactory.DEVICE_TYPE_BTRFS`
     * :const:`~blivet.devicefactory.DEVICE_TYPE_DISK`
     * :const:`~blivet.devicefactory.DEVICE_TYPE_LVM_THINP`
+    * :const:`~blivet.devicefactory.DEVICE_TYPE_LVM_VDO`
     * :func:`~blivet.devicefactory.is_supported_device_type`
     * :func:`~blivet.devicefactory.get_device_factory`
     * :func:`~blivet.devicefactory.get_device_type`

--- a/doc/api/devices.rst
+++ b/doc/api/devices.rst
@@ -54,6 +54,8 @@ devices
         * :attr:`~blivet.devices.lvm.LVMSnapshotMixin.is_snapshot_lv`
         * :attr:`~blivet.devices.lvm.LVMThinLogicalVolumeMixin.is_thin_lv`
         * :attr:`~blivet.devices.lvm.LVMThinPoolMixin.is_thin_pool`
+        * :attr:`~blivet.devices.lvm.LVMVDOLogicalVolumeMixin.is_vdo_lv`
+        * :attr:`~blivet.devices.lvm.LVMVDOPoolMixin.is_vdo_pool`
         * :attr:`~blivet.devices.dm.DMDevice.map_name`
         * :attr:`~blivet.devices.lvm.LVMLogicalVolumeBase.metadata_size`
         * :attr:`~blivet.devices.lvm.LVMLogicalVolumeDevice.vg`


### PR DESCRIPTION
Forgot to add this in the LVM VDO PR. Surprisingly simple API, but based on the other LVM "public API", this is all that's needed.