### PR TITLE
Distutils deprecation

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -30,7 +30,6 @@ import shutil
 import time
 import itertools
 from collections import namedtuple
-from distutils.spawn import find_executable
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -61,7 +60,7 @@ def has_iscsi():
         return False
 
     if not ISCSID:
-        location = find_executable("iscsid")
+        location = shutil.which("iscsid")
         if not location:
             return False
         ISCSID = location
@@ -380,7 +379,7 @@ class iSCSI(object):
         util.run_program(['modprobe', '-a'] + ISCSI_MODULES)
         # iscsiuio is needed by Broadcom offload cards (bnx2i). Currently
         # not present in iscsi-initiator-utils for Fedora.
-        iscsiuio = find_executable('iscsiuio')
+        iscsiuio = shutil.which('iscsiuio')
         if iscsiuio:
             log.debug("iscsi: iscsiuio is at %s", iscsiuio)
             util.run_program([iscsiuio])

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -20,7 +20,7 @@
 # Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
 
 import abc
-from distutils.spawn import find_executable
+import shutil
 
 from six import add_metaclass
 
@@ -121,7 +121,7 @@ class Path(Method):
             :returns: [] if the name of the application is in the path
             :rtype: list of str
         """
-        if not find_executable(resource.name):
+        if not shutil.which(resource.name):
             return ["application %s is not in $PATH" % resource.name]
         else:
             return []

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
 
-import setuptools  # pylint: disable=unused-import
-from distutils.core import setup
-from distutils import filelist
-from distutils.command.sdist import sdist
+import setuptools
+from setuptools import setup
+from setuptools.command.sdist import sdist
 import subprocess
 import sys
 import os
@@ -40,7 +39,7 @@ def findall(dirname=os.curdir):
 
     return file_list
 
-filelist.findall = findall
+setuptools.findall = findall
 
 # Extend the sdist command
 class blivet_sdist(sdist):


### PR DESCRIPTION
We have some hacks in `setup.py` so it's possible this breaks *something* but everything I was able to manually test seems to be working. I guess we won't be sure until next upstream release.