### PR TITLE
Remove unused flag multipath

### DIFF
--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -46,7 +46,6 @@ class Flags(object):
         else:
             self.selinux = selinux.is_selinux_enabled()
 
-        self.multipath = True
         self.dmraid = True
         self.ibft = True
         self.noiswmd = False


### PR DESCRIPTION
We are not using the flag internally and Anaconda is not setting it, see also https://github.com/rhinstaller/anaconda/pull/3586#issuecomment-910462263