### PR TITLE
Support configuring partition type UUIDs for GPT partition auto-discovery

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -487,7 +487,7 @@ class Blivet(object):
         """
         if 'fmt_type' in kwargs:
             kwargs["fmt"] = get_format(kwargs.pop("fmt_type"),
-                                       mountpoint=kwargs.pop("mountpoint",
+                                       mountpoint=kwargs.get("mountpoint",
                                                              None),
                                        **kwargs.pop("fmt_args", {}))
 

--- a/blivet/devicelibs/gpt.py
+++ b/blivet/devicelibs/gpt.py
@@ -1,0 +1,251 @@
+# gpt.py
+# GPT partitioning helpers
+#
+# Copyright (C) Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import uuid
+
+from blivet.arch import get_arch
+from blivet.errors import GPTVolUUIDError
+
+GPT_VOL_ARCH_ROOT = "root"
+GPT_VOL_ARCH_ROOT_VERITY = "root_verity"
+GPT_VOL_ARCH_ROOT_VERITY_SIG = "root_verity_sig"
+GPT_VOL_ARCH_USR = "usr"
+GPT_VOL_ARCH_USR_VERITY = "usr_verity"
+GPT_VOL_ARCH_USR_VERITY_SIG = "usr_verity_sig"
+
+GPT_VOL_ESP = "esp"
+GPT_VOL_XBOOTLDR = "xbootldr"
+GPT_VOL_SWAP = "swap"
+GPT_VOL_HOME = "home"
+GPT_VOL_SRV = "srv"
+GPT_VOL_VAR = "var"
+GPT_VOL_TMP = "tmp"
+GPT_VOL_USER_HOME = "user_home"
+GPT_VOL_LINUX_GENERIC = "linux_generic"
+
+_gpt_common_uuid = {
+    GPT_VOL_ESP: uuid.UUID("c12a7328-f81f-11d2-ba4b-00a0c93ec93b"),
+    GPT_VOL_XBOOTLDR: uuid.UUID("bc13c2ff-59e6-4262-a352-b275fd6f7172"),
+    GPT_VOL_SWAP: uuid.UUID("0657fd6d-a4ab-43c4-84e5-0933c84b4f4f"),
+    GPT_VOL_HOME: uuid.UUID("933ac7e1-2eb4-4f13-b844-0e14e2aef915"),
+    GPT_VOL_SRV: uuid.UUID("3b8f8425-20e0-4f3b-907f-1a25a76f98e8"),
+    GPT_VOL_VAR: uuid.UUID("4d21b016-b534-45c2-a9fb-5c16e091fd2d"),
+    GPT_VOL_TMP: uuid.UUID("7ec6f557-3bc5-4aca-b293-16ef5df639d1"),
+    GPT_VOL_USER_HOME: uuid.UUID("773f91ef-66d4-49b5-bd83-d683bf40ad16"),
+    GPT_VOL_LINUX_GENERIC: uuid.UUID("0fc63daf-8483-4772-8e79-3d69d8477de4"),
+}
+
+_gpt_arch_uuid = {
+    GPT_VOL_ARCH_ROOT: {
+        "alpha": uuid.UUID("6523f8ae-3eb1-4e2a-a05a-18b695ae656f"),
+        "arc": uuid.UUID("d27f46ed-2919-4cb8-bd25-9531f3c16534"),
+        "arm": uuid.UUID("69dad710-2ce4-4e3c-b16c-21a1d49abed3"),
+        "aarch64": uuid.UUID("b921b045-1df0-41c3-af44-4c6f280d3fae"),
+        "i386": uuid.UUID("44479540-f297-41b2-9af7-d131d5f0458a"),
+        "ia64": uuid.UUID("993d8d3d-f80e-4225-855a-9daf8ed7ea97"),
+        "loongarch64": uuid.UUID("77055800-792c-4f94-b39a-98c91b762bb6"),
+        "mips64el": uuid.UUID("700bda43-7a34-4507-b179-eeb93d7a7ca3"),
+        "mipsel": uuid.UUID("37c58c8a-d913-4156-a25f-48b1b64e07f0"),
+        "parisc": uuid.UUID("1aacdb3b-5444-4138-bd9e-e5c2239b2346"),
+        "ppc": uuid.UUID("1de3f1ef-fa98-47b5-8dcd-4a860a654d78"),
+        "ppc64": uuid.UUID("912ade1d-a839-4913-8964-a10eee08fbd2"),
+        "ppc64el": uuid.UUID("c31c45e6-3f39-412e-80fb-4809c4980599"),
+        "riscv32": uuid.UUID("60d5a7fe-8e7d-435c-b714-3dd8162144e1"),
+        "riscv64": uuid.UUID("72ec70a6-cf74-40e6-bd49-4bda08e8f224"),
+        "s390": uuid.UUID("08a7acea-624c-4a20-91e8-6e0fa67d23f9"),
+        "s390x": uuid.UUID("5eead9a9-fe09-4a1e-a1d7-520d00531306"),
+        "tilegx": uuid.UUID("c50cdd70-3862-4cc3-90e1-809a8c93ee2c"),
+        "x86_64": uuid.UUID("4f68bce3-e8cd-4db1-96e7-fbcaf984b709"),
+    },
+    GPT_VOL_ARCH_ROOT_VERITY: {
+        "alpha": uuid.UUID("fc56d9e9-e6e5-4c06-be32-e74407ce09a5"),
+        "arc": uuid.UUID("24b2d975-0f97-4521-afa1-cd531e421b8d"),
+        "arm": uuid.UUID("7386cdf2-203c-47a9-a498-f2ecce45a2d6"),
+        "aarch64": uuid.UUID("df3300ce-d69f-4c92-978c-9bfb0f38d820"),
+        "i386": uuid.UUID("d13c5d3b-b5d1-422a-b29f-9454fdc89d76"),
+        "ia64": uuid.UUID("86ed10d5-b607-45bb-8957-d350f23d0571"),
+        "loongarch64": uuid.UUID("f3393b22-e9af-4613-a948-9d3bfbd0c535"),
+        "mips64el": uuid.UUID("16b417f8-3e06-4f57-8dd2-9b5232f41aa6"),
+        "mipsel": uuid.UUID("d7d150d2-2a04-4a33-8f12-16651205ff7b"),
+        "parisc": uuid.UUID("d212a430-fbc5-49f9-a983-a7feef2b8d0e"),
+        "ppc": uuid.UUID("98cfe649-1588-46dc-b2f0-add147424925"),
+        "ppc64": uuid.UUID("9225a9a3-3c19-4d89-b4f6-eeff88f17631"),
+        "ppc64el": uuid.UUID("906bd944-4589-4aae-a4e4-dd983917446a"),
+        "riscv32": uuid.UUID("ae0253be-1167-4007-ac68-43926c14c5de"),
+        "riscv64": uuid.UUID("b6ed5582-440b-4209-b8da-5ff7c419ea3d"),
+        "s390": uuid.UUID("7ac63b47-b25c-463b-8df8-b4a94e6c90e1"),
+        "s390x": uuid.UUID("b325bfbe-c7be-4ab8-8357-139e652d2f6b"),
+        "tilegx": uuid.UUID("966061ec-28e4-4b2e-b4a5-1f0a825a1d84"),
+        "x86_64": uuid.UUID("2c7357ed-ebd2-46d9-aec1-23d437ec2bf5"),
+    },
+    GPT_VOL_ARCH_ROOT_VERITY_SIG: {
+        "alpha": uuid.UUID("d46495b7-a053-414f-80f7-700c99921ef8"),
+        "arc": uuid.UUID("143a70ba-cbd3-4f06-919f-6c05683a78bc"),
+        "arm": uuid.UUID("42b0455f-eb11-491d-98d3-56145ba9d037"),
+        "aarch64": uuid.UUID("6db69de6-29f4-4758-a7a5-962190f00ce3"),
+        "i386": uuid.UUID("5996fc05-109c-48de-808b-23fa0830b676"),
+        "ia64": uuid.UUID("e98b36ee-32ba-4882-9b12-0ce14655f46a"),
+        "loongarch64": uuid.UUID("5afb67eb-ecc8-4f85-ae8e-ac1e7c50e7d0"),
+        "mips64el": uuid.UUID("904e58ef-5c65-4a31-9c57-6af5fc7c5de7"),
+        "mipsel": uuid.UUID("c919cc1f-4456-4eff-918c-f75e94525ca5"),
+        "parisc": uuid.UUID("15de6170-65d3-431c-916e-b0dcd8393f25"),
+        "ppc": uuid.UUID("1b31b5aa-add9-463a-b2ed-bd467fc857e7"),
+        "ppc64": uuid.UUID("f5e2c20c-45b2-4ffa-bce9-2a60737e1aaf"),
+        "ppc64el": uuid.UUID("d4a236e7-e873-4c07-bf1d-bf6cf7f1c3c6"),
+        "riscv32": uuid.UUID("3a112a75-8729-4380-b4cf-764d79934448"),
+        "riscv64": uuid.UUID("efe0f087-ea8d-4469-821a-4c2a96a8386a"),
+        "s390": uuid.UUID("3482388e-4254-435a-a241-766a065f9960"),
+        "s390x": uuid.UUID("c80187a5-73a3-491a-901a-017c3fa953e9"),
+        "tilegx": uuid.UUID("b3671439-97b0-4a53-90f7-2d5a8f3ad47b"),
+        "x86_64": uuid.UUID("41092b05-9fc8-4523-994f-2def0408b176"),
+    },
+    GPT_VOL_ARCH_USR: {
+        "alpha": uuid.UUID("e18cf08c-33ec-4c0d-8246-c6c6fb3da024"),
+        "arc": uuid.UUID("7978a683-6316-4922-bbee-38bff5a2fecc"),
+        "arm": uuid.UUID("7d0359a3-02b3-4f0a-865c-654403e70625"),
+        "aarch64": uuid.UUID("b0e01050-ee5f-4390-949a-9101b17104e9"),
+        "i386": uuid.UUID("75250d76-8cc6-458e-bd66-bd47cc81a812"),
+        "ia64": uuid.UUID("4301d2a6-4e3b-4b2a-bb94-9e0b2c4225ea"),
+        "loongarch64": uuid.UUID("e611c702-575c-4cbe-9a46-434fa0bf7e3f"),
+        "mips64el": uuid.UUID("c97c1f32-ba06-40b4-9f22-236061b08aa8"),
+        "mipsel": uuid.UUID("0f4868e9-9952-4706-979f-3ed3a473e947"),
+        "parisc": uuid.UUID("dc4a4480-6917-4262-a4ec-db9384949f25"),
+        "ppc": uuid.UUID("7d14fec5-cc71-415d-9d6c-06bf0b3c3eaf"),
+        "ppc64": uuid.UUID("2c9739e2-f068-46b3-9fd0-01c5a9afbcca"),
+        "ppc64el": uuid.UUID("15bb03af-77e7-4d4a-b12b-c0d084f7491c"),
+        "riscv32": uuid.UUID("b933fb22-5c3f-4f91-af90-e2bb0fa50702"),
+        "riscv64": uuid.UUID("beaec34b-8442-439b-a40b-984381ed097d"),
+        "s390": uuid.UUID("cd0f869b-d0fb-4ca0-b141-9ea87cc78d66"),
+        "s390x": uuid.UUID("8a4f5770-50aa-4ed3-874a-99b710db6fea"),
+        "tilegx": uuid.UUID("55497029-c7c1-44cc-aa39-815ed1558630"),
+        "x86_64": uuid.UUID("8484680c-9521-48c6-9c11-b0720656f69e"),
+    },
+    GPT_VOL_ARCH_USR_VERITY: {
+        "alpha": uuid.UUID("8cce0d25-c0d0-4a44-bd87-46331bf1df67"),
+        "arc": uuid.UUID("fca0598c-d880-4591-8c16-4eda05c7347c"),
+        "arm": uuid.UUID("c215d751-7bcd-4649-be90-6627490a4c05"),
+        "aarch64": uuid.UUID("6e11a4e7-fbca-4ded-b9e9-e1a512bb664e"),
+        "i386": uuid.UUID("8f461b0d-14ee-4e81-9aa9-049b6fb97abd"),
+        "ia64": uuid.UUID("6a491e03-3be7-4545-8e38-83320e0ea880"),
+        "loongarch64": uuid.UUID("f46b2c26-59ae-48f0-9106-c50ed47f673d"),
+        "mips64el": uuid.UUID("3c3d61fe-b5f3-414d-bb71-8739a694a4ef"),
+        "mipsel": uuid.UUID("46b98d8d-b55c-4e8f-aab3-37fca7f80752"),
+        "parisc": uuid.UUID("5843d618-ec37-48d7-9f12-cea8e08768b2"),
+        "ppc": uuid.UUID("df765d00-270e-49e5-bc75-f47bb2118b09"),
+        "ppc64": uuid.UUID("bdb528a5-a259-475f-a87d-da53fa736a07"),
+        "ppc64el": uuid.UUID("ee2b9983-21e8-4153-86d9-b6901a54d1ce"),
+        "riscv32": uuid.UUID("cb1ee4e3-8cd0-4136-a0a4-aa61a32e8730"),
+        "riscv64": uuid.UUID("8f1056be-9b05-47c4-81d6-be53128e5b54"),
+        "s390": uuid.UUID("b663c618-e7bc-4d6d-90aa-11b756bb1797"),
+        "s390x": uuid.UUID("31741cc4-1a2a-4111-a581-e00b447d2d06"),
+        "tilegx": uuid.UUID("2fb4bf56-07fa-42da-8132-6b139f2026ae"),
+        "x86_64": uuid.UUID("77ff5f63-e7b6-4633-acf4-1565b864c0e6"),
+    },
+    GPT_VOL_ARCH_USR_VERITY_SIG: {
+        "alpha": uuid.UUID("5c6e1c76-076a-457a-a0fe-f3b4cd21ce6e"),
+        "arc": uuid.UUID("94f9a9a1-9971-427a-a400-50cb297f0f35"),
+        "arm": uuid.UUID("d7ff812f-37d1-4902-a810-d76ba57b975a"),
+        "aarch64": uuid.UUID("c23ce4ff-44bd-4b00-b2d4-b41b3419e02a"),
+        "i386": uuid.UUID("974a71c0-de41-43c3-be5d-5c5ccd1ad2c0"),
+        "ia64": uuid.UUID("8de58bc2-2a43-460d-b14e-a76e4a17b47f"),
+        "loongarch64": uuid.UUID("b024f315-d330-444c-8461-44bbde524e99"),
+        "mips64el": uuid.UUID("f2c2c7ee-adcc-4351-b5c6-ee9816b66e16"),
+        "mipsel": uuid.UUID("3e23ca0b-a4bc-4b4e-8087-5ab6a26aa8a9"),
+        "parisc": uuid.UUID("450dd7d1-3224-45ec-9cf2-a43a346d71ee"),
+        "ppc": uuid.UUID("7007891d-d371-4a80-86a4-5cb875b9302e"),
+        "ppc64": uuid.UUID("0b888863-d7f8-4d9e-9766-239fce4d58af"),
+        "ppc64el": uuid.UUID("c8bfbd1e-268e-4521-8bba-bf314c399557"),
+        "riscv32": uuid.UUID("c3836a13-3137-45ba-b583-b16c50fe5eb4"),
+        "riscv64": uuid.UUID("d2f9000a-7a18-453f-b5cd-4d32f77a7b32"),
+        "s390": uuid.UUID("17440e4f-a8d0-467f-a46e-3912ae6ef2c5"),
+        "s390x": uuid.UUID("3f324816-667b-46ae-86ee-9b0c0c6c11b4"),
+        "tilegx": uuid.UUID("4ede75e2-6ccc-4cc8-b9c7-70334b087510"),
+        "x86_64": uuid.UUID("e7bb33fb-06cf-4e81-8273-e543b413e2e2"),
+    },
+}
+
+
+def gpt_part_uuid_for_volume(voltype, arch=None):
+    """
+    :param path: the volume type as a GPT_VOL constant
+    :type path: str
+    :param arch: the architecture of the target install, None to use host arch
+    :type path: str
+
+    :returns: the GPT partition type UUID or None
+    :rtype: str
+
+    Given a volume type defined by one of the GPT_VOL constants,
+    determine if there is a well known GPT partition type UUID
+    associated to allow the partition to be automatically mounted.
+
+    The architecture must be canonicalized in accordance with the
+    blivet.arch logic. Usually it can be omitted, to request use
+    of the host architecture detected by blivet.arch.get_arch.
+    """
+    if voltype in _gpt_common_uuid:
+        return _gpt_common_uuid[voltype]
+    elif voltype not in _gpt_arch_uuid:
+        raise GPTVolUUIDError("Unknown volume type")
+
+    if arch is None:
+        arch = get_arch()
+
+    if arch not in _gpt_arch_uuid[voltype]:
+        raise GPTVolUUIDError("Unknown architecture %s" % arch)
+
+    return _gpt_arch_uuid[voltype][arch]
+
+
+def gpt_part_uuid_for_mountpoint(path, arch=None):
+    """
+    :param path: the absolute path at which a filesystem is to be mounted
+    :type path: str
+    :param arch: the architecture of the target install, None to use host arch
+    :type path: str
+
+    :returns: the GPT partition type UUID or None
+    :rtype: str
+
+    Given an absolute path at which a filesystem is to be mounted,
+    determine if there is a well known GPT partition type UUID
+    associated to allow the partition to be automatically mounted.
+
+    The architecture must be canonicalized in accordance with the
+    blivet.arch logic. Usually it can be omitted, to request use
+    of the host architecture detected by blivet.arch.get_arch.
+    """
+    mapping = {
+        "/": GPT_VOL_ARCH_ROOT,
+        "/usr": GPT_VOL_ARCH_USR,
+
+        "/efi": GPT_VOL_ESP,
+        "/boot/efi": GPT_VOL_ESP,
+        "/boot": GPT_VOL_XBOOTLDR,
+        "/home": GPT_VOL_HOME,
+        "/var": GPT_VOL_VAR,
+        "/srv": GPT_VOL_SRV,
+        "/tmp": GPT_VOL_TMP,
+    }
+
+    if path not in mapping:
+        return None
+
+    return gpt_part_uuid_for_volume(mapping[path], arch)

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -22,6 +22,7 @@
 import os
 import parted
 import _ped
+from uuid import UUID
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -70,7 +71,8 @@ class PartitionDevice(StorageDevice):
                  size=None, grow=False, maxsize=None, start=None, end=None,
                  major=None, minor=None, bootable=None,
                  sysfs_path='', parents=None, exists=False,
-                 part_type=None, primary=False, weight=None, disk_tags=None):
+                 part_type=None, primary=False, weight=None, disk_tags=None,
+                 part_type_uuid=None):
         """
             :param name: the device name (generally a device node's basename)
             :type name: str
@@ -112,6 +114,8 @@ class PartitionDevice(StorageDevice):
             :type weight: int or NoneType
             :keyword disk_tags: (str) tags defining candidate disk set
             :type disk_tags: iterable
+            :keyword part_type_uuid: GPT partition type UUID or None
+            :type part_type_uuid: uuid.UUID or NoneType
 
             .. note::
 
@@ -142,6 +146,7 @@ class PartitionDevice(StorageDevice):
         self.req_start_sector = None
         self.req_end_sector = None
         self.req_name = None
+        self.req_part_type_uuid = None
 
         self._bootable = False
 
@@ -150,6 +155,7 @@ class PartitionDevice(StorageDevice):
         self._part_type = None
         self._parted_partition = None
         self._orig_path = None
+        self._part_type_uuid = None
 
         if not exists and size is None:
             if start is not None and end is not None:
@@ -221,6 +227,8 @@ class PartitionDevice(StorageDevice):
             self.req_start_sector = start
             self.req_end_sector = end
 
+            self.req_part_type_uuid = part_type_uuid
+
         # update current_size again now when we have parted_partition and
         # information about part_type
         if self.exists and self.status:
@@ -246,7 +254,8 @@ class PartitionDevice(StorageDevice):
                    "start": self.parted_partition.geometry.start,
                    "end": self.parted_partition.geometry.end,
                    "flags": self.parted_partition.getFlagsAsString()})
