### PR TITLE
Add support for attaching and creating LVM writecached LVs

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -728,8 +728,12 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
 
         self._cache = None
         if cache_request and not self.exists:
-            self._cache = LVMCache(self, size=cache_request.size, exists=False,
-                                   pvs=cache_request.fast_devs, mode=cache_request.mode)
+            if cache_request.cache_type == LVMCacheType.lvmcache:
+                self._cache = LVMCache(self, size=cache_request.size, exists=False,
+                                       pvs=cache_request.fast_devs, mode=cache_request.mode)
+            elif cache_request.cache_type == LVMCacheType.lvmwritecache:
+                self._cache = LVMWriteCache(self, size=cache_request.size, exists=False,
+                                            pvs=cache_request.fast_devs)
 
         self._pv_specs = []
         pvs = pvs or []
@@ -2611,7 +2615,6 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             blockdev.lvm.lvcreate(self.vg.name, self._name, self.size,
                                   type=self.seg_type, pv_list=pvs)
         else:
-            mode = blockdev.lvm.cache_get_mode_from_str(self.cache.mode)
             fast_pvs = [pv.path for pv in self.cache.fast_pvs]
 
             if self._pv_specs:
@@ -2632,8 +2635,13 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             # XXX: we need to pass slow_pvs+fast_pvs (without duplicates) as slow PVs because parts of the
             # fast PVs may be required for allocation of the LV (it may span over the slow PVs and parts of
             # fast PVs)
-            blockdev.lvm.cache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size, self.cache.md_size,
-                                                mode, 0, util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+            if self.cache.type == "cache":
+                mode = blockdev.lvm.cache_get_mode_from_str(self.cache.mode)
+                blockdev.lvm.cache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size, self.cache.md_size,
+                                                    mode, 0, util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+            else:
+                blockdev.lvm.writecache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size,
+                                                         util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
 
     @type_specific
     def _post_create(self):
@@ -2781,6 +2789,16 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             raise errors.DeviceError("Cannot attach a cache pool to the '%s' LV" % self.name)
         blockdev.lvm.cache_attach(self.vg.name, self.lvname, cache_pool_lv.lvname)
         self._cache = LVMCache(self, size=cache_pool_lv.size, exists=True)
+
+    def attach_writecache(self, writecache_lv):
+        if self.is_thin_lv or self.is_snapshot_lv or self.is_internal_lv:
+            raise errors.DeviceError("Cannot attach writecache to the '%s' LV" % self.name)
+        try:
+            blockdev.lvm.writecache_attach(self.vg.name, self.lvname, writecache_lv.lvname)
+        except blockdev.LVMError as err:
+            raise errors.DeviceError("Failed to attach writecache to %s" % self.name) from err
+
+        self._cache = LVMWriteCache(self, size=writecache_lv.size, exists=True)
 
 
 class LVMCache(Cache):
@@ -2934,13 +2952,38 @@ class LVMWriteCache(Cache):
 
     type = "writecache"
 
-    def __init__(self, cached_lv, size, exists):
+    def __init__(self, cached_lv, size, exists=False, pvs=None):
         self._cached_lv = cached_lv
         self._exists = exists
         self._size = size
 
-        if not self._exists:
-            raise ValueError("Only preexisting LVM writecache devices are currently supported.")
+        self._pv_specs = []
+        if not exists:
+            self._size = cached_lv.vg.align(self._size)
+            for pv_spec in pvs:
+                if isinstance(pv_spec, LVPVSpec):
+                    self._pv_specs.append(pv_spec)
+                elif isinstance(pv_spec, StorageDevice):
+                    self._pv_specs.append(LVPVSpec(pv_spec, Size(0)))
+            self._assign_pv_space()
+
+    def _assign_pv_space(self):
+        # calculate the size of space that we need to place somewhere
+        space_to_assign = self.size - sum(spec.size for spec in self._pv_specs)
+
+        # skip the PVs that already have some chunk of the space assigned
+        for spec in (spec for spec in self._pv_specs if not spec.size):
+            if spec.pv.format.free >= space_to_assign:
+                # enough space in this PV, put everything in there and quit
+                spec.size = space_to_assign
+                space_to_assign = Size(0)
+                break
+            elif spec.pv.format.free > 0:
+                # some space, let's use it and move on to another PV (if any)
+                spec.size = spec.pv.format.free
+                space_to_assign -= spec.pv.format.free
+        if space_to_assign > 0:
+            raise errors.DeviceError("Not enough free space in the PVs for this cache: %s short" % space_to_assign)
 
     @property
     def size(self):
