### PR TITLE
Fix ActionRemoveMember requires check (#1993655)

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -1031,7 +1031,7 @@ class ActionRemoveMember(DeviceAction):
                 - any destroy/resize action on the device
         """
         retval = False
-        if ((action.is_shrink or action.is_destroy) and
+        if ((action.is_shrink or action.is_destroy) and hasattr(action.device, "container") and
                 action.device.container == self.container):
             retval = True
         elif action.is_add and action.container == self.container:


### PR DESCRIPTION
The check fails for actions with devices that don't have
a container, e.g. when removing a partition and also removing
a member from a container.