### PR TITLE
Correctly set vg_name after adding/removing a PV from a VG

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -385,6 +385,8 @@ class LVMVolumeGroupDevice(ContainerDevice):
         if not parent.format.exists:
             parent.format.free = self._get_pv_usable_space(parent)
 
+        parent.format.vg_name = self.name
+
     def _remove_parent(self, parent):
         # XXX It would be nice to raise an exception if removing this member
         #     would not leave enough space, but the devicefactory relies on it
@@ -395,6 +397,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
         super(LVMVolumeGroupDevice, self)._remove_parent(parent)
         parent.format.free = None
         parent.format.container_uuid = None
+        parent.format.vg_name = None
 
     # We can't rely on lvm to tell us about our size, free space, &c
     # since we could have modifications queued, unless the VG and all of

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -443,6 +443,19 @@ class LVMDeviceTest(unittest.TestCase):
             self.assertFalse(pool.exists)
             self.assertTrue(lvm.lvremove.called)
 
+    def test_add_remove_pv(self):
+        pv1 = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                            size=Size("1024 MiB"))
+        pv2 = StorageDevice("pv2", fmt=blivet.formats.get_format("lvmpv"),
+                            size=Size("1024 MiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv1])
+
+        vg._add_parent(pv2)
+        self.assertEqual(pv2.format.vg_name, vg.name)
+
+        vg._remove_parent(pv2)
+        self.assertEqual(pv2.format.vg_name, None)
+
 
 class TypeSpecificCallsTest(unittest.TestCase):
     def test_type_specific_calls(self):


### PR DESCRIPTION
Without setting the LVMPhysicalVolume.vg_name argument to None
after removing the PV from its VG, the PV is still considered
active and cannot be removed.

Yet another issue discovered when working on https://github.com/linux-system-roles/storage/pull/264