### PR TITLE
Misc pylint fixes for rawhide

### DIFF
--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -50,7 +50,7 @@ def validate_cb(cb, kwargs=None, arg_count=None):
     arg_count = arg_count or 0
 
     if six.PY2:
-        argspec = inspect.getargspec(cb)  # pylint: disable=deprecated-method
+        argspec = inspect.getargspec(cb)  # pylint: disable=deprecated-method,no-member
         if argspec.varargs or argspec.keywords:
             return True
         params = argspec.args

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -568,9 +568,17 @@ class NVDIMMNamespaceDevicePopulatorTestCase(PopulatorHelperTestCase):
         nvdimm_data = Mock(mode=blockdev.NVDIMMNamespaceMode.SECTOR, devname='dummy',
                            uuid='test-uuid', sector_size=512)
 
-        with patch("blivet.static_data.nvdimm.get_namespace_info", return_value=nvdimm_data):
-            with patch("blivet.populator.helpers.disk.blockdev.nvdimm_namespace_get_mode_str", return_value="sector"):
-                device = helper.run()
+        try:
+            patcher = patch("blivet.static_data.nvdimm.get_namespace_info", return_value=nvdimm_data)
+            patcher.start()
+        except AttributeError:
+            patcher = patch("blivet.static_data.nvdimm.nvdimm.get_namespace_info", return_value=nvdimm_data)
+            patcher.start()
+
+        with patch("blivet.populator.helpers.disk.blockdev.nvdimm_namespace_get_mode_str", return_value="sector"):
+            device = helper.run()
+
+        patcher.stop()
 
         self.assertIsInstance(device, NVDIMMNamespaceDevice)
         self.assertTrue(device.exists)

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -29,7 +29,8 @@ class BlivetLintConfig(CensorshipConfig):
             FalsePositive(r"Parameters differ from overridden 'do_task' method$"),
             FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify|arguments-renamed|redundant-u-string-prefix)'"),
             FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$"),
-            FalsePositive(r"Instance of 'GError' has no 'message' member")  # overriding currently broken local pylint disable
+            FalsePositive(r"Instance of 'GError' has no 'message' member"),  # overriding currently broken local pylint disable
+            FalsePositive(r"Module '(gi.repository.Gio|gi.repository.GLib)' has no .* member")  # pylint/astroid has issues with GI modules https://github.com/PyCQA/pylint/issues/6352
         ]
 
     def _files(self):


### PR DESCRIPTION
Pylint finally works with Python 3.11 on rawhide and shows some new warnings.