### PR TITLE
Change label_format_ok and uuid_format_ok to class methods

### DIFF
--- a/blivet/tasks/fslabeling.py
+++ b/blivet/tasks/fslabeling.py
@@ -35,8 +35,9 @@ class FSLabeling(object):
     default_label = abc.abstractproperty(
         doc="Default label set on this filesystem at creation.")
 
+    @classmethod
     @abc.abstractmethod
-    def label_format_ok(self, label):
+    def label_format_ok(cls, label):
         """Returns True if this label is correctly formatted for this
            filesystem, otherwise False.
 

--- a/blivet/tasks/fsuuid.py
+++ b/blivet/tasks/fsuuid.py
@@ -10,8 +10,9 @@ class FSUUID(object):
        UUID.
     """
 
+    @classmethod
     @abc.abstractmethod
-    def uuid_format_ok(self, uuid):
+    def uuid_format_ok(cls, uuid):
         """Returns True if the given UUID is correctly formatted for
            this filesystem, otherwise False.
 


### PR DESCRIPTION
These are class methods in the subclasses and pylint is now
complaining about this.