### PR TITLE
Fix activating old style LVM snapshots

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1461,9 +1461,13 @@ class LVMSnapshotMixin(object):
             self._update_format_from_origin()
 
     @old_snapshot_specific
-    def setup(self, orig=False):
-        # the old snapshot cannot be setup and torn down
-        pass
+    def setup(self, orig=False):  # pylint: disable=unused-argument
+        # the old snapshot is activated together with the origin
+        if self.origin and not self.origin.status:
+            try:
+                self.origin.setup()
+            except blockdev.LVMError as lvmerr:
+                log.error("failed to activate origin LV: %s", lvmerr)
 
     @old_snapshot_specific
     def teardown(self, recursive=False):


### PR DESCRIPTION
The old style snapshots are activated together with the origin LV
so we need to make sure it is activated to be able to remove the
snapshot or its format.

Resolves: rhbz#1961739