### PR TITLE
ci: Fix installing targetcli on Debian/Ubuntu

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -155,7 +155,7 @@
         - python3-bugzilla
         - python3-libvirt
         - python3-pip
-        - targetcli
+        - targetcli-fb
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
   - name: Install pocketlint using pip (Debian/Ubuntu)


### PR DESCRIPTION
The package is called targetcli-fb on Debian and Ubuntu.