### PR TITLE
Make sure we close the streams when reading a file

### DIFF
--- a/blivet/arch.py
+++ b/blivet/arch.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import os
 
 from .storage_log import log_exception_info
+from .util import read_file
 
 import logging
 log = logging.getLogger("blivet")
@@ -217,7 +218,7 @@ def is_t2mac():
     elif not os.path.isfile(DMI_PRODUCT_ID):
         t2_mac = False
     else:
-        buf = open(DMI_PRODUCT_ID).read()
+        buf = read_file(DMI_PRODUCT_ID)
         t2_mac = (buf in APPLE_T2_PRODUCT_NAMES)
     return t2_mac
 
@@ -236,7 +237,7 @@ def is_mactel():
         mactel = False
     else:
         try:
-            buf = open(DMI_CHASSIS_VENDOR).read()
+            buf = read_file(DMI_CHASSIS_VENDOR)
             mactel = ("apple" in buf.lower())
         except UnicodeDecodeError:
             mactel = False

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -447,7 +447,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         state_file = "%s/md/array_state" % self.sysfs_path
         try:
-            state = open(state_file).read().strip()
+            state = util.read_file(state_file).strip()
             if state in self._true_status_strings:
                 status = True
         except OSError:
@@ -462,7 +462,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         member_name = os.path.basename(member.sysfs_path)
         path = "/sys/%s/md/dev-%s/state" % (self.sysfs_path, member_name)
         try:
-            state = open(path).read().strip()
+            state = util.read_file(path).strip()
         except OSError:
             state = None
 
@@ -474,7 +474,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         rc = False
         degraded_file = "%s/md/degraded" % self.sysfs_path
         if os.access(degraded_file, os.R_OK):
-            val = open(degraded_file).read().strip()
+            val = util.read_file(degraded_file).strip()
             if val == "1":
                 rc = True
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -886,8 +886,7 @@ def device_get_iscsi_nic(info):
     iface = None
     session = device_get_iscsi_session(info)
     if session:
-        iface = open("/sys/class/iscsi_session/%s/ifacename" %
-                     session).read().strip()
+        iface = util.read_file("/sys/class/iscsi_session/%s/ifacename" % session).strip()
     return iface
 
 
@@ -898,7 +897,7 @@ def device_get_iscsi_initiator(info):
         if host:
             initiator_file = "/sys/class/iscsi_host/%s/initiatorname" % host
             if os.access(initiator_file, os.R_OK):
-                initiator = open(initiator_file, "rb").read().strip()
+                initiator = util.read_file(initiator_file, "rb").strip()
                 initiator_name = initiator.decode("utf-8", errors="replace")
                 log.debug("found offload iscsi initiatorname %s in file %s",
                           initiator_name, initiator_file)
@@ -907,8 +906,8 @@ def device_get_iscsi_initiator(info):
     if initiator_name is None:
         session = device_get_iscsi_session(info)
         if session:
-            initiator = open("/sys/class/iscsi_session/%s/initiatorname" %
-                             session, "rb").read().strip()
+            initiator = util.read_file("/sys/class/iscsi_session/%s/initiatorname" %
+                                       session, "rb").strip()
             initiator_name = initiator.decode("utf-8", errors="replace")
             log.debug("found iscsi initiatorname %s", initiator_name)
     return initiator_name

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -280,17 +280,17 @@ def get_mount_paths(dev):
 def get_mount_device(mountpoint):
     """ Given a mountpoint, return the device node path mounted there. """
     mountpoint = os.path.realpath(mountpoint)  # eliminate symlinks
-    mounts = open("/proc/mounts").readlines()
     mount_device = None
-    for mnt in mounts:
-        try:
-            (device, path, _rest) = mnt.split(None, 2)
-        except ValueError:
-            continue
+    with open("/proc/mounts") as mounts:
+        for mnt in mounts.readline():
+            try:
+                (device, path, _rest) = mnt.split(None, 2)
+            except ValueError:
+                continue
 
-        if path == mountpoint:
-            mount_device = device
-            break
+            if path == mountpoint:
+                mount_device = device
+                break
 
     if mount_device and re.match(r'/dev/loop\d+$', mount_device):
         loop_name = os.path.basename(mount_device)
@@ -609,6 +609,12 @@ def sha256_file(filename):
             block = f.read(65536)
 
     return sha256.hexdigest()
+
+
+def read_file(filename, mode="r"):
+    with open(filename, mode) as f:
+        content = f.read()
+    return content
 
 
 class ObjectID(object):


### PR DESCRIPTION
Python's garbage collector should close these automatically, but we shouldn't depend on that and close the file descriptor when no longer needed.