### PR TITLE
Fix adding/removing devices to the LVM reject filter

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -260,6 +260,7 @@ class ActionList(object):
             log.debug("action: %s", action)
 
             # Remove lvm filters for devices we are operating on
+            lvm.lvm_cc_removeFilterRejectRegexp(action.device.name)
             for device in (d for d in devices if d.depends_on(action.device)):
                 lvm.lvm_cc_removeFilterRejectRegexp(device.name)
 

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -70,8 +70,8 @@ safe_name_characters = "0-9a-zA-Z._-"
 # Theoretically we can handle all that can be handled with the LVM --config
 # argument.  For every time we call an lvm_cc (lvm compose config) funciton
 # we regenerate the config_args with all global info.
-config_args_data = {"filterRejects": [],    # regular expressions to reject.
-                    "filterAccepts": []}   # regexp to accept
+config_args_data = {"filterRejects": set(),    # regular expressions to reject.
+                    "filterAccepts": set()}    # regexp to accept
 
 
 def _set_global_config():
@@ -119,7 +119,7 @@ def needs_config_refresh(fn):
 def lvm_cc_addFilterRejectRegexp(regexp):
     """ Add a regular expression to the --config string."""
     log.debug("lvm filter: adding %s to the reject list", regexp)
-    config_args_data["filterRejects"].append(regexp)
+    config_args_data["filterRejects"].add(regexp)
 
 
 @needs_config_refresh
@@ -128,15 +128,15 @@ def lvm_cc_removeFilterRejectRegexp(regexp):
     log.debug("lvm filter: removing %s from the reject list", regexp)
     try:
         config_args_data["filterRejects"].remove(regexp)
-    except ValueError:
+    except KeyError:
         log.debug("%s wasn't in the reject list", regexp)
         return
 
 
 @needs_config_refresh
 def lvm_cc_resetFilter():
-    config_args_data["filterRejects"] = []
-    config_args_data["filterAccepts"] = []
+    config_args_data["filterRejects"] = set()
+    config_args_data["filterAccepts"] = set()
 
 
 def determine_parent_lv(internal_lv, lvs, lv_info):

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -119,7 +119,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         dt.actions._actions.append(Mock(name="fake action"))
 
         lvm.lvm_cc_addFilterRejectRegexp("xxx")
-        lvm.config_args_data["filterAccepts"].append("yyy")
+        lvm.config_args_data["filterAccepts"].add("yyy")
 
         dt.ignored_disks.append(names[0])
         dt.exclusive_disks.append(names[1])
@@ -138,8 +138,8 @@ class DeviceTreeTestCase(unittest.TestCase):
 
         self.assertEqual(dt._hidden, empty_list)
 
-        self.assertEqual(lvm.config_args_data["filterAccepts"], empty_list)
-        self.assertEqual(lvm.config_args_data["filterRejects"], empty_list)
+        self.assertEqual(lvm.config_args_data["filterAccepts"], set())
+        self.assertEqual(lvm.config_args_data["filterRejects"], set())
 
         self.assertEqual(dt.exclusive_disks, empty_list)
         self.assertEqual(dt.ignored_disks, empty_list)


### PR DESCRIPTION
Because the filter is a list internally we can add a device multiple times to it and remove it only once when we decide to use the device.