### PR TITLE
README: Fix API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To install these dependencies use following commands:
 
 See [CONTRIBUTING](https://github.com/storaged-project/blivet/blob/master/CONTRIBUTING)
 
-Developer documentation is available on our [website](http://storaged.org/blivet/docs/) or on [Read the Docs](https://blivet.readthedocs.io/en/latest/).
+Developer documentation is available on our [website](http://storaged.org/blivet/) or on [Read the Docs](https://blivet.readthedocs.io/en/latest/).
 
 Additional information about the release process, roadmap and other development-related materials are also available in the [GitHub Wiki](https://github.com/storaged-project/blivet/wiki).
 


### PR DESCRIPTION
storaged.org/blivet/docs contains old documentation, latest version
is available at storaged.org/blivet