### PR TITLE
Mark NTFS as supported

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1248,6 +1248,7 @@ class NTFS(FS):
     _uuidfs = fsuuid.NTFSUUID()
     _resizable = True
     _formattable = True
+    _supported = True
     _min_size = Size("1 MiB")
     _max_size = Size("16 TiB")
     _packages = ["ntfsprogs"]

--- a/blivet/tasks/fsmkfs.py
+++ b/blivet/tasks/fsmkfs.py
@@ -312,7 +312,8 @@ class NTFSMkfs(FSMkfs):
 
     @property
     def args(self):
-        return []
+        # -F (force) to allow creating the format on disks, -f (fast) to skip zeroing the device
+        return ["-F", "-f"]
 
 
 class ReiserFSMkfs(FSMkfs):


### PR DESCRIPTION
Related: https://github.com/linux-system-roles/storage/issues/151

Anaconda already explicitly excludes NTFS (https://github.com/rhinstaller/anaconda/pull/937) so this won't be a problem for them.