### PR TITLE
ActionDestroyDevice should not obsolete ActionRemoveMember

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -463,8 +463,8 @@ class ActionDestroyDevice(DeviceAction):
             - obsoletes all actions w/ lower id that act on the same device,
               including self, if device does not exist
 
-            - obsoletes all but ActionDestroyFormat actions w/ lower id on the
-              same device if device exists
+            - obsoletes all but ActionDestroyFormat and ActionRemoveMember actions
+              w/ lower id on the same device if device exists
 
             - obsoletes all actions that add a member to this action's
               (container) device
@@ -474,9 +474,9 @@ class ActionDestroyDevice(DeviceAction):
         if action.device.id == self.device.id:
             if self.id >= action.id and not self.device.exists:
                 rc = True
-            elif self.id > action.id and \
-                    self.device.exists and \
-                    not (action.is_destroy and action.is_format):
+            elif self.id > action.id and self.device.exists and \
+                    not ((action.is_destroy and action.is_format) or
+                         action.is_remove):
                 rc = True
             elif action.is_add and (action.device == self.device):
                 rc = True

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1197,6 +1197,13 @@ class DeviceActionTestCase(StorageTestCase):
         self.assertEqual(create_sdc2.requires(remove_sdc1), False)
         self.assertEqual(remove_sdc1.requires(create_sdc2), False)
 
+        # destroy sdc1, the ActionRemoveMember should not be obsoleted
+        sdc1.exists = True
+        destroy_sdc1 = ActionDestroyDevice(sdc1)
+        destroy_sdc1.apply()
+        self.assertFalse(destroy_sdc1.obsoletes(remove_sdc1))
+        self.assertTrue(destroy_sdc1.requires(remove_sdc1))
+
     def test_action_sorting(self, *args, **kwargs):
         """ Verify correct functioning of action sorting. """
 


### PR DESCRIPTION
If we want to remove a PV from a VG and then remove the PV device,
the ActionDestroyDevice must not obsolete the ActionRemoveMember
action. Eventhough we are going to remove the device, we still
need to call "vgreduce" first.