### PR TITLE
Disable Fedora ELN builds in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,5 +9,4 @@ jobs:
   metadata:
     targets:
     - fedora-all
-    - fedora-eln
   trigger: pull_request


### PR DESCRIPTION
Fedora ELN builds are broken all the time because of repository
or GPG signatures issues, it doesn't make sense to have a test
that is broken all the time and outside of our control.