### PR TITLE
Do not crash when a disk populator doesn't return kwargs

### DIFF
--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -68,6 +68,8 @@ class DiskDevicePopulator(DevicePopulator):
         log_method_call(self, name=name)
 
         kwargs = self._get_kwargs()
+        if not kwargs:
+            return
         device = self._device_class(name, **kwargs)
         self._devicetree._add_device(device)
         return device


### PR DESCRIPTION
This happens when trying to use Blivet on a system with a BIOS
RAID without dmraid installed. Because we don't fully support
BIOS RAIDs using MD the MDBiosRaidDevicePopulator helper fails
to get kwargs for the BIOS RAID "disk" and populate fails.

----

This is just a workaround. We should aim to fully support DDF RAIDs with MD (some changes will be needed in libblockdev too see https://github.com/storaged-project/libblockdev/issues/722). Populator is also one the things we should focus when making Blivet more stable, returning `None` from `_get_kwargs` means we try to pass `**None` for the device constructor which crashes without even telling the user what's wrong.