### PR TITLE
Fix resolving devices with names that look like BIOS drive number

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -634,20 +634,20 @@ class DeviceTreeBase(object):
                     (label.startswith("'") and label.endswith("'"))):
                 label = label[1:-1]
             device = self.labels.get(label)
-        elif re.match(r'(0x)?[A-Fa-f0-9]{2}(p\d+)?$', devspec):
-            # BIOS drive number
-            (drive, _p, partnum) = devspec.partition("p")
-            spec = int(drive, 16)
-            for (edd_name, edd_number) in self.edd_dict.items():
-                if edd_number == spec:
-                    device = self.get_device_by_name(edd_name + partnum)
-                    break
         elif options and "nodev" in options.split(","):
             device = self.get_device_by_name(devspec)
             if not device:
                 device = self.get_device_by_path(devspec)
         else:
-            if not devspec.startswith("/dev/"):
+            if re.match(r'(0x)?[A-Fa-f0-9]{2}(p\d+)?$', devspec):
+                # BIOS drive number
+                (drive, _p, partnum) = devspec.partition("p")
+                spec = int(drive, 16)
+                for (edd_name, edd_number) in self.edd_dict.items():
+                    if edd_number == spec:
+                        device = self.get_device_by_name(edd_name + partnum)
+                        break
+            if not device and not devspec.startswith("/dev/"):
                 device = self.get_device_by_name(devspec)
                 if not device:
                     devspec = "/dev/" + devspec

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -49,6 +49,9 @@ class DeviceTreeTestCase(unittest.TestCase):
         dev3 = StorageDevice("sdp2", exists=True)
         dt._add_device(dev3)
 
+        dev4 = StorageDevice("10", exists=True)
+        dt._add_device(dev4)
+
         dt.edd_dict.update({"dev1": 0x81,
                             "dev2": 0x82})
 
@@ -62,6 +65,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertEqual(dt.resolve_device("0x82"), dev2)
 
         self.assertEqual(dt.resolve_device(dev3.name), dev3)
+        self.assertEqual(dt.resolve_device(dev4.name), dev4)
 
     def test_device_name(self):
         # check that devicetree.names property contains all device's names


### PR DESCRIPTION
A RAID array named "10" will not be resolved because we try to
resolve it using EDD data and after this lookup fails, we don't
try the name.

Resolves: rhbz#1960798