### PR TITLE
Fix missing whitespaces around not keyword

### DIFF
--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -130,7 +130,7 @@ class FileDevice(StorageDevice):
 
     def is_name_valid(self, name):
         # Override StorageDevice.is_name_valid to allow /
-        return not('\x00' in name or name == '.' or name == '..')
+        return '\x00' not in name and name != '.' and name != '..'
 
     def update_sysfs_path(self):
         pass

--- a/blivet/devices/nfs.py
+++ b/blivet/devices/nfs.py
@@ -76,7 +76,7 @@ class NFSDevice(StorageDevice, NetworkStorageDevice):
 
     def is_name_valid(self, name):
         # Override StorageDevice.is_name_valid to allow /
-        return not('\x00' in name or name == '.' or name == '..')
+        return '\x00' not in name and name != '.' and name != '..'
 
     def update_sysfs_path(self):
         pass

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -886,4 +886,4 @@ class StorageDevice(Device):
             return all(self.is_name_valid(n) for n in name.split('/'))
 
         badchars = any(c in ('\x00', '/') for c in name)
-        return not(badchars or name == '.' or name == '..')
+        return not badchars and name != '.' and name != '..'

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1422,7 +1422,7 @@ class TmpFS(NoDevFS):
 
         # if the size is 0, which is probably not set, accept the default
         # size when mounting.
-        self._accept_default_size = not(self._size)
+        self._accept_default_size = not self._size
 
     def create(self, **kwargs):
         """ A filesystem is created automatically once tmpfs is mounted. """


### PR DESCRIPTION
Latest pycodestyle is complaining about missing whitespace around
"not" which we were (at some places) using as a function instead
of keyword like "not(...)".