### PR TITLE
tests: Mark "fake" disks in test_get_related_disks as non-existing

### DIFF
--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -408,9 +408,9 @@ class DeviceTreeTestCase(unittest.TestCase):
     def test_get_related_disks(self):
         tree = DeviceTree()
 
-        sda = DiskDevice("sda", size=Size('300g'))
-        sdb = DiskDevice("sdb", size=Size('300g'))
-        sdc = DiskDevice("sdc", size=Size('300G'))
+        sda = DiskDevice("sda", size=Size('300g'), exists=False)
+        sdb = DiskDevice("sdb", size=Size('300g'), exists=False)
+        sdc = DiskDevice("sdc", size=Size('300G'), exists=False)
 
         tree._add_device(sda)
         tree._add_device(sdb)


### PR DESCRIPTION
We are using "real" disk names ("sda", "sdb"...) in this test so
we need to avoid reading their real sizes which we do for existing
devices using os.stat. The test can fail if we have a disk with
the same name and small (or zero) size.