### PR TITLE
Do not crash when changing disklabel on disks with active devices

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -211,9 +211,8 @@ class ActionList(object):
                     except StorageError as e:
                         log.info("teardown of %s failed: %s", device.name, e)
             else:
-                raise RuntimeError("partitions in use on disks with changes "
-                                   "pending: %s" %
-                                   ",".join(problematic))
+                log.debug("ignoring devices in use on disks with changes: %s",
+                          ",".join(problematic))
 
         log.info("resetting parted disks...")
         for device in devices:


### PR DESCRIPTION
The _find_active_devices_on_action_disks function originally
prevented from making any changes on disks with active devices
(active LVs, mounted partitions etc.)  This was changed in
b72e957d2b23444824316331ae21d1c594371e9c and the check currently
prevents only reformatting the disklabel on such disks which
should be already impossible on disks with an existing partition.

This change for the 3.4 stable branch keeps the current behaviour
where the active devices are teared down when running in installer
mode to avoid potential issues with the installer.