### PR TITLE
Add support for LVM RAID raid0 level

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -61,7 +61,7 @@ LVM_CACHE_MIN_METADATA_SIZE = Size("8 MiB")
 LVM_CACHE_MAX_METADATA_SIZE = Size("16 GiB")
 LVM_CACHE_DEFAULT_MODE = blockdev.LVMCacheMode.WRITETHROUGH
 
-raid_levels = raid.RAIDLevels(["linear", "striped", "raid1", "raid4", "raid5", "raid6", "raid10"])
+raid_levels = raid.RAIDLevels(["linear", "striped", "raid0", "raid1", "raid4", "raid5", "raid6", "raid10"])
 raid_seg_types = list(itertools.chain.from_iterable([level.names for level in raid_levels if level.name != "linear"]))
 
 ThPoolProfile = namedtuple("ThPoolProfile", ["name", "desc"])

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -250,6 +250,24 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertTrue(lv.is_raid_lv)
         self.assertEqual(lv.num_raid_pvs, 2)
 
+    def test_lvm_logical_volume_raid0(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1025 MiB"))
+        pv2 = StorageDevice("pv2", fmt=blivet.formats.get_format("lvmpv"),
+                            size=Size("513 MiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv, pv2])
+
+        lv = LVMLogicalVolumeDevice("testlv", parents=[vg], size=Size("512 MiB"),
+                                    fmt=blivet.formats.get_format("xfs"),
+                                    exists=False, seg_type="raid0", pvs=[pv, pv2])
+
+        self.assertEqual(lv.seg_type, "raid0")
+        # 512 MiB - 4 MiB (metadata)
+        self.assertEqual(lv.size, Size("508 MiB"))
+        self.assertEqual(lv._raid_level, raid.RAID0)
+        self.assertTrue(lv.is_raid_lv)
+        self.assertEqual(lv.num_raid_pvs, 2)
+
     def test_lvm_logical_volume_insuf_seg_type(self):
         # pylint: disable=unused-variable
         pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),


### PR DESCRIPTION
When we initially added support for LVM RAID, raid0 wasn't
supported yet so we added support only for the old "striped"
segment type. RAID0 is now supported by LVM so we should support
it too.

Related: https://github.com/linux-system-roles/storage/pull/271