### PR TITLE
Correctly cancel configure actions in cancel()

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -1111,6 +1111,8 @@ class ActionConfigureFormat(DeviceAction):
         if hasattr(self.device, 'ignore_skip_activation'):
             self.device.ignore_skip_activation -= 1
 
+        super(ActionConfigureFormat, self).cancel()
+
     def execute(self, callbacks=None):
         super(ActionConfigureFormat, self).execute(callbacks=callbacks)
 
@@ -1162,6 +1164,7 @@ class ActionConfigureDevice(DeviceAction):
             return
 
         setattr(self.device, self.attr, self.old_value)
+        super(ActionConfigureDevice, self).cancel()
 
     def execute(self, callbacks=None):
         super(ActionConfigureDevice, self).execute(callbacks=callbacks)

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1329,6 +1329,7 @@ class ConfigurationActionsTest(unittest.TestCase):
         ac.cancel()
         self.assertEqual(mock_device.conf1, "old_value")
 
+        ac.apply()
         ac.execute()
         mock_device.do_conf1.assert_called_once_with(dry_run=False)
 
@@ -1362,5 +1363,6 @@ class ConfigurationActionsTest(unittest.TestCase):
         ac.cancel()
         self.assertEqual(mock_format.conf1, "old_value")
 
+        ac.apply()
         ac.execute()
         mock_format.do_conf1.assert_called_once_with(dry_run=False)


### PR DESCRIPTION
The action also must be marked as not applied which is what the
DeviceAction.cancel() call does for all actions.