### PR TITLE
Improve and document VM tests

### DIFF
--- a/tests/vmtests/README.rst
+++ b/tests/vmtests/README.rst
@@ -1,0 +1,57 @@
+Running VM tests
+================
+
+The VM tests are intended to run aginst a libvirt managed KVM
+virtual machine, running a Live OS with two unprovisioned
+disks present. A suitable environment can be created using
+the virt-install program and Fedora Workstation Live CD
+media. As root follow the steps::
+
+  $ cd /var/lib/libvirt/images
+  $ wget https://fedora.mirrorservice.org/fedora/linux/releases/36/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-36-1.5.iso
+  $ virt-install \
+      --cdrom /var/lib/libvirt/images/Fedora-Workstation-Live-x86_64-36-1.5.iso \
+      --name f36live \
+      --memory 2000 \
+      --noautoconsole \
+      --vnc \
+      --disk /var/lib/libvirt/images/f37livedata1.img,size=10 \
+      --disk /var/lib/libvirt/images/f37livedata2.img,size=10
+
+Connect to this running VM using virt-viewer from your desktop::
+
+  $ virt-viewer -c qemu:///system f36live
+
+when the live environment is ready a few quick configuration
+steps are needed, from a terminal window in the guest:
+
+* Edit ``/etc/ssh/sshd_config`` to set ``PermitRootLogin yes``
+* Start SH with ``systemctl start sshd``
+* Run ``passwd`` to set a root password
+
+Note that if the VM is shutoff these steps will need repeating
+since the live CD environment is stateless.
+
+Back in the host OS, optionally deploy an SSH key to the VM
+to avoid the need to provide a password when running tests::
+
+  $ ssh-copy-id f36live
+
+Note the above assumes that the ``libvirt-nss`` package is
+installed  and ``libvirt_guest`` added to ``hosts:`` in
+``/etc/nsswitch.conf`` to provide DNS/IP resolution based
+on the guest VM name.
+
+With those setup steps completed, the tests can be run using::
+
+  $ python ./tests/vmtests/runvmtests.py \
+      --connection qemu:///system \
+      --repo https://github.com/<YOUR-USERNAME>/blivet \
+      --branch <GIT-BRANCH-TO-TEST> \
+      --name f36live \
+      --ip f36live
+
+The ``runvmtests.py`` script will save and restore snapshots
+of the guest VM memory and disk state either side of each
+test.  If a test fails, the ``--test`` arg takes the name of
+a single test class to run.

--- a/tests/vmtests/runvmtests.py
+++ b/tests/vmtests/runvmtests.py
@@ -29,7 +29,7 @@ def parse_args():
     parser.add_argument("--connection", type=str, help="Libvirt connection URI", required=True)
     parser.add_argument("--name", type=str, help="Name of the virtual machine", required=True)
     parser.add_argument("--ip", type=str, help="IP adress of the virtual machine", required=True)
-    parser.add_argument("--vmpass", type=str, help="Root passphrase for the virtual machine", required=True)
+    parser.add_argument("--vmpass", type=str, help="Root passphrase for the virtual machine", required=False)
     parser.add_argument("--virtpass", type=str, help="Root passphrase for the libvirt host", required=False)
     parser.add_argument("--verbose", "-v", action='store_true', help="Display verbose information")
     parser.add_argument("--debug", "-d", action='store_true', help="Display debugging information")
@@ -113,7 +113,7 @@ def ssh_connection(cmd_args):
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     try:
-        ssh.connect(cmd_args.ip, username="root", password=cmd_args.virtpass)
+        ssh.connect(cmd_args.ip, username="root", password=cmd_args.vmpass)
     except paramiko.AuthenticationException:
         raise RuntimeError("Authentication failed while trying to connect to virtual machine.")
 


### PR DESCRIPTION
I've struggled to figure out how to actually run the VM tests in blivet since there's no docs.

This series attempts to help in that respect by adding a tests/vmtests/README.rst file, whose content I inferred / reverse engineered from terse description in

```
commit aa9160875482debdf6eacc0cbfa6ca1906cf5cb1
Author: Vojtech Trefny <vtrefny@redhat.com>
Date:   Thu Aug 25 11:08:42 2016 +0200

    Add a script to run tests in a virtual machine
    
    This script will start the machine, make a snapshot of its initial
    state and run the tests on it (reverting to the snashot after each
    test). The VM must automatically boot to an live image with ssh
    enabled.
```

With the steps I document, I was able to successfully run the VM tests. If there is a better way to achieve this, that the maintainers typically follow, then please let me know and I'll improve/change the docs correspondingly.

In figuring this out, I felt the runvmtests.py script would benefit from logging. To speed up debugging failed tests I also make it possible to run just one test and to avoid starting/stopping the test VM. Indeed avoiding starting/stopping is key with my documented instructions since the Live CD image I suggested doesn't have SSH enabled by default.

There was also a small bug in password arg handling for SSH
