### PR TITLE
ci: Run Anaconda tests correctly on rhel9-branch

### DIFF
--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      TARGET_BRANCH: 'master'
+      TARGET_BRANCH: 'rhel-9'
 
     steps:
       - name: Clone Anaconda repository

--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -1,5 +1,12 @@
 name: Run validation tests from Anaconda
-on: pull_request
+
+on:
+  pull_request:
+    branches:
+     - rhel9-branch
+  push:
+    branches:
+     - rhel9-branch
 
 permissions:
   contents: read

--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -43,10 +43,11 @@ jobs:
           # - Install dependencies for blivet.
           # - Install blivet to the container.
           # - Run Anaconda tests.
-          podman run -i --rm -v ./blivet:/blivet:z -v ./anaconda:/anaconda:z quay.io/rhinstaller/anaconda-ci:$TARGET_BRANCH sh -c " \
+          podman run -i --rm -v ./blivet:/blivet:z -v ./anaconda:/anaconda:z quay.io/rhinstaller/anaconda-ci:master sh -c " \
               set -xe; \
               dnf remove -y python3-blivet; \
               dnf install -y python3-blockdev libblockdev-plugins-all python3-bytesize libbytesize python3-pyparted parted libselinux-python3; \
+              dnf install -y audit-libs audit-libs-devel; \
               cd /blivet; \
               python3 ./setup.py install; \
               cd /anaconda; \


### PR DESCRIPTION
So we can avoid issues like https://github.com/rhinstaller/anaconda/pull/4430 in the future when making changes in blivet.