-
+            if hasattr(parted.Partition, "type_uuid"):
+                s += " type_uuid = %s" % self.parted_partition.type_uuid
         return s
 
     @property
@@ -263,6 +272,8 @@ class PartitionDevice(StorageDevice):
                       "start": self.parted_partition.geometry.start,
                       "end": self.parted_partition.geometry.end,
                       "flags": self.parted_partition.getFlagsAsString()})
+            if hasattr(parted.Partition, "type_uuid"):
+                d.update({"type_uuid": self.parted_partition.type_uuid})
         return d
 
     def align_target_size(self, newsize):
@@ -327,6 +338,25 @@ class PartitionDevice(StorageDevice):
             ptype = self.req_part_type
 
         return ptype
+
+    @property
+    def part_type_uuid_req(self):
+        if self.req_part_type_uuid is not None:
+            return self.req_part_type_uuid
+        return None
+
+    @property
+    def part_type_uuid(self):
+        """ Get the partition's type (as a UUID object). """
+        if not self.exists:
+            return self.part_type_uuid_req
+        else:
+            if hasattr(parted.Partition, "type_uuid"):
+                try:
+                    return UUID(bytes=self.parted_partition.type_uuid)
+                except AttributeError:
+                    pass
+            return self._part_type_uuid
 
     @property
     def is_extended(self):
