### PR TITLE
Do not set chunk size for RAID 1

### DIFF
--- a/blivet/devicelibs/raid.py
+++ b/blivet/devicelibs/raid.py
@@ -462,6 +462,18 @@ class RAID1(RAIDn):
     def _get_recommended_stride(self, member_count):
         return None
 
+    def get_size(self, member_sizes, num_members=None, chunk_size=None, superblock_size_func=None):
+        if not member_sizes:
+            return Size(0)
+
+        if num_members is None:
+            num_members = len(member_sizes)
+
+        min_size = min(member_sizes)
+        superblock_size = superblock_size_func(min_size)
+        min_data_size = self._trim(min_size - superblock_size, chunk_size)
+        return self.get_net_array_size(num_members, min_data_size)
+
 
 RAID1 = RAID1()
 ALL_LEVELS.add_raid_level(RAID1)

--- a/tests/devices_test/md_test.py
+++ b/tests/devices_test/md_test.py
@@ -1,6 +1,11 @@
 import six
 import unittest
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 import blivet
 
 from blivet.devices import StorageDevice
@@ -27,8 +32,26 @@ class MDRaidArrayDeviceTest(unittest.TestCase):
         raid_array = MDRaidArrayDevice(name="raid", level="raid0", member_devices=2,
                                        total_devices=2, parents=[member1, member2])
 
-        # no chunk_size specified -- default value
+        # no chunk_size specified and RAID0 -- default value
         self.assertEqual(raid_array.chunk_size, mdraid.MD_CHUNK_SIZE)
+
+        with patch("blivet.devices.md.blockdev.md.create") as md_create:
+            raid_array._create()
+            md_create.assert_called_with("/dev/md/raid", "raid0", ["/dev/member1", "/dev/member2"],
+                                         0, version="default", bitmap=False,
+                                         chunk_size=mdraid.MD_CHUNK_SIZE)
+
+        raid_array = MDRaidArrayDevice(name="raid", level="raid1", member_devices=2,
+                                       total_devices=2, parents=[member1, member2])
+
+        # no chunk_size specified and RAID1 -- no chunk size set (0)
+        self.assertEqual(raid_array.chunk_size, Size(0))
+
+        with patch("blivet.devices.md.blockdev.md.create") as md_create:
+            raid_array._create()
+            md_create.assert_called_with("/dev/md/raid", "raid1", ["/dev/member1", "/dev/member2"],
+                                         0, version="default", bitmap=True,
+                                         chunk_size=0)
 
     def test_chunk_size2(self):
 
@@ -40,11 +63,25 @@ class MDRaidArrayDeviceTest(unittest.TestCase):
         raid_array = MDRaidArrayDevice(name="raid", level="raid0", member_devices=2,
                                        total_devices=2, parents=[member1, member2],
                                        chunk_size=Size("1024 KiB"))
-
         self.assertEqual(raid_array.chunk_size, Size("1024 KiB"))
+
+        # for raid0 setting chunk_size = 0 means "default"
+        raid_array.chunk_size = Size(0)
+        self.assertEqual(raid_array.chunk_size, mdraid.MD_CHUNK_SIZE)
 
         with six.assertRaisesRegex(self, ValueError, "new chunk size must be of type Size"):
             raid_array.chunk_size = 1
 
         with six.assertRaisesRegex(self, ValueError, "new chunk size must be multiple of 4 KiB"):
             raid_array.chunk_size = Size("5 KiB")
+
+        with six.assertRaisesRegex(self, ValueError, "specifying chunk size is not allowed for raid1"):
+            MDRaidArrayDevice(name="raid", level="raid1", member_devices=2,
+                              total_devices=2, parents=[member1, member2],
+                              chunk_size=Size("1024 KiB"))
+
+        raid_array = MDRaidArrayDevice(name="raid", level="raid1", member_devices=2,
+                                       total_devices=2, parents=[member1, member2])
+
+        with six.assertRaisesRegex(self, ValueError, "specifying chunk size is not allowed for raid1"):
+            raid_array.chunk_size = Size("512 KiB")


### PR DESCRIPTION
Setting chunk size for RAID 1 doesn't make sense and latest
mdadm started returning error instead of ignoring the --chunk
option when creating an array.

Resolves: rhbz#1987170