### PR TITLE
When sorting devices make sure partitions are sorted correctly

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -42,7 +42,7 @@ from .devicetree import DeviceTree
 from .formats import get_default_filesystem_type
 from .flags import flags
 from .formats import get_format
-from .util import capture_output
+from .util import capture_output, natural_sort_key
 from . import arch
 from . import devicefactory
 from . import __version__
@@ -148,7 +148,7 @@ class Blivet(object):
     def devices(self):
         """ A list of all the devices in the device tree. """
         devices = self.devicetree.devices
-        devices.sort(key=lambda d: d.name)
+        devices.sort(key=natural_sort_key)
         return devices
 
     @property

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -164,7 +164,7 @@ class Device(util.ObjectID):
     @property
     def children(self):
         """List of this device's immediate descendants."""
-        return self._children[:]
+        return sorted(self._children[:], key=util.natural_sort_key)
 
     @property
     def dict(self):

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1131,3 +1131,14 @@ def detect_virt():
         return False
     else:
         return vm[0] in ('qemu', 'kvm', 'xen')
+
+
+def natural_sort_key(device):
+    """ Sorting key for devices which makes sure partitions are sorted in natural
+        way, e.g. 'sda1, sda2, ..., sda10' and not like 'sda1, sda10, sda2, ...'
+    """
+    if device.type == "partition" and device.parted_partition and device.disk:
+        part_num = getattr(device.parted_partition, "number", -1)
+        return [device.disk.name, part_num]
+    else:
+        return [device.name, 0]

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,11 +1,13 @@
 import unittest
 
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, Mock
 except ImportError:
-    from mock import patch
+    from mock import patch, Mock
 
 import blivet
+
+from blivet.devices import PartitionDevice, DiskDevice, StorageDevice
 
 
 class SuggestNameTestCase(unittest.TestCase):
@@ -51,3 +53,33 @@ class SuggestNameTestCase(unittest.TestCase):
         with patch("blivet.devicetree.DeviceTree.names", ["parent-root"]):
             name = b.suggest_device_name(parent=blivet.devices.Device(name="parent"), mountpoint="/")
             self.assertEqual(name, "root00")
+
+
+class SortDevicesTest(unittest.TestCase):
+
+    def test_sort_devices(self):
+        bl = blivet.Blivet()
+
+        disk = DiskDevice("sda", parents=[], size=blivet.size.Size("1 GiB"))
+        bl.devicetree._add_device(disk)
+
+        for i in range(1, 12):
+            part = PartitionDevice(name="sda%d" % i, parents=[disk])
+            part.parents = [disk]
+            part._parted_partition = Mock(number=i)
+            bl.devicetree._add_device(part)
+
+        self.assertEqual([d.name for d in bl.devices],
+                         ["sda"] + ["sda%d" % i for i in range(1, 12)])
+
+        # disk children should be also sorted
+        self.assertEqual([d.name for d in disk.children],
+                         ["sda%d" % i for i in range(1, 12)])
+
+        # add some "extra" devices just to be sure the "non-partition" sort still works
+        bl.devicetree._add_device(StorageDevice("sdb", parents=[]))
+        bl.devicetree._add_device(StorageDevice("nvme0n1", parents=[]))
+        bl.devicetree._add_device(StorageDevice("10", parents=[]))
+
+        self.assertEqual([d.name for d in bl.devices],
+                         ["10", "nvme0n1", "sda"] + ["sda%d" % i for i in range(1, 12)] + ["sdb"])


### PR DESCRIPTION
We need a special sorting key for partitions to make sure they are
sorted like "sda1, sda2, ..., sda10" and not like "sda1, sda10,
sda2, ...".

Resolves: rhbz#1915333

----

When removing a logical partition, the "higher number" partitions are automatically renumbered (e.g. with sda5 and sda6, sda6 becomes sda5 after removing sda5). We have a code to adjust to this behaviour (sorting destroy actions etc.) but it still causes issues for Anaconda when allowing to remove partitions in the UI where Anaconda uses the displayed name to remove the partition which no longer exists in the model. By correctly sorting the partitions we can make sure Anaconda removes them in correct order (see also https://github.com/rhinstaller/anaconda/pull/2755).