@@ -592,6 +622,8 @@ class PartitionDevice(StorageDevice):
         self.target_size = self._size
 
         self._part_type = self.parted_partition.type
+        if hasattr(parted.Partition, "type_uuid"):
+            self._part_type_uuid = self.parted_partition.type_uuid
 
         self._bootable = self.get_flag(parted.PARTITION_BOOT)
 
@@ -637,7 +669,8 @@ class PartitionDevice(StorageDevice):
         log_method_call(self, self.name, status=self.status)
         self.disk.format.add_partition(self.parted_partition.geometry.start,
                                        self.parted_partition.geometry.end,
-                                       self.parted_partition.type)
+                                       self.parted_partition.type,
+                                       self.part_type_uuid)
 
         self._wipe()
         try:

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -330,3 +330,7 @@ class ISCSIError(StorageError, OSError):
 
 class NVMeError(StorageError, OSError):
     pass
+
+
+class GPTVolUUIDError(StorageError):
+    pass

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -91,6 +91,11 @@ class Flags(object):
 
         self.debug_threads = False
 
+        # Assign GPT partition type UUIDs to allow partition
+        # auto-discovery according to:
+        # https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
+        self.gpt_discoverable_partitions = False
+
     def get_boot_cmdline(self):
         with open("/proc/cmdline") as f:
             buf = f.read().strip()

