### PR TITLE
iscsi: Replace all log_exception_info calls with log.info

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -22,7 +22,6 @@ from . import udev
 from . import util
 from .flags import flags
 from .i18n import _
-from .storage_log import log_exception_info
 from . import safe_dbus
 import os
 import re
@@ -276,8 +275,8 @@ class iSCSI(object):
                                           'org.freedesktop.DBus.ObjectManager',
                                           'GetManagedObjects',
                                           None)[0]
-        except safe_dbus.DBusCallError:
-            log_exception_info(log.info, "iscsi: Failed to get active sessions.")
+        except safe_dbus.DBusCallError as e:
+            log.info("iscsi: Failed to get active sessions: %s", str(e))
             return []
 
         sessions = (obj for obj in objects.keys() if re.match(r'.*/iscsi/session[0-9]+$', obj))
@@ -301,8 +300,8 @@ class iSCSI(object):
         args = GLib.Variant("(a{sv})", ([], ))
         try:
             found_nodes, _n_nodes = self._call_initiator_method("DiscoverFirmware", args)
-        except safe_dbus.DBusCallError:
-            log_exception_info(log.info, "iscsi: No IBFT info found.")
+        except safe_dbus.DBusCallError as e:
+            log.info("iscsi: No IBFT info found: %s", str(e))
             # an exception here means there is no ibft firmware, just return
             return
 


### PR DESCRIPTION
We don't get any useful information from the exception, it's
always the same traceback from a failed DBus call and we only use
these when a called failed because firmware ISCSI is not supported.
The resulting log message also looks like a failure with the
traceback logged and not just as a debug information.

Resolves: rhbz#2028134

----

Similar to #943, we had the `log_exception_info` function on two other places that are not triggered so often and as visible as the previous one, but it's still confusing when we log the entire traceback for something that isn't critical.