### PR TITLE
LVM devices support

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -259,10 +259,9 @@ class ActionList(object):
         for action in self._actions:
             log.debug("action: %s", action)
 
-            # Remove lvm filters for devices we are operating on
-            lvm.lvm_cc_removeFilterRejectRegexp(action.device.name)
             for device in (d for d in devices if d.depends_on(action.device)):
-                lvm.lvm_cc_removeFilterRejectRegexp(device.name)
+                if device.format.type == "lvmpv":
+                    lvm.lvm_devices_add(device.path)
 
     def _post_process(self, devices=None):
         """ Clean up relics from action queue execution. """

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -65,40 +65,29 @@ LVMETAD_SOCKET_PATH = "/run/lvm/lvmetad.socket"
 
 safe_name_characters = "0-9a-zA-Z._-"
 
-# Start config_args handling code
-#
-# Theoretically we can handle all that can be handled with the LVM --config
-# argument.  For every time we call an lvm_cc (lvm compose config) funciton
-# we regenerate the config_args with all global info.
-config_args_data = {"filterRejects": set(),    # regular expressions to reject.
-                    "filterAccepts": set()}    # regexp to accept
+# list of devices that LVM is allowed to use
+# with LVM >= 2.0.13 we'll use this for the --devices option and when creating
+# the /etc/lvm/devices/system.devices file
+# with older versions of LVM we will use this for the --config based filtering
+_lvm_devices = set()
 
 
 def _set_global_config():
     """lvm command accepts lvm.conf type arguments preceded by --config. """
 
-    filter_string = ""
-    rejects = config_args_data["filterRejects"]
-    for reject in rejects:
-        filter_string += ("\"r|/%s$|\"," % reject)
+    device_string = ""
 
-    if filter_string:
-        filter_string = "filter=[%s]" % filter_string.strip(",")
+    # now explicitly "accept" all LVM devices
+    for device in _lvm_devices:
+        device_string += "\"a|%s$|\"," % device
 
-    # XXX consider making /tmp/blivet.lvm.XXXXX, writing an lvm.conf there, and
-    #     setting LVM_SYSTEM_DIR
-    devices_string = 'preferred_names=["^/dev/mapper/", "^/dev/md/", "^/dev/sd"]'
-    if filter_string:
-        devices_string += " %s" % filter_string
+    # now add all devices to the "reject" filter
+    device_string += "\"r|.*|\""
 
-    # for now ignore the LVM devices file and rely on our filters
-    if availability.LVMDEVICES.available:
-        devices_string += " use_devicesfile=0"
+    filter_string = "filter=[%s]" % device_string
 
-    # devices_string can have (inside the brackets) "dir", "scan",
-    # "preferred_names", "filter", "cache_dir", "write_cache_state",
-    # "types", "sysfs_scan", "md_component_detection".  see man lvm.conf.
-    config_string = " devices { %s } " % (devices_string)  # strings can be added
+    config_string = " devices { %s } " % filter_string
+
     if not flags.lvm_metadata_backup:
         config_string += "backup {backup=0 archive=0} "
     if flags.debug:
@@ -120,27 +109,26 @@ def needs_config_refresh(fn):
 
 
 @needs_config_refresh
-def lvm_cc_addFilterRejectRegexp(regexp):
-    """ Add a regular expression to the --config string."""
-    log.debug("lvm filter: adding %s to the reject list", regexp)
-    config_args_data["filterRejects"].add(regexp)
+def lvm_devices_add(path):
+    """ Add a device (PV) to the list of devices LVM is allowed to use """
+    log.debug("lvm filter: device %s added to the list of allowed devices")
+    _lvm_devices.add(path)
 
 
 @needs_config_refresh
-def lvm_cc_removeFilterRejectRegexp(regexp):
-    """ Remove a regular expression from the --config string."""
-    log.debug("lvm filter: removing %s from the reject list", regexp)
+def lvm_devices_remove(path):
+    """ Remove a device (PV) to the list of devices LVM is allowed to use """
+    log.debug("lvm filter: device %s removed from the list of allowed devices")
     try:
-        config_args_data["filterRejects"].remove(regexp)
+        _lvm_devices.remove(path)
     except KeyError:
-        log.debug("%s wasn't in the reject list", regexp)
+        log.debug("%s wasn't in the devices list", path)
         return
 
 
 @needs_config_refresh
-def lvm_cc_resetFilter():
-    config_args_data["filterRejects"] = set()
-    config_args_data["filterAccepts"] = set()
+def lvm_devices_reset():
+    _lvm_devices.clear()
 
 
 def determine_parent_lv(internal_lv, lvs, lv_info):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -274,8 +274,8 @@ class LVMVolumeGroupDevice(ContainerDevice):
         log_method_call(self, self.name, status=self.status)
         if not self.complete:
             for pv in self.pvs:
-                # Remove the PVs from the ignore filter so we can wipe them.
-                lvm.lvm_cc_removeFilterRejectRegexp(pv.name)
+                # add PVS to the list of LVM devices so we can wipe them.
+                lvm.lvm_devices_add(pv.path)
 
             # Don't run vgremove or vgreduce since there may be another VG with
             # the same name that we want to keep/use.

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -96,7 +96,7 @@ class DeviceTreeBase(object):
 
         self._hidden = []
 
-        lvm.lvm_cc_resetFilter()
+        lvm.lvm_devices_reset()
 
         self.exclusive_disks = exclusive_disks or []
         self.ignored_disks = ignored_disks or []
@@ -879,7 +879,8 @@ class DeviceTreeBase(object):
         self._remove_device(device, force=True, modparent=False)
 
         self._hidden.append(device)
-        lvm.lvm_cc_addFilterRejectRegexp(device.name)
+        if device.format.type == "lvmpv":
+            lvm.lvm_devices_remove(device.path)
 
     def unhide(self, device):
         """ Restore a device's visibility.
@@ -905,7 +906,8 @@ class DeviceTreeBase(object):
                 self._hidden.remove(hidden)
                 self._devices.append(hidden)
                 hidden.add_hook(new=False)
-                lvm.lvm_cc_removeFilterRejectRegexp(hidden.name)
+                if hidden.format.type == "lvmpv":
+                    lvm.lvm_devices_add(hidden.path)
 
     def expand_taglist(self, taglist):
         """ Expands tags in input list into devices.

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -131,6 +131,9 @@ class LVMPhysicalVolume(DeviceFormat):
         ea_yes = blockdev.ExtraArg.new("-y", "")
         blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
 
+        if lvm.HAVE_LVMDEVICES:
+            blockdev.lvm.devices_add(self.device)
+
     def _destroy(self, **kwargs):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
@@ -141,6 +144,8 @@ class LVMPhysicalVolume(DeviceFormat):
         finally:
             lvm.lvm_devices_remove(self.device)
             udev.settle()
+            if lvm.HAVE_LVMDEVICES:
+                blockdev.lvm.devices_delete(self.device)
 
     @property
     def destroyable(self):

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -132,7 +132,10 @@ class LVMPhysicalVolume(DeviceFormat):
         blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
 
         if lvm.HAVE_LVMDEVICES:
