### PR TITLE
Improve error message printed for missing dependecies

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -173,7 +173,7 @@ class DeviceAction(util.ObjectID):
     def _check_device_dependencies(self):
         unavailable_dependencies = self.device.unavailable_dependencies
         if unavailable_dependencies:
-            dependencies_str = ", ".join(str(d) for d in unavailable_dependencies)
+            dependencies_str = ", ".join("%s:\n%s" % (str(d), ", ".join(d.availability_errors)) for d in unavailable_dependencies)
             raise DependencyError("device type %s requires unavailable_dependencies: %s" % (self.device.type, dependencies_str))
 
     def apply(self):

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -224,7 +224,7 @@ class BlockDevMethod(Method):
             try:
                 self._tech_info.check_fn(tech, mode)
             except GLib.GError as e:
-                errors.append(str(e))
+                errors.append("%s: %s" % (tech.value_name, e.message))
         return errors
 
     def availability_errors(self, resource):
@@ -242,7 +242,7 @@ class BlockDevMethod(Method):
             tech_missing = self._check_technologies()
             if tech_missing:
                 return ["libblockdev plugin %s is loaded but some required "
-                        "technologies are not available:\n%s" % (self._tech_info.plugin_name, tech_missing)]
+                        "technologies are not available (%s)" % (self._tech_info.plugin_name, "; ".join(tech_missing))]
             else:
                 return []
 


### PR DESCRIPTION
The existing error message can be confusing for people that don't
know internals of blivet and libblockdev and the information what
is actually broken or not installed on the system is missing
completely. Example for LVM VDO with missing kvdo module:

Before:

device type lvmvdopool requires unavailable_dependencies:
libblockdev lvm plugin (vdo technology)

After:

device type lvmvdopool requires unavailable_dependencies:
libblockdev lvm plugin (vdo technology):
libblockdev plugin lvm is loaded but some required technologies
are not available (BD_LVM_TECH_VDO: Kernel module 'kvdo' not
available)