--- a/examples/partitioning.py
+++ b/examples/partitioning.py
@@ -1,7 +1,12 @@
 import os
 
 import blivet
+from uuid import UUID
+from blivet.devices import LUKSDevice
 from blivet.size import Size
+from blivet.flags import flags
+from blivet import formats
+from blivet.formats import disklabel
 from blivet.util import set_up_logging, create_sparse_tempfile
 
 set_up_logging()
@@ -15,6 +20,9 @@ b.disk_images["disk2"] = disk2_file
 
 b.reset()
 
+disklabel.DiskLabel.set_default_label_type("gpt")
+flags.gpt_discoverable_partitions = True
+
 try:
     disk1 = b.devicetree.get_device_by_name("disk1")
     disk2 = b.devicetree.get_device_by_name("disk2")
@@ -24,20 +32,37 @@ try:
 
     # new partition on either disk1 or disk2 with base size 10GiB and growth
     # up to a maximum size of 50GiB
-    dev = b.new_partition(size=Size("10MiB"), maxsize=Size("50GiB"),
-                          grow=True, parents=[disk1, disk2])
-    b.create_device(dev)
+    root = b.new_partition(size=Size("10MiB"), maxsize=Size("50GiB"),
+                           grow=True, parents=[disk1, disk2],
+                           mountpoint="/")
+    b.create_device(root)
 
     # new partition on disk1 with base size 5GiB and unbounded growth and an
     # ext4 filesystem
