### PR TITLE
Do no try to read cache MD size for inactive LVs from cache stats

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1159,7 +1159,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
             for lv in self._internal_lvs:
                 if lv.int_lv_type == LVMInternalLVtype.cache_pool:
                     if self.seg_type == "cache":
-                        self._cache = LVMCache(self, size=lv.size, exists=True)
+                        self._cache = LVMCache(self, size=lv.size, md_size=lv.metadata_size, exists=True)
                     elif self.seg_type == "writecache":
                         self._cache = LVMWriteCache(self, size=lv.size, exists=True)
 
@@ -2691,7 +2691,7 @@ class LVMCache(Cache):
 
     @property
     def md_size(self):
-        if self.exists:
+        if self.exists and self.stats:
             return self.stats.md_size
         else:
             return self._md_size


### PR DESCRIPTION
We read cache stats from the DM table so it's not available for
inactive logical volumes. We can use the metadata size we get from
the internal LV in this case.

Resolves: rhbz#1893553