### PR TITLE
Create loop devices for tests with --partscan

### DIFF
--- a/tests/formats_test/loopbackedtestcase.py
+++ b/tests/formats_test/loopbackedtestcase.py
@@ -32,7 +32,7 @@ def make_loop_dev(device_name, file_name):
         :param str file_name: the path of the backing file
     """
 
-    proc = subprocess.Popen(["losetup", device_name, file_name],
+    proc = subprocess.Popen(["losetup", device_name, file_name, "--partscan"],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     while True:
         proc.communicate()


### PR DESCRIPTION
On latest rawhide newly created partitions are not added when the
loop device is created without the partscan option.
Related: rhbz#2055708