### PR TITLE
Fix util.virt_detect on Xen

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1130,4 +1130,4 @@ def detect_virt():
     except (safe_dbus.DBusCallError, safe_dbus.DBusPropertyError):
         return False
     else:
-        return vm[0] in ('qemu', 'kvm')
+        return vm[0] in ('qemu', 'kvm', 'xen')


### PR DESCRIPTION
Xen is apparently still alive so we should return True for it too.

-----

Discover by the new Fedora/RHEL tests that run in EC2. I guess we could also adjust the `MiscTest.test_detect_virt` test but I think it makes more sense to return `True` for Xen too.