@@ -2965,15 +3008,37 @@ class LVMWriteCache(Cache):
 
     @property
     def backing_device_name(self):
-        return self._cached_lv.name
+        if self._exists:
+            return self._cached_lv.name
+        else:
+            return None
 
     @property
     def cache_device_name(self):
-        vg_name = self._cached_lv.vg.name
-        return "%s-%s" % (vg_name, blockdev.lvm.cache_pool_name(vg_name, self._cached_lv.lvname))
+        if self.exists:
+            vg_name = self._cached_lv.vg.name
+            return "%s-%s" % (vg_name, blockdev.lvm.cache_pool_name(vg_name, self._cached_lv.lvname))
+        else:
+            return None
+
+    @property
+    def fast_pvs(self):
+        return [spec.pv for spec in self._pv_specs]
+
+    @property
+    def pv_space_used(self):
+        """
+        :returns: space to be occupied by the cache on its LV's VG's PVs (one has to love LVM)
+        :rtype: list of LVPVSpec
+
+        """
+        return self._pv_specs
 
     def detach(self):
-        raise NotImplementedError
+        try:
+            blockdev.lvm.writecache_detach(self._cached_lv.vg.name, self._cached_lv.lvname, False)
+        except blockdev.LVMError as err:
+            raise errors.DeviceError("Failed to detach writecache from %s" % self._cached_lv.lvname) from err
 
 
 class LVMCacheStats(CacheStats):
@@ -3046,21 +3111,28 @@ class LVMCacheStats(CacheStats):
         return self._write_misses
 
 
+class LVMCacheType(Enum):
+    lvmcache = 1
+    lvmwritecache = 2
+
+
 class LVMCacheRequest(CacheRequest):
 
     """Class representing the LVM cache creation request"""
 
-    def __init__(self, size, pvs, mode=None):
+    def __init__(self, size, pvs, mode=None, cache_type=LVMCacheType.lvmcache):
         """
         :param size: requested size of the cache
         :type size: :class:`~.size.Size`
         :param pvs: PVs to allocate the cache on/from
         :type pvs: list of (:class:`~.devices.storage.StorageDevice` or :class:`LVPVSpec`)
         :param str mode: requested mode for the cache (``None`` means the default is used)
-
+        :param cache_type: type of the cache to use (writecache or "normal" cache)
+        :type cache_type: enum :class:`LVMCacheType`
         """
         self._size = size
         self._mode = mode or "writethrough"
+        self._cache_type = cache_type
         self._pv_specs = []
         for pv_spec in pvs:
             if isinstance(pv_spec, LVPVSpec):
@@ -3088,3 +3160,7 @@ class LVMCacheRequest(CacheRequest):
     @property
     def mode(self):
         return self._mode
+
+    @property
+    def cache_type(self):
+        return self._cache_type

--- a/examples/lvm_cache.py
+++ b/examples/lvm_cache.py
@@ -3,7 +3,7 @@ import os
 import blivet
 from blivet.size import Size
 from blivet.util import set_up_logging, create_sparse_tempfile
-from blivet.devices.lvm import LVMCacheRequest
+from blivet.devices.lvm import LVMCacheRequest, LVMCacheType
 
 set_up_logging()
 b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
@@ -34,19 +34,14 @@ try:
     vg = b.new_vg(parents=[pv, pv2])
     b.create_device(vg)
 
-    # new lv with base size 5GiB and unbounded growth and an ext4 filesystem
-    dev = b.new_lv(fmt_type="ext4", size=Size("5GiB"), grow=True,
-                   parents=[vg], name="unbounded")
-    b.create_device(dev)
-
-    # new lv with base size 5GiB and growth up to 15GiB and an ext4 filesystem
-    dev = b.new_lv(fmt_type="ext4", size=Size("5GiB"), grow=True,
-                   maxsize=Size("15GiB"), parents=[vg], name="bounded")
-    b.create_device(dev)
-
-    # new lv with a fixed size of 2GiB formatted as swap space
+    # new lv cached by a standard LVM cache
     cache_spec = LVMCacheRequest(size=Size("1GiB"), pvs=[pv2])
     dev = b.new_lv(fmt_type="ext4", size=Size("2GiB"), parents=[vg], name="cached", cache_request=cache_spec)
