### PR TITLE
Set correct map name for existing LUKS devices

### DIFF
--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -73,7 +73,13 @@ class LUKSFormatPopulator(FormatPopulator):
 
     def _get_kwargs(self):
         kwargs = super(LUKSFormatPopulator, self)._get_kwargs()
-        kwargs["name"] = "luks-%s" % udev.device_get_uuid(self.data)
+
+        holders = udev.device_get_holders(self.data)
+        if holders:
+            kwargs["name"] = udev.device_get_name(holders[0])
+        else:
+            kwargs["name"] = "luks-%s" % udev.device_get_uuid(self.data)
+
         kwargs["luks_version"] = "luks%s" % udev.device_get_format_version(self.data)
         return kwargs
 

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -55,6 +55,20 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.fmt.update_size_info()
         self.assertEqual(self.fmt.current_size, new_size)
 
+    def test_map_name(self):
+        self.fmt.device = self.loop_devices[0]
+
+        # create and open the luks format
+        self.fmt.create()
+        self.fmt.setup()
+        self.addCleanup(self._luks_close)
+
+        self.assertEqual(self.fmt.map_name, "luks-%s" % self.fmt.uuid)
+        self.assertTrue(self.fmt.status)
+
+        self.fmt.teardown()
+        self.assertFalse(self.fmt.status)
+
     def _luks_close(self):
         self.fmt.teardown()
 


### PR DESCRIPTION
We assume that all LUKS device are named luks-<UUID>. This is true
for devices activated by us or UDisks, but manually opened devices
can have a different name. This change uses sysfs holders to check
the "real" name for opened LUKS devices and makes sure we always
set correct state for the LUKS format based on the name (we check
whether /dev/mapper/<map_name> exists when checking whether the
LUKS format is active or not).