### PR TITLE
Use LVM PV format current_size in LVMVolumeGroupDevice._remove

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -293,7 +293,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         # do not run pvmove on empty PVs
         member.format.update_size_info()
-        if member.format.free < member.format.size:
+        if member.format.free < member.format.current_size:
             blockdev.lvm.pvmove(member.path)
         blockdev.lvm.vgreduce(self.name, member.path)
 


### PR DESCRIPTION
The member format size is 0 when target size is not set.