+    b.create_device(dev)
+
+    # new lv cached by a LVM writecache
+    cache_spec = LVMCacheRequest(size=Size("1GiB"), pvs=[pv2], cache_type=LVMCacheType.lvmwritecache)
+    dev = b.new_lv(fmt_type="ext4", size=Size("2GiB"), parents=[vg], name="writecached", cache_request=cache_spec)
     b.create_device(dev)
 
     # allocate the growable lvs

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -11,10 +11,10 @@ import blivet
 from blivet.devices import StorageDevice
 from blivet.devices import LVMLogicalVolumeDevice
 from blivet.devices import LVMVolumeGroupDevice
-from blivet.devices.lvm import LVMVDOPoolMixin
+from blivet.devices.lvm import LVMCache, LVMWriteCache, LVMVDOPoolMixin
 from blivet.devices.lvm import LVMVDOLogicalVolumeMixin
 from blivet.devices.lvm import LVMCacheRequest
-from blivet.devices.lvm import LVPVSpec, LVMInternalLVtype
+from blivet.devices.lvm import LVPVSpec, LVMInternalLVtype, LVMCacheType
 from blivet.size import Size
 from blivet.devicelibs import raid
 from blivet import devicefactory
@@ -104,6 +104,7 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertTrue(lv.cached)
         cache = lv.cache
         self.assertIsNotNone(cache)
+        self.assertIsInstance(cache, LVMCache)
 
         # the cache reserves space for its metadata from the requested size, but
         # it may require (and does in this case) a pmspare LV to be allocated
@@ -151,6 +152,43 @@ class LVMDeviceTest(unittest.TestCase):
         # already have pmspare space reserved for lv1's cache (and shared)
         # 256 MiB - 8 MiB (metadata) [no pmspare]
         self.assertEqual(cache.size, Size("248 MiB"))
+
+    def test_lvmwritecached_logical_volume_init(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1 GiB"))
+        pv2 = StorageDevice("pv2", fmt=blivet.formats.get_format("lvmpv"),
+                            size=Size("512 MiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
+
+        req_size = pv2.format.free
+        cache_req = LVMCacheRequest(req_size, [pv2], cache_type=LVMCacheType.lvmwritecache)
+        xfs_fmt = blivet.formats.get_format("xfs")
+        lv = LVMLogicalVolumeDevice("testlv",
+                                    parents=[vg],
+                                    fmt=xfs_fmt,
+                                    size=Size(xfs_fmt.min_size),
+                                    exists=False,
+                                    cache_request=cache_req)
+        self.assertEqual(lv.size, xfs_fmt.min_size)
+
+        # check that the LV behaves like a cached LV
+        self.assertTrue(lv.cached)
+        cache = lv.cache
+        self.assertIsNotNone(cache)
+        self.assertIsInstance(cache, LVMWriteCache)
+
+        # the cache reserves space for its metadata from the requested size, but
+        # it may require (and does in this case) a pmspare LV to be allocated
+        self.assertEqual(lv.vg_space_used, lv.cache.size + lv.cache.md_size + lv.size)
+
+        self.assertEqual(cache.size, req_size)
+        self.assertEqual(cache.vg_space_used, req_size)
+        self.assertIsInstance(cache.size, Size)
+        self.assertIsInstance(cache.vg_space_used, Size)
+        self.assertFalse(cache.exists)
+        self.assertIsNone(cache.backing_device_name)
+        self.assertIsNone(cache.cache_device_name)
+        self.assertEqual(set(cache.fast_pvs), set([pv2]))
 
     def test_lvm_logical_volume_with_pvs_init(self):
         pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),


### PR DESCRIPTION
This adds support to attach an existing LV as a writecache to
another LV and to create a writecached LV.

Fixes: #1027 

This is a good candidate for more tests, especially something that will actually try to attach and detach the writecache LV so I'll wait for #1028 to be merged and add more tests later.