### PR TITLE
ci: Run static analysis checks in GitHub actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    branches:
+     - 3.*-devel
+     - master
+  push:
+    branches:
+     - 3.*-devel
+     - master
+  schedule:
+    - cron: 0 0 * * 0
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run:   |
+         sudo apt-get -qq update
+         sudo apt-get -y -qq install make ansible
+         sudo make install-requires
+    - name: Run checks
+      run: make check


### PR DESCRIPTION
We don't really need to run the checks (pylint, pycodestyle and translation-canary) in our CI, everything can run in the GH actions on Ubuntu without a problem. This uses our ansible playbook to install dependencies including pocketlint and latest pylint from pip so the action itself is actually really simple.