### PR TITLE
Use the new Stratis tool to predict pool and fs used size

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -29,6 +29,7 @@ from ..static_data import stratis_info
 from ..storage_log import log_method_call
 from ..errors import DeviceError, StratisError
 from ..size import Size
+from ..tasks import availability
 from .. import devicelibs
 
 
@@ -40,6 +41,7 @@ class StratisPoolDevice(StorageDevice):
     _packages = ["stratisd", "stratis-cli"]
     _dev_dir = "/dev/stratis"
     _format_immutable = True
+    _external_dependencies = [availability.STRATISPREDICTUSAGE_APP, availability.STRATIS_DBUS]
 
     def __init__(self, *args, **kwargs):
         """
@@ -188,6 +190,7 @@ class StratisFilesystemDevice(StorageDevice):
     _resizable = False
     _packages = ["stratisd", "stratis-cli"]
     _dev_dir = "/dev/stratis"
+    _external_dependencies = [availability.STRATISPREDICTUSAGE_APP, availability.STRATIS_DBUS]
 
     def __init__(self, *args, **kwargs):
         if kwargs.get("size") is None and not kwargs.get("exists"):

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -25,6 +25,7 @@ import shutil
 from six import add_metaclass
 
 from .. import safe_dbus
+from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -535,3 +536,8 @@ FSCK_F2FS_APP = application("fsck.f2fs")
 MKFS_F2FS_APP = application("mkfs.f2fs")
 
 MOUNT_APP = application("mount")
+
+STRATISPREDICTUSAGE_APP = application("stratis-predict-usage")
+
+STRATIS_SERVICE_METHOD = DBusMethod(STRATIS_SERVICE, STRATIS_PATH)
+STRATIS_DBUS = dbus_service("stratis", STRATIS_SERVICE_METHOD)

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -902,6 +902,8 @@ class StratisFactoryTestCase(DeviceFactoryTestCase):
     encryption_supported = False
     factory_class = devicefactory.StratisFactory
 
+    _disk_size = Size("3 GiB")
+
     # pylint: disable=unused-argument
     def _get_size_delta(self, devices=None):
         """ Return size delta for a specific factory type.
@@ -965,7 +967,7 @@ class StratisFactoryTestCase(DeviceFactoryTestCase):
         # change container size
         kwargs = {"disks": self.b.disks,
                   "mountpoint": "/factorytest",
-                  "container_size": Size("2.5 GiB")}
+                  "container_size": Size("5 GiB")}
         device = self._factory_device(device_type, **kwargs)
         self._validate_factory_device(device, device_type, **kwargs)
 

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -896,6 +896,8 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
         self.assertIsNone(factory2.get_container())
 
 
+# we use stratis tools to predict metadata use so we can't simply "mask" the dependencies here
+@unittest.skipUnless(not StratisFilesystemDevice.unavailable_type_dependencies(), "some unsupported device classes required for this test")
 class StratisFactoryTestCase(DeviceFactoryTestCase):
     device_class = StratisFilesystemDevice
     device_type = devicefactory.DEVICE_TYPE_STRATIS


### PR DESCRIPTION
stratis-predict-usage from the latest Stratis 3.1.0 can now
predict used/metadata size for pools with non-existing blockdevs
and also supports predicting used/metadata size for filesystems
so we no longer need to guess these ourselves.