### PR TITLE
fix problem:function allocate_partitions threw an exception while adding /boot partitions to a RAID disk

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -764,6 +764,8 @@ def allocate_partitions(storage, disks, partitions, freespace, boot_disk=None):
         growth = 0  # in sectors
         # loop through disks
         for _disk in req_disks:
+            if _disk.path not in disklabels:
+                continue
             disklabel = disklabels[_disk.path]
             best = None
             current_free = free


### PR DESCRIPTION
Fix the problem: when using a RAID disk, an error occurs when creating the /boot partition: `Failed to add new device. Click for details, '/dev/sdb'`, Locate that the code `disklabel = disklabels [_ disk. path]` in the blivet function allocate_partitions does not determine whether _ disk. path is in disklabels. Therefore, if _ disk. path is not in disklabels, python throws an exception, causing the disk partition to fail

bugzilla:#1969283