### PR TITLE
Rename unit_tests.storagetestcase to unit_tests.blivettestcase 

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -58,22 +58,25 @@ inherit from them.
   Used for tests which don't touch disk space;
 
 
-- :class:`~tests.storagetestcase.StorageTestCase` - intended as a base class for
+- :class:`~tests.unit_tests.blivettestcase.BlivetTestCase` - intended as a base class for
   higher-level tests. Most of what it does is stub out operations that touch
   disks. Currently it is only used in
-  :class:`~tests.action_test.DeviceActionTestCase`;
+  :class:`~tests.unit_tests.action_test.DeviceActionTestCase`;
 
 
-- :class:`~tests.loopbackedtestcase.LoopBackedTestCase` and
-  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` - both classes
+- :class:`~tests.storage_tests.loopbackedtestcase.LoopBackedTestCase`,
+  :class:`~tests.storage_tests.imagebackedtestcase.ImageBackedTestCase` and
+  :class:`~tests.storage_tests.storagetestcase.StorageTestCase` - all three classes
   represent actual storage space.
-  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` uses the same stacks
+  :class:`~tests.storage_tests.imagebackedtestcase.ImageBackedTestCase` uses the same stacks
   as anaconda disk image installations. These mimic normal disks more closely
   than using loop devices directly. Usually
-  :class:`~tests.loopbackedtestcase.LoopBackedTestCase` is used for stacks of
+  :class:`~tests.storage_tests.loopbackedtestcase.LoopBackedTestCase` is used for stacks of
   limited depth (eg: md array with two loop members) and
-  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` for stacks of greater
+  :class:`~tests.storage_tests.imagebackedtestcase.ImageBackedTestCase` for stacks of greater
   or arbitrary depth.
+  :class:`~tests.storage_tests.storagetestcase.StorageTestCase` uses `targetcli` to create
+  virtual SCSI drives for full stack tests on "real" hardware.
 
 
 In order to get a high level view of how test classes inherit from each other

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -3,6 +3,7 @@ from .devices_test import *
 from .formats_tests import *
 
 from .action_test import *
+from .blivettestcase import *
 from .dbus_test import *
 from .devicefactory_test import *
 from .devicetree_test import *
@@ -11,7 +12,6 @@ from .misc_test import *
 from .parentlist_test import *
 from .populator_test import *
 from .size_test import *
-from .storagetestcase import *
 from .task_tests import *
 from .tsort_test import *
 from .udev_test import *

--- a/tests/unit_tests/action_test.py
+++ b/tests/unit_tests/action_test.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from mock import Mock, patch
 
-from .storagetestcase import StorageTestCase
+from .blivettestcase import BlivetTestCase
 import blivet
 from blivet.formats import get_format
 from blivet.size import Size
@@ -90,7 +90,7 @@ def _patch_format_dependencies(fn):
     return fn_with_patch
 
 
-class DeviceActionTestCase(StorageTestCase):
+class DeviceActionTestCase(BlivetTestCase):
 
     """ DeviceActionTestSuite """
 

--- a/tests/unit_tests/blivettestcase.py
+++ b/tests/unit_tests/blivettestcase.py
@@ -15,15 +15,14 @@ from blivet.devices import StorageDevice
 from blivet.devices import PartitionDevice
 
 
-class StorageTestCase(unittest.TestCase):
+class BlivetTestCase(unittest.TestCase):
 
-    """ StorageTestCase
+    """ BlivetUnitTestCase
 
-        This is a base class for storage test cases. It sets up imports of
-        the blivet package, along with an Anaconda instance and a Storage
-        instance. There are lots of little patches to prevent various pieces
-        of code from trying to access filesystems and/or devices on the host
-        system, along with a couple of convenience methods.
+        This is a base class for unit test cases. It sets up imports of
+        the blivet package. There are lots of little patches to prevent various
+        pieces of code from trying to access filesystems and/or devices
+        on the host system, along with a couple of convenience methods.
 
     """
 


### PR DESCRIPTION
Having two storagetestcase classes and module could be confusing
and these are unit tests that don't really touch any storage.