### PR TITLE
Do not use FS.mount for btrfs temporary mounts

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -123,7 +123,7 @@ class BTRFSDevice(StorageDevice):
         else:
             tmpdir = tempfile.mkdtemp(prefix=self._temp_dir_prefix)
             try:
-                fmt.mount(mountpoint=tmpdir)
+                util.mount(device=fmt.device, mountpoint=tmpdir, fstype=fmt.type)
             except errors.FSError as e:
                 log.debug("btrfs temp mount failed: %s", e)
                 raise


### PR DESCRIPTION
The FS.mount/setup does additional things, notably setting SELinux
context when running in the installer mode, which we don't want to
do when mounting the btrfs volume just to get list of subvolumes.