### PR TITLE
Exclude unusable disks from PartitionFactory 

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1065,6 +1065,24 @@ class PartitionFactory(DeviceFactory):
                                             **kwargs)
         return device
 
+    def _configure(self):
+        disks = []
+        for disk in self.disks:
+            if not disk.partitioned:
+                log.debug("removing unpartitioned disk %s", disk.name)
+            elif not disk.format.supported:
+                log.debug("removing disk with unsupported format %s", disk.name)
+            else:
+                disks.append(disk)
+
+        if not disks:
+            raise DeviceFactoryError("no usable disks specified for partition")
+
+        log.debug("setting new factory disks to %s", [d.name for d in disks])
+        self.disks = disks  # pylint: disable=attribute-defined-outside-init
+
+        super(PartitionFactory, self)._configure()
+
     def _set_disks(self):
         self.raw_device.req_disks = self.disks[:]
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -764,7 +764,10 @@ def allocate_partitions(storage, disks, partitions, freespace, boot_disk=None):
         growth = 0  # in sectors
         # loop through disks
         for _disk in req_disks:
-            disklabel = disklabels[_disk.path]
+            try:
+                disklabel = disklabels[_disk.path]
+            except KeyError:
+                raise PartitioningError("Requested disk %s doesn't have a usable disklabel for partitioning" % _disk.name)
             best = None
             current_free = free
             try:


### PR DESCRIPTION
For multipath devices anaconda creates the `PartitionFactory` with both the multipath device and the disks (so for example with `disks=["sda", "sdb", "mpatha"]`). Technically speaking this isn't correct but we allow this in other factories and when `LVMFactory` is used we exclude the disks in the `PartitionSetFactory` when creating the physical volumes so we should do the same with the `PartitionFactory`.