### PR TITLE
Add support for creating standalone integrity devices

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -132,6 +132,10 @@ class LUKSError(DeviceFormatError):
     pass
 
 
+class IntegrityError(LUKSError):
+    pass
+
+
 class MDMemberError(DeviceFormatError):
     pass
 

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -332,6 +332,13 @@ BLOCKDEV_CRYPTO = BlockDevTechInfo(plugin_name="crypto",
                                                  blockdev.CryptoTech.ESCROW: blockdev.CryptoTechMode.CREATE})
 BLOCKDEV_CRYPTO_TECH = BlockDevMethod(BLOCKDEV_CRYPTO)
 
+BLOCKDEV_CRYPTO_INTEGRITY = BlockDevTechInfo(plugin_name="crypto",
+                                             check_fn=blockdev.crypto_is_tech_avail,
+                                             technologies={blockdev.CryptoTech.INTEGRITY: (blockdev.CryptoTechMode.CREATE |
+                                                                                           blockdev.CryptoTechMode.OPEN_CLOSE |
+                                                                                           blockdev.CryptoTechMode.QUERY)})
+BLOCKDEV_CRYPTO_TECH_INTEGRITY = BlockDevMethod(BLOCKDEV_CRYPTO_INTEGRITY)
+
 # libblockdev dm plugin required technologies and modes
 BLOCKDEV_DM_ALL_MODES = (blockdev.DMTechMode.CREATE_ACTIVATE |
                          blockdev.DMTechMode.REMOVE_DEACTIVATE |
@@ -419,6 +426,8 @@ BLOCKDEV_SWAP_TECH = BlockDevMethod(BLOCKDEV_SWAP)
 # due to missing dependencies)
 BLOCKDEV_BTRFS_PLUGIN = blockdev_plugin("libblockdev btrfs plugin", BLOCKDEV_BTRFS_TECH)
 BLOCKDEV_CRYPTO_PLUGIN = blockdev_plugin("libblockdev crypto plugin", BLOCKDEV_CRYPTO_TECH)
+BLOCKDEV_CRYPTO_PLUGIN_INTEGRITY = blockdev_plugin("libblockdev crypto plugin (integrity technology)",
+                                                   BLOCKDEV_CRYPTO_TECH_INTEGRITY)
 BLOCKDEV_DM_PLUGIN = blockdev_plugin("libblockdev dm plugin", BLOCKDEV_DM_TECH)
 BLOCKDEV_DM_PLUGIN_RAID = blockdev_plugin("libblockdev dm plugin (raid technology)", BLOCKDEV_DM_TECH_RAID)
 BLOCKDEV_LOOP_PLUGIN = blockdev_plugin("libblockdev loop plugin", BLOCKDEV_LOOP_TECH)

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -3,10 +3,11 @@ try:
 except ImportError:
     from mock import patch
 
+import os
 import unittest
 
-from blivet.formats.luks import LUKS
-
+from blivet.formats.luks import LUKS, Integrity
+from blivet.devicelibs import crypto
 from blivet.size import Size
 
 from . import loopbackedtestcase
@@ -125,3 +126,24 @@ class LUKSNodevTestCase(unittest.TestCase):
 
         fmt = LUKS(luks_version="luks2", luks_sector_size=4096)
         self.assertEqual(fmt.luks_sector_size, 4096)
+
+
+@unittest.skipUnless(Integrity._plugin.available, "Integrity support not available")
+class IntegrityTestCase(loopbackedtestcase.LoopBackedTestCase):
+
+    def __init__(self, methodName='run_test'):
+        super(IntegrityTestCase, self).__init__(methodName=methodName, device_spec=[Size("100 MiB")])
+
+    def test_integrity(self):
+        fmt = Integrity(device=self.loop_devices[0])
+        self.assertEqual(fmt.algorithm, crypto.DEFAULT_INTEGRITY_ALGORITHM)
+
+        # create and open the integrity format
+        fmt.create()
+        fmt.setup()
+        self.assertTrue(fmt.status)
+        self.assertTrue(os.path.exists("/dev/mapper/%s" % fmt.map_name))
+
+        fmt.teardown()
+        self.assertFalse(fmt.status)
+        self.assertFalse(os.path.exists("/dev/mapper/%s" % fmt.map_name))


### PR DESCRIPTION
Advanced options for the integrity format are not support, users
can choose only the integrity algorithm (HMAC is not supported)
and sector size.

Depends on https://github.com/storaged-project/libblockdev/pull/663 (but if the `availability` code works we don't need the new version of libblockdev to merge this).