### PR TITLE
Do not add device name as a parameter for errors.DeviceError

### DIFF
--- a/blivet/devices/container.py
+++ b/blivet/devices/container.py
@@ -146,7 +146,7 @@ class ContainerDevice(StorageDevice):
             This method writes the member addition to disk.
         """
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         error = self._verify_member_uuid(member, expect_equality=False)
         if error:
@@ -179,7 +179,7 @@ class ContainerDevice(StorageDevice):
         """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         error = self._verify_member_uuid(member, require_existence=False)
         if error:

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -141,7 +141,7 @@ class DiskDevice(StorageDevice):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
         if not self.media_present:
-            raise errors.DeviceError("cannot destroy disk with no media", self.name)
+            raise errors.DeviceError("cannot destroy disk with no media")
 
         StorageDevice._pre_destroy(self)
 

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -124,7 +124,7 @@ class DMDevice(StorageDevice):
         """ Return the dm-X (eg: dm-0) device node for this device. """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         return blockdev.dm.node_from_name(self.name)
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -203,7 +203,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ Update this device's sysfs path. """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         self.sysfs_path = ''
 
@@ -244,7 +244,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
     def _pre_setup(self, orig=False):
         if self.exists and not self.complete:
-            raise errors.DeviceError("cannot activate VG with missing PV(s)", self.name)
+            raise errors.DeviceError("cannot activate VG %s -- some of its PVs are missing" % self.name)
         return StorageDevice._pre_setup(self, orig=orig)
 
     def _teardown(self, recursive=None):
@@ -313,7 +313,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
         # verify we have the space, then add it
         # do not verify for growing vg (because of ks)
         if not lv.exists and not self.growable and not (lv.is_thin_lv or lv.is_vdo_lv) and lv.size > self.free_space:
-            raise errors.DeviceError("new lv is too large to fit in free space", self.name)
+            raise errors.DeviceError("new lv is too large to fit in free space")
 
         log.debug("Adding %s/%s to %s", lv.name, lv.size, self.name)
         self._lvs.append(lv)
@@ -971,7 +971,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         """ Return the dm-X (eg: dm-0) device node for this device. """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         return blockdev.dm.node_from_name(self.map_name)
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -331,7 +331,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         """ This array's mdadm.conf entry. """
         uuid = self.mdadm_format_uuid
         if self.member_devices is None or not uuid:
-            raise errors.DeviceError("array is not fully defined", self.name)
+            raise errors.DeviceError("array %s is not fully defined" % self.name)
 
         fmt = "ARRAY %s level=%s num-devices=%d UUID=%s\n"
         return fmt % (self.path, self.level, self.member_devices, uuid)
@@ -694,7 +694,7 @@ class MDContainerDevice(MDRaidArrayDevice):
     def mdadm_conf_entry(self):
         uuid = self.mdadm_format_uuid
         if not uuid:
-            raise errors.DeviceError("array is not fully defined", self.name)
+            raise errors.DeviceError("array %s is not fully defined" % self.name)
 
         return "ARRAY %s UUID=%s\n" % (self.path, uuid)
 
@@ -770,7 +770,7 @@ class MDBiosRaidArrayDevice(MDRaidArrayDevice):
     def mdadm_conf_entry(self):
         uuid = self.mdadm_format_uuid
         if not uuid:
-            raise errors.DeviceError("array is not fully defined", self.name)
+            raise errors.DeviceError("array %s is not fully defined" % self.name)
 
         return "ARRAY %s UUID=%s\n" % (self.path, uuid)
 

--- a/blivet/devices/optical.py
+++ b/blivet/devices/optical.py
@@ -54,7 +54,7 @@ class OpticalDevice(StorageDevice):
         """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         try:
             fd = os.open(self.path, os.O_RDONLY)
@@ -72,7 +72,7 @@ class OpticalDevice(StorageDevice):
         """ Eject the drawer. """
         log_method_call(self, self.name, status=self.status)
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         # try to umount and close device before ejecting
         self.teardown()

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -185,7 +185,7 @@ class PartitionDevice(StorageDevice):
             self._parted_partition = self.disk.format.parted_disk.getPartitionByPath(self.path)
             if not self._parted_partition:
                 self.parents = []
-                raise errors.DeviceError("cannot find parted partition instance", self.name)
+                raise errors.DeviceError("cannot find parted partition instance for %s" % self.name)
 
             self._orig_path = self.path
             # collect information about the partition from parted
@@ -493,7 +493,7 @@ class PartitionDevice(StorageDevice):
                 else:
                     self.unset_flag(parted.PARTITION_BOOT)
             else:
-                raise errors.DeviceError("boot flag not available for this partition", self.name)
+                raise errors.DeviceError("boot flag not available for this partition")
 
             self._bootable = bootable
         else:
@@ -743,7 +743,7 @@ class PartitionDevice(StorageDevice):
 
     def _pre_resize(self):
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         # don't teardown when resizing luks
         if self.format.type == "luks" and self.children:

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -308,7 +308,7 @@ class StorageDevice(Device):
         # this method.
         log_method_call(self, self.name, status=os.path.exists(self.path))
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         try:
             udev_device = pyudev.Devices.from_device_file(udev.global_udev,
@@ -404,7 +404,7 @@ class StorageDevice(Device):
             Return True if setup should proceed or False if not.
         """
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         if self.status or not self.controllable:
             return False
@@ -442,7 +442,7 @@ class StorageDevice(Device):
             Return True if teardown should proceed or False if not.
         """
         if not self.exists and not recursive:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         if not self.status or not self.controllable or self.protected:
             return False
@@ -479,7 +479,7 @@ class StorageDevice(Device):
     def _pre_create(self):
         """ Preparation and pre-condition checking for device creation. """
         if self.exists:
-            raise errors.DeviceError("device has already been created", self.name)
+            raise errors.DeviceError("device has already been created")
 
         self.setup_parents()
 
@@ -511,10 +511,10 @@ class StorageDevice(Device):
     def _pre_destroy(self):
         """ Preparation and precondition checking for device destruction. """
         if not self.exists:
-            raise errors.DeviceError("device has not been created", self.name)
+            raise errors.DeviceError("device has not been created")
 
         if not self.isleaf:
-            raise errors.DeviceError("Cannot destroy non-leaf device", self.name)
+            raise errors.DeviceError("Cannot destroy non-leaf device %s" % self.name)
 
         self.teardown()
 


### PR DESCRIPTION
DeviceError doesn't expect additional arguments which leads to the
exception message being tuple of (msg, name) instead of a simple
string.

------

I've tried to find out why the name is added for some `DeviceError`s, but as far as I can tell it never expected device name as a second parameter. We have some exceptions like that (notably `UnusableConfigurationError`, but not `DeviceError`). I added the name to the exception string where it makes sense and for most calls it's also logged by `log_method_call` so we shouldn't lose any information. Feel free to suggest better messages for the exceptions.