### PR TITLE
Set partition flags after setting parted filesystem (#2033875)

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -630,11 +630,11 @@ class ActionCreateFormat(DeviceAction):
                     continue
                 self.device.unset_flag(flag)
 
-            if self.format.parted_flag is not None:
-                self.device.set_flag(self.format.parted_flag)
-
             if self.format.parted_system is not None:
                 self.device.parted_partition.system = self.format.parted_system
+
+            if self.format.parted_flag is not None:
+                self.device.set_flag(self.format.parted_flag)
 
             self.device.disk.format.commit_to_disk()
             udev.settle()


### PR DESCRIPTION
With latest parted setting the parted filesystem property changes
the GPT type set by the flags to the default type for the fs, e.g.
to "Microsoft basic data" for FAT instead of "EFI System" which
is set with the boot flag on GPT.