### PR TITLE
tests: Fix message when skipping stratis tests

### DIFF
--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -14,7 +14,8 @@ class StratisTestCase(StorageTestCase):
     def setUpClass(cls):
         unavailable_deps = StratisFilesystemDevice.unavailable_type_dependencies()
         if unavailable_deps:
-            raise unittest.SkipTest("some unavailable dependencies required for this test: %s" % unavailable_deps)
+            dep_str = ", ".join([d.name for d in unavailable_deps])
+            raise unittest.SkipTest("some unavailable dependencies required for this test: %s" % dep_str)
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Before:
'some unavailable dependencies required for this test:
{<blivet.tasks.availability.ExternalResource object at 0x7f3fabad4eb0>,
<blivet.tasks.availability.ExternalResource object at 0x7f3fabad4df0>}'

After:
'some unavailable dependencies required for this test: stratis,
stratis-predict-usage'