-            blockdev.lvm.devices_add(self.device)
+            try:
+                blockdev.lvm.devices_add(self.device)
+            except blockdev.LVMError as e:
+                log.debug("Failed to add newly created PV %s to the LVM devices file: %s", self.device, str(e))
 
     def _destroy(self, **kwargs):
         log_method_call(self, device=self.device,
@@ -145,7 +148,10 @@ class LVMPhysicalVolume(DeviceFormat):
             lvm.lvm_devices_remove(self.device)
             udev.settle()
             if lvm.HAVE_LVMDEVICES:
-                blockdev.lvm.devices_delete(self.device)
+                try:
+                    blockdev.lvm.devices_delete(self.device)
+                except blockdev.LVMError as e:
+                    log.debug("Failed to remove PV %s from the LVM devices file: %s", self.device, str(e))
 
     @property
     def destroyable(self):

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -124,6 +124,7 @@ class LVMPhysicalVolume(DeviceFormat):
     def _create(self, **kwargs):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
+        lvm.lvm_devices_add(self.device)
 
         lvm._set_global_config()
 
@@ -138,6 +139,7 @@ class LVMPhysicalVolume(DeviceFormat):
         except blockdev.LVMError:
             DeviceFormat._destroy(self, **kwargs)
         finally:
+            lvm.lvm_devices_remove(self.device)
             udev.settle()
 
     @property

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -87,6 +87,12 @@ class LVMFormatPopulator(FormatPopulator):
     def _get_kwargs(self):
         kwargs = super(LVMFormatPopulator, self)._get_kwargs()
 
+        # new PV, add it to the LVM devices list and re-run pvs/lvs/vgs
+        lvm.lvm_devices_add(self.device.path)
+        pvs_info.drop_cache()
+        vgs_info.drop_cache()
+        lvs_info.drop_cache()
+
         pv_info = pvs_info.cache.get(self.device.path, None)
 
         name = udev.device_get_name(self.data)

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -24,7 +24,6 @@ import copy
 import six
 
 from ... import udev
-from ...devicelibs import lvm
 from ...devices import PartitionDevice
 from ...errors import DeviceError
 from ...formats import get_format
@@ -66,7 +65,6 @@ class PartitionDevicePopulator(DevicePopulator):
         if disk is None:
             # if the disk is still not in the tree something has gone wrong
             log.error("failure finding disk for %s", name)
-            lvm.lvm_cc_addFilterRejectRegexp(name)
             return
 
         if not disk.partitioned or not disk.format.supported:
@@ -78,12 +76,6 @@ class PartitionDevicePopulator(DevicePopulator):
             # and instantiate a PartitionDevice so our view of the layout is
             # complete.
             if not disk.partitionable or disk.format.type == "iso9660" or disk.format.hidden:
-                # there's no need to filter partitions on members of multipaths or
-                # fwraid members from lvm since multipath and dmraid are already
-                # active and lvm should therefore know to ignore them
-                if not disk.format.hidden:
-                    lvm.lvm_cc_addFilterRejectRegexp(name)
-
                 log.debug("ignoring partition %s on %s", name, disk.format.type)
                 return
 

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -317,10 +317,10 @@ class PopulatorMixin(object):
                 continue
 
             # Make sure lvm doesn't get confused by PVs that belong to
-            # incomplete VGs. We will remove the PVs from the reject list when/if
+            # incomplete VGs. We will add the PVs to the accept list when/if
             # the time comes to remove the incomplete VG and its PVs.
             for pv in vg.pvs:
-                lvm.lvm_cc_addFilterRejectRegexp(pv.name)
+                lvm.lvm_devices_remove(pv.path)
 
     def set_disk_images(self, images):
         """ Set the disk images and reflect them in exclusive_disks.

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -897,6 +897,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         device = Mock()
         device.parents = []
         device.size = Size("10g")
+        device.path = "/dev/sda1"
         devicetree._add_device(device)
 
         # pylint: disable=attribute-defined-outside-init
@@ -924,15 +925,13 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         pv_info.pe_start = 0
         pv_info.pv_free = 0
 
-        device.path = sentinel.pv_path
-
         vg_device = Mock()
         vg_device.parents = []
         vg_device.lvs = []
         get_device_by_uuid.return_value = vg_device
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
-            mock_pvs_cache.return_value = {sentinel.pv_path: pv_info}
+            mock_pvs_cache.return_value = {device.path: pv_info}
             with patch("blivet.udev.device_get_format", return_value=self.udev_type):
                 helper = self.helper_class(devicetree, data, device)
                 self.assertFalse(device in vg_device.parents)
@@ -957,7 +956,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         pv_info.vg_pv_count = 1
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
-            mock_pvs_cache.return_value = {sentinel.pv_path: pv_info}
+            mock_pvs_cache.return_value = {device.path: pv_info}
             with patch("blivet.static_data.lvm_info.VGsInfo.cache", new_callable=PropertyMock) as mock_vgs_cache:
                 mock_vgs_cache.return_value = {pv_info.vg_uuid: Mock()}
                 with patch("blivet.udev.device_get_format", return_value=self.udev_type):
@@ -1007,7 +1006,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         get_device_by_uuid.side_effect = gdbu
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
-            mock_pvs_cache.return_value = {sentinel.pv_path: pv_info}
+            mock_pvs_cache.return_value = {device.path: pv_info}
             with patch("blivet.static_data.lvm_info.VGsInfo.cache", new_callable=PropertyMock) as mock_vgs_cache:
                 mock_vgs_cache.return_value = {pv_info.vg_uuid: Mock()}
                 with patch("blivet.static_data.lvm_info.LVsInfo.cache", new_callable=PropertyMock) as mock_lvs_cache:

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -13,6 +13,7 @@ from gi.repository import BlockDev as blockdev
 from blivet.devices import DiskDevice, DMDevice, FileDevice, LoopDevice
 from blivet.devices import MDRaidArrayDevice, MultipathDevice, OpticalDevice
 from blivet.devices import PartitionDevice, StorageDevice, NVDIMMNamespaceDevice
+from blivet.devicelibs import lvm
 from blivet.devicetree import DeviceTree
 from blivet.formats import get_device_format_class, get_format, DeviceFormat
 from blivet.formats.disklabel import DiskLabel
@@ -393,8 +394,7 @@ class PartitionDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch.object(DiskLabel, "parted_disk")
     @patch.object(DiskLabel, "parted_device")
     @patch.object(PartitionDevice, "probe")
-    # TODO: fix the naming of the lvm filter functions
-    @patch("blivet.devicelibs.lvm.lvm_cc_addFilterRejectRegexp")
+    @patch("blivet.devicelibs.lvm.lvm_devices_add")
     @patch("blivet.udev.device_get_major", return_value=88)
     @patch("blivet.udev.device_get_minor", return_value=19)
     @patch.object(DeviceTree, "get_device_by_name")
@@ -972,6 +972,8 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
                     vg_device = devicetree.get_device_by_name(pv_info.vg_name)
                     self.assertTrue(vg_device is not None)
                     devicetree._remove_device(vg_device)
+
+                    self.assertIn(device.path, lvm._lvm_devices)
 
         get_device_by_uuid.reset_mock()
 


### PR DESCRIPTION
Work in progress version of the LVM devices file and "filtering" support (check [lvmdevices manpage](https://man7.org/linux/man-pages/man8/lvmdevices.8.html) for more information about this new LVM feature).

Because we need to support the "old" lvm.conf based filtering too (the new LVM devices feature is currently available only on CentOS/RHEL 9) the first commit switches from the existing *reject* based filtering to *accept* based. This is the biggest change in this PR, the LVM devices support itself is just about switching from calling LVM with `--config devices` to `--devices`. Libblockdev support needs to merged first, see https://github.com/storaged-project/libblockdev/pull/646