-    dev = b.new_partition(fmt_type="ext4", size=Size("5GiB"), grow=True,
-                          parents=[disk1])
-    b.create_device(dev)
+    home = b.new_partition(fmt_type="ext4", size=Size("5GiB"), grow=True,
+                           parents=[disk1], mountpoint="/home")
+    b.create_device(home)
+
+    var = b.new_partition(fmt_type="luks",
+                          fmt_args={
+                              "passphrase": "123456",
+                          }, size=Size("200MiB"),
+                          parents=[disk2],
+                          mountpoint="/var")
+    b.create_device(var)
+
+    varenc = LUKSDevice(
+        name="luks-user", size=var.size, parents=var)
+    b.create_device(varenc)
+
+    varfs = formats.get_format(
+        fmt_type="ext4", device=varenc.path, mountpoint="/usr")
+    b.format_device(varenc, varfs)
 
     # new partition on any suitable disk with a fixed size of 2GiB formatted
     # as swap space
-    dev = b.new_partition(fmt_type="swap", size=Size("2GiB"))
-    b.create_device(dev)
+    swap = b.new_partition(fmt_type="swap", size=Size("2GiB"))
+    b.create_device(swap)
 
     # allocate the partitions (decide where and on which disks they'll reside)
     blivet.partitioning.do_partitioning(b)
