### PR TITLE
Add support for NPIV-enabled zFCP devices

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -577,7 +577,15 @@ class ZFCPDiskDevice(DiskDevice):
                   'lun': self.fcp_lun}
 
     def dracut_setup_args(self):
-        return set(["rd.zfcp=%s,%s,%s" % (self.hba_id, self.wwpn, self.fcp_lun,)])
+        from ..zfcp import is_npiv_enabled
+
+        # zFCP devices in NPIV mode need only the device ID
+        if is_npiv_enabled(self.hba_id):
+            dracut_args = set(["rd.zfcp=%s" % self.hba_id])
+        else:
+            dracut_args = set(["rd.zfcp=%s,%s,%s" % (self.hba_id, self.wwpn, self.fcp_lun,)])
+
+        return dracut_args
 
 
 class DASDDevice(DiskDevice):

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1141,3 +1141,25 @@ def natural_sort_key(device):
         return [device.disk.name, part_num]
     else:
         return [device.name, 0]
+
+
+def get_kernel_module_parameter(module, parameter):
+    """ Return the value of a given kernel module parameter
+
+    :param str module: a kernel module
+    :param str parameter: a module parameter
+    :returns: the value of the given kernel module parameter or None
+    :rtype: str
+    """
+
+    value = None
+
+    parameter_path = os.path.join("/sys/module", module, "parameters", parameter)
+    try:
+        with open(parameter_path) as f:
+            value = f.read().strip()
+    except IOError as e:
+        log.warning("Couldn't get the value of the parameter '%s' from the kernel module '%s': %s",
+                    parameter, module, str(e))
+
+    return value

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -136,6 +136,7 @@ class ZFCPDeviceBase(ABC):
         # A list of existing SCSI devices in format Host:Bus:Target:Lun
         scsi_devices = [f for f in os.listdir(scsidevsysfs) if re.search(r'^[0-9]+:[0-9]+:[0-9]+:[0-9]+$', f)]
 
+        scsi_device_found = False
         for scsidev in scsi_devices:
             fcpsysfs = os.path.join(scsidevsysfs, scsidev)
 
@@ -147,12 +148,13 @@ class ZFCPDeviceBase(ABC):
                 fcplunsysfs = f.readline().strip()
 
             if self._is_scsi_associated_with_fcp(fcphbasysfs, fcpwwpnsysfs, fcplunsysfs):
+                scsi_device_found = True
                 scsidel = os.path.join(scsidevsysfs, scsidev, "delete")
                 logged_write_line_to_file(scsidel, "1")
                 udev.settle()
-                return
 
-        log.warning("No scsi device found to delete for zfcp %s", self)
+        if not scsi_device_found:
+            log.warning("No scsi device found to delete for zfcp %s", self)
 
 
 class ZFCPDevice(ZFCPDeviceBase):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -182,3 +182,14 @@ class GetSysfsAttrTestCase(unittest.TestCase):
             # the unicode replacement character (U+FFFD) should be used instead
             model = util.get_sysfs_attr(sysfs, "model")
             self.assertEqual(model, "test model\ufffd")
+
+
+class GetKernelModuleParameterTestCase(unittest.TestCase):
+
+    def test_nonexisting_kernel_module(self):
+        self.assertIsNone(util.get_kernel_module_parameter("unknown_module", "unknown_parameter"))
+
+    def test_get_kernel_module_parameter_value(self):
+        with mock.patch('blivet.util.open', mock.mock_open(read_data='value\n')):
+            value = util.get_kernel_module_parameter("module", "parameter")
+        self.assertEqual(value, "value")


### PR DESCRIPTION
This change adds a support for [zFCP NPIV (N_Port ID virtualization)](https://www.ibm.com/docs/en/linux-on-systems?topic=later-n-port-id-virtualization) devices.
NPIV-enabled devices are activated just by using the device ID. The kernel module will detect the WWPNs and LUNs and bring all the devices up automatically. This means the user doesn't have to provide the WWPN and LUN IDs.

Related: rhbz#[1937030](https://bugzilla.redhat.com/show_bug.cgi?id=1937030)

TODO:

- [x] additional testing in anaconda