### PR TITLE
pylint: Remove deprecated pylint warnings from pylintrc and code

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1040,7 +1040,6 @@ def default_namedtuple(name, fields, doc=""):
             field_names.append(field)
     nt = namedtuple(name, field_names)
 
-    # pylint: disable=no-init
     class TheDefaultNamedTuple(nt):
         if doc:
             __doc__ = doc

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -28,7 +28,6 @@ class SELinuxContextTestCase(unittest.TestCase):
     @patch.object(fs.FS, "_pre_setup", return_value=True)
     @patch("os.access", return_value=True)
     # pylint: disable=unused-argument
-    # pylint: disable=no-self-use
     def exec_mount_selinux_format(self, formt, *args):
         """ Test of correct selinux context parameter value when mounting """
 

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -65,9 +65,6 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=W0105,           # String statement has no effect
-        W0110,           # map/filter on lambda could be replaced by comprehension
-        W0141,           # Used builtin function %r
-        W0142,           # Used * or ** magic
         W0212,           # Access to a protected member of a client class
         W0511,           # Used when a warning note as FIXME or XXX is detected.
         W0603,           # Using the global statement
@@ -195,13 +192,6 @@ max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.


### PR DESCRIPTION
Latest pylint removed some deprecated warnings/messages and now
complains about disabling unknown messages.