@@ -46,6 +71,12 @@ try:
     # write the new partitions to disk and format them as specified
     b.do_it()
     print(b.devicetree)
+
+    print("/ assigned GUID %s" % UUID(bytes=root.parted_partition.type_uuid))
+    print("/home assigned GUID %s" % UUID(bytes=home.parted_partition.type_uuid))
+    print("/var assigned GUID %s" % UUID(bytes=var.parted_partition.type_uuid))
+    print("<swap> assigned GUID %s" % UUID(bytes=swap.parted_partition.type_uuid))
+
 finally:
     b.devicetree.teardown_disk_images()
     os.unlink(disk1_file)

--- a/tests/unit_tests/devices_test/device_methods_test.py
+++ b/tests/unit_tests/devices_test/device_methods_test.py
@@ -263,6 +263,7 @@ class PartitionDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
             super(PartitionDeviceMethodsTestCase, self).test_create()
 
         with patch.object(self.device, "_wipe"):
+            self.device.parted_partition.type_uuid = bytes([0] * 16)
             self.device._create()
             self.assertTrue(self.device.disk.format.add_partition.called)
             self.assertTrue(self.device.disk.format.commit.called)

--- a/tests/unit_tests/gpt_test.py
+++ b/tests/unit_tests/gpt_test.py
@@ -1,0 +1,76 @@
+# gpt_test.py
+# GPT partitioning helpers test suite
+#
+# Copyright (C) Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import unittest
+from uuid import UUID
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from blivet.devicelibs import gpt
+from blivet.errors import GPTVolUUIDError
+
+
+class GPTTestCase(unittest.TestCase):
+
+    def test_uuid_for_vol_arch_less(self):
+        uuid = gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_SRV)
+        self.assertEqual(uuid, UUID("3b8f8425-20e0-4f3b-907f-1a25a76f98e8"))
+
+    @mock.patch("blivet.devicelibs.gpt.get_arch", return_value="ppc64")
+    def test_uuid_for_vol_arch_implicit(self, mock_get_arch):
+        uuid = gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_ARCH_USR_VERITY)
+        mock_get_arch.assert_called_once()
+        self.assertEqual(uuid, UUID("bdb528a5-a259-475f-a87d-da53fa736a07"))
+
+    def test_uuid_for_vol_arch_explicit(self):
+        uuid = gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_ARCH_USR_VERITY,
+                                            arch="s390")
+        self.assertEqual(uuid, UUID("b663c618-e7bc-4d6d-90aa-11b756bb1797"))
+
+    def test_uuid_for_vol_arch_unknown(self):
+        with self.assertRaises(GPTVolUUIDError):
+            gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_ARCH_USR_VERITY,
+                                         arch="nope")
+
+    def test_uuid_for_vol_unknown(self):
+        with self.assertRaises(GPTVolUUIDError):
+            gpt.gpt_part_uuid_for_volume("nope")
+
+    def test_uuid_for_path_arch_less(self):
+        uuid = gpt.gpt_part_uuid_for_mountpoint("/home")
+        self.assertEqual(uuid, UUID("933ac7e1-2eb4-4f13-b844-0e14e2aef915"))
+
+    @mock.patch("blivet.devicelibs.gpt.get_arch", return_value="ppc64")
+    def test_uuid_for_path_arch_implicit(self, mock_get_arch):
+        uuid = gpt.gpt_part_uuid_for_mountpoint("/")
+        mock_get_arch.assert_called_once()
+        self.assertEqual(uuid, UUID("912ade1d-a839-4913-8964-a10eee08fbd2"))
+
+    def test_uuid_for_path_arch_explicit(self):
+        uuid = gpt.gpt_part_uuid_for_mountpoint("/",
+                                                arch="s390")
+        self.assertEqual(uuid, UUID("08a7acea-624c-4a20-91e8-6e0fa67d23f9"))
+
+    def test_uuid_for_path_unknown(self):
+        uuid = gpt.gpt_part_uuid_for_mountpoint("/nope")
+        self.assertEqual(uuid, None)

