### PR TITLE
Make sure we mount the top level subvolume when mounting btrfs

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -123,7 +123,8 @@ class BTRFSDevice(StorageDevice):
         else:
             tmpdir = tempfile.mkdtemp(prefix=self._temp_dir_prefix)
             try:
-                util.mount(device=fmt.device, mountpoint=tmpdir, fstype=fmt.type)
+                util.mount(device=fmt.device, mountpoint=tmpdir, fstype=fmt.type,
+                           options=fmt.mountopts)
             except errors.FSError as e:
                 log.debug("btrfs temp mount failed: %s", e)
                 raise


### PR DESCRIPTION
If we don't specify the subvolid=5 we end up mounting the default
subvolume and if it isn't the top volume one, we can't remove
other subvolumes "higher" in the hierarchy.

This makes the installer crash when reinstalling over a preexisting
btrfs installation, for example the default openSUSE installation
where the default subvolume is a post installation snapshot.

Resolves: rhbz#2026205