### PR TITLE
Revert "Use PARTITION_ESP flag for EFIFS partitions (#1930486)"

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -29,13 +29,7 @@ import uuid as uuid_mod
 import random
 import stat
 
-from parted import fileSystemType
-
-try:
-    from parted import PARTITION_ESP
-except ImportError:
-    # this flag is sometimes not available in pyparted, see https://github.com/dcantrell/pyparted/issues/80
-    PARTITION_ESP = 18
+from parted import fileSystemType, PARTITION_BOOT
 
 from ..tasks import fsck
 from ..tasks import fsinfo
@@ -948,7 +942,7 @@ class EFIFS(FATFS):
     _min_size = Size("50 MiB")
     _check = True
     _mount_class = fsmount.EFIFSMount
-    parted_flag = PARTITION_ESP
+    parted_flag = PARTITION_BOOT
 
     @property
     def supported(self):

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -33,7 +33,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
-%global partedver 3.2
+%global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
 %global libblockdevver 2.24


### PR DESCRIPTION
This reverts commit aeffc4d50d5059e6a782ee41ccd49061d28996ab.

Using the correct 0xef partition type for EFI System Partition
unfortunately doesn't work with RaspberryPi so we need to keep
using 0x06 with "normal" boot flag to make it boot.

Resolves: rhbz#1975375