--- a/tests/vmtests/gpt_test.py
+++ b/tests/vmtests/gpt_test.py
@@ -1,0 +1,174 @@
+import unittest
+from uuid import UUID
+
+from .vmbackedtestcase import VMBackedTestCase
+
+from blivet.devicelibs import gpt
+from blivet.devices import LUKSDevice
+from blivet.flags import flags
+from blivet import formats
+from blivet.formats import disklabel
+from blivet import partitioning
+from blivet.size import Size
+from blivet.util import set_up_logging
+
+import parted
+
+set_up_logging()
+
+
+class GPTTestBase(VMBackedTestCase):
+
+    # Default parted GUID for "Linux Data" partition
+    LINUX_DATA_GUID = UUID("0fc63daf-8483-4772-8e79-3d69d8477de4")
+
+    def __init__(self, *args, **kwargs):
+        super(GPTTestBase, self).__init__(*args, **kwargs)
+
+        self.root = None
+        self.home = None
+        self.tmp = None
+        self.srv = None
+        self.etc = None
+        self.swap = None
+        self.usrluks = None
+        self.usr = None
+
+    def set_up_disks(self):
+        disklabel.DiskLabel.set_default_label_type("gpt")
+
+    def _clean_up(self):
+        super(GPTTestBase, self)._clean_up()
+
+        disklabel.DiskLabel.set_default_label_type(None)
+
+    def _set_up_storage(self):
+        # A part whose UUID varies per architecture, without FS formatted
+        self.root = self.blivet.new_partition(
+            size=Size("10MiB"), maxsize=Size("50GiB"), grow=True,
+            parents=self.blivet.disks, mountpoint="/")
+        self.blivet.create_device(self.root)
+
+        # A part whose UUID is fixed per architecture, without FS formatted
+        self.home = self.blivet.new_partition(
+            size=Size("50MiB"), parents=self.blivet.disks,
+            mountpoint="/home")
+        self.blivet.create_device(self.home)
+
+        # A part whose UUID is fixed per architecture, with FS formatted
+        self.tmp = self.blivet.new_partition(
+            fmt_type="ext4", size=Size("50MiB"),
+            parents=self.blivet.disks, mountpoint="/tmp")
+        self.blivet.create_device(self.tmp)
+
+        # A part whose UUID specified explicitly, with FS formatted
+        self.srv = self.blivet.new_partition(
+            fmt_type="ext4", size=Size("50MiB"),
+            parents=self.blivet.disks, mountpoint="/srv",
+            part_type_uuid=gpt.gpt_part_uuid_for_mountpoint("/srv"))
+        self.blivet.create_device(self.srv)
+
+        # A part with no special UUID assignment
+        self.etc = self.blivet.new_partition(
+            size=Size("20MiB"), parents=self.blivet.disks,
+            mountpoint="/etc")
+        self.blivet.create_device(self.etc)
+
+        # A part whose UUID is based off fmt type
+        self.swap = self.blivet.new_partition(
+            fmt_type="swap", size=Size("20MiB"), parents=self.blivet.disks)
+        self.blivet.create_device(self.swap)
+
+        # An encrypted part
+        self.usrluks = self.blivet.new_partition(
+            fmt_type="luks", fmt_args={
+                "passphrase": "123456",
+            }, size=Size("100MiB"),
+            parents=self.blivet.disks, mountpoint="/usr")
+        self.blivet.create_device(self.usrluks)
+
+        self.usr = LUKSDevice(
+            name="luks-user", size=self.usrluks.size, parents=self.usrluks)
+        self.blivet.create_device(self.usr)
+
+        extfs = formats.get_format(
+            fmt_type="ext4", device=self.usr.path, mountpoint="/usr")
+        self.blivet.format_device(self.usr, extfs)
+
+        # Allocate the partitions
+        partitioning.do_partitioning(self.blivet)
+
+
+class GPTDiscoverableTestCase(GPTTestBase):
+
+    def setUp(self):
+        olddisc = flags.gpt_discoverable_partitions
+        flags.gpt_discoverable_partitions = True
+        super(GPTDiscoverableTestCase, self).setUp()
+        flags.gpt_discoverable_partitions = olddisc
+
+    @unittest.skipUnless(hasattr(parted.Partition, "type_uuid"),
+                         "requires part type UUID in pyparted")
+    def test_check_gpt_part_type(self):
+        want = gpt.gpt_part_uuid_for_mountpoint("/")
+        got = UUID(bytes=self.root.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        want = gpt.gpt_part_uuid_for_mountpoint("/home")
+        got = UUID(bytes=self.home.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        want = gpt.gpt_part_uuid_for_mountpoint("/tmp")
+        got = UUID(bytes=self.tmp.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        want = gpt.gpt_part_uuid_for_mountpoint("/srv")
+        got = UUID(bytes=self.srv.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        got = UUID(bytes=self.etc.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)
+
+        want = gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_SWAP)
+        got = UUID(bytes=self.swap.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        want = gpt.gpt_part_uuid_for_mountpoint("/usr")
+        got = UUID(bytes=self.usrluks.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+
+class GPTNonDiscoverableTestCase(GPTTestBase):
+
+    def setUp(self):
+        olddisc = flags.gpt_discoverable_partitions
+        flags.gpt_discoverable_partitions = False
+        super(GPTNonDiscoverableTestCase, self).setUp()
+        flags.gpt_discoverable_partitions = olddisc
+
+    @unittest.skipUnless(hasattr(parted.Partition, "type_uuid"),
+                         "requires part type UUID in pyparted")
+    def test_check_gpt_part_type(self):
+
+        got = UUID(bytes=self.root.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)
+
+        got = UUID(bytes=self.home.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)
+
+        got = UUID(bytes=self.tmp.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)
+
+        want = gpt.gpt_part_uuid_for_mountpoint("/srv")
+        got = UUID(bytes=self.srv.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        got = UUID(bytes=self.etc.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)
+
+        want = gpt.gpt_part_uuid_for_volume(gpt.GPT_VOL_SWAP)
+        got = UUID(bytes=self.swap.parted_partition.type_uuid)
+        self.assertEqual(want, got)
+
+        got = UUID(bytes=self.usrluks.parted_partition.type_uuid)
+        self.assertEqual(self.LINUX_DATA_GUID, got)

--- a/tests/vmtests/runvmtests.py
+++ b/tests/vmtests/runvmtests.py
@@ -37,6 +37,7 @@ def parse_args():
     parser.add_argument("--verbose", "-v", action='store_true', help="Display verbose information")
     parser.add_argument("--debug", "-d", action='store_true', help="Display debugging information")
     parser.add_argument("--test", "-t", help="Filter test classes to PATTERN")
+    parser.add_argument("--logs", "-l", action='store_true', help="Capture and save blivet.log per failed test")
     args = parser.parse_args()
     return args
 
@@ -172,6 +173,14 @@ def run_tests(cmd_args):
 
                 print(out)
                 print(err)
+
+                if ret != 0 and cmd_args.logs:
+                    _stdin, stdout, _stderr = ssh.exec_command("cat /tmp/blivet.log")
+                    out = stdout.read().decode("utf-8")
+
+                    logfile = "blivet-" + test + ".log"
+                    with open(logfile, "w") as fh:
+                        print(out, file=fh)
 
                 # save the result
                 if ret != 0:

--- a/tests/vmtests/runvmtests.py
+++ b/tests/vmtests/runvmtests.py
@@ -18,7 +18,9 @@ TESTS = ["tests.vmtests.blivet_reset_vmtest.LVMTestCase",
          "tests.vmtests.blivet_reset_vmtest.MDRaid0TestCase",
          "tests.vmtests.blivet_reset_vmtest.LVMOnMDTestCase",
          "tests.vmtests.blivet_reset_vmtest.LVMVDOTestCase",
-         "tests.vmtests.blivet_reset_vmtest.StratisTestCase"]
+         "tests.vmtests.blivet_reset_vmtest.StratisTestCase",
+         "tests.vmtests.gpt_test.GPTDiscoverableTestCase",
+         "tests.vmtests.gpt_test.GPTNonDiscoverableTestCase"]
 
 SNAP_NAME = "snapshot"
 


### PR DESCRIPTION
The discoverable partitions specification defines a way to identify partitions used for various well known mount points:

  https://uapi-group.org/specifications/specs/discoverable_partitions_specification/

This relies on setting well known GPT partition GUIDs, instead of parted's generic "Linux Data"  GUID which more or less everything gets set to today (swap being a notable exception).

My goal is to make it possible for applications like Anaconda to "do the right thing(tm)" with little to no effort when doing disk partitioning. This series aims to make that possible, while still retaining the current behaviour by default for the sake of backwards compatibility.

With this series, a simple app usage might not need anything more than to opt-in to discoverable partitions with:

```
from blivet.git import gpt_set_discoverable_partitions

gpt_set_discoverable_partitions(True)
```

Assuming the disk has 'gpt' disk label and the app is already passing 'mountpoint' to the ``blivet.new_partition()`` method then it will "just work" and pick the right GUID for the given mount point. The `mountpoint` parameter would historically only be needed if a format is requested with `new_partition`, but now it can be passed regardless so it can be forwarded onto the `PartitionDevice` constructor.

The `examples/partitioning.py` script illustrates this, as does a comprehensive test at ``tests/vmtests/gpt_test.py``

If the app is more advanced and creating `PartitionDevice` instances directly instead of via the convenient `blivet.py` API entrypoints, then it will need to be changed to pass `mountpoint` to this object constructor too, but this is still hopefully fairly straightforward. 

Note that this functionality relies on `pypartd` exposing the `type_uuid` attribute on the Partition object. This is new functionality added to pyparted last month in https://github.com/dcantrell/pyparted/pull/95  Note `pyparted` only exposes this if compiled against a new enough `parted`. As a result some code additions in this series have 'hasattr' changes to attempt to gracefully degrade when the functionality is missing.

Since this is my first time looking at Blivet code in any detail, its taken me a while to get my head around the design and expected usage patterns. I'm still not entirely confident in my understanding, but the `examples/partitioning.py` script is at least doing the right thing with this series of changes.

Happy to have feedback on things I've overlooked / approached in the wrong/suboptimal way.