### PR TITLE
Do not raise deprecated IOError from iscsi and fcoe modules

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -307,3 +307,13 @@ class EventHandlingError(StorageError):
 
 class ThreadError(StorageError):
     """ An error occurred in a non-main thread. """
+
+# other
+
+
+class FCoEError(StorageError, OSError):
+    pass
+
+
+class ISCSIError(StorageError, OSError):
+    pass

--- a/blivet/fcoe.py
+++ b/blivet/fcoe.py
@@ -18,6 +18,7 @@
 #
 
 import os
+from . import errors
 from . import udev
 from . import util
 import logging
@@ -118,7 +119,7 @@ class FCoE(object):
            Returns error message, or empty string if succeeded.
         """
         if not has_fcoe():
-            raise IOError(_("FCoE not available"))
+            raise errors.FCoEError(_("FCoE not available"))
 
         log.info("Activating FCoE SAN attached to %s, dcb: %s autovlan: %s",
                  nic, dcb, auto_vlan)

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from . import errors
 from . import udev
 from . import util
 from .flags import flags
@@ -410,7 +411,7 @@ class iSCSI(object):
         """
 
         if not has_iscsi():
-            raise IOError(_("iSCSI not available"))
+            raise errors.ISCSIError(_("iSCSI not available"))
         if self._initiator == "":
             raise ValueError(_("No initiator name set"))
 
@@ -530,7 +531,7 @@ class iSCSI(object):
         found_nodes = self.discover(ipaddr, port, discover_user, discover_pw,
                                     discover_user_in, discover_pw_in)
         if found_nodes is None:
-            raise IOError(_("No iSCSI nodes discovered"))
+            raise errors.ISCSIError(_("No iSCSI nodes discovered"))
 
         for node in found_nodes:
             if target and target != node.name:
@@ -550,10 +551,10 @@ class iSCSI(object):
                 logged_in = logged_in + 1
 
         if found == 0:
-            raise IOError(_("No new iSCSI nodes discovered"))
+            raise errors.ISCSIError(_("No new iSCSI nodes discovered"))
 
         if logged_in == 0:
-            raise IOError(_("Could not log in to any of the discovered nodes"))
+            raise errors.ISCSIError(_("Could not log in to any of the discovered nodes"))
 
         self.stabilize()
 


### PR DESCRIPTION
IOError is now deprecated and only an alias to OSError. Raising
IOError doesn't really makes sense for our use cases so we are
replacing it with custom FCoE/ISCSIError exceptions that are also
subclasses of OSError to keep backward compatibility.

Fixes: #944