### PR TITLE
Update DeviceFormat.target_size in update_size_info

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -412,6 +412,9 @@ class DeviceFormat(ObjectID):
 
     def update_size_info(self):
         """ Update this format's current and minimum size (for resize). """
+        # make sure the target size which is initialy set to self._size is also updated
+        if self.exists and self.target_size == Size(0):
+            self._target_size = self._size
 
     def do_resize(self):
         """ Resize this filesystem based on this instance's target_size attr.

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -364,6 +364,8 @@ class FS(DeviceFormat):
         except (FSError, NotImplementedError) as e:
             log.warning("Failed to obtain minimum size for device %s: %s", self.device, e)
 
+        super(FS, self).update_size_info()
+
     def _pad_size(self, size):
         """ Return a size padded according to some inflating rules.
 

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -253,6 +253,8 @@ class LUKS(DeviceFormat):
         else:
             self._resizable = True
 
+        super(LUKS, self).update_size_info()
+
     def _pre_setup(self, **kwargs):
         if not self.configured:
             raise LUKSError("luks device not configured")

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -165,6 +165,8 @@ class LVMPhysicalVolume(DeviceFormat):
         else:
             self._resizable = True
 
+        super(LVMPhysicalVolume, self).update_size_info()
+
     @property
     def free(self):
         """ Information about the free space in this PV """


### PR DESCRIPTION
DeviceFormat.size returns target_size for resizable format so
without updating it in update_size_info we'll always get old or
invalid value for size.

---

One more issue discovered thanks to https://github.com/linux-system-roles/storage/pull/264 -- because we don't know the lvmpv format size we fail to call `pvmove` before running `vgreduce` and removing a non-empty PV from a VG will fail.