### PR TITLE
Ignore parent dependencies during action execute

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -172,7 +172,7 @@ class DeviceAction(util.ObjectID):
         self._applied = False
 
     def _check_device_dependencies(self):
-        unavailable_dependencies = self.device.unavailable_dependencies
+        unavailable_dependencies = self.device.unavailable_direct_dependencies
         if unavailable_dependencies:
             dependencies_str = ", ".join("%s:\n%s" % (str(d), ", ".join(d.availability_errors)) for d in unavailable_dependencies)
             raise DependencyError("device type %s requires unavailable_dependencies: %s" % (self.device.type, dependencies_str))

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -358,3 +358,12 @@ class Device(util.ObjectID):
             :rtype: set of availability.external_resource
         """
         return set(e for e in self.external_dependencies if not e.available)
+
+    @property
+    def unavailable_direct_dependencies(self):
+        """ Any unavailable external dependencies of this device.
+
+            :returns: A list of unavailable external dependencies.
+            :rtype: set of availability.external_resource
+        """
+        return set(e for e in self.type_external_dependencies() if not e.available)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2527,6 +2527,16 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         return deps
 
     @property
+    def unavailable_direct_dependencies(self):
+        deps = super(LVMLogicalVolumeBase, self).unavailable_dependencies
+        if self.is_vdo_pool:
+            deps.update(e for e in LVMVDOPoolMixin.type_external_dependencies() if not e.available)
+        if self.is_vdo_lv:
+            deps.update(e for e in LVMVDOLogicalVolumeMixin.type_external_dependencies() if not e.available)
+
+        return deps
+
+    @property
     @type_specific
     def vg(self):
         """This Logical Volume's Volume Group."""

--- a/tests/unit_tests/action_test.py
+++ b/tests/unit_tests/action_test.py
@@ -1395,7 +1395,7 @@ class ConfigurationActionsTest(unittest.TestCase):
     def test_device_configuration(self):
 
         mock_device = Mock(spec=StorageDevice)
-        mock_device.configure_mock(unavailable_dependencies=[])
+        mock_device.configure_mock(unavailable_direct_dependencies=[])
         mock_device.configure_mock(config_actions_map={"conf1": "do_conf1", "conf2": "do_conf2", "conf3": None})
         attrs = {"conf1": "old_value", "do_conf1": Mock(return_value=None), "conf2": "old_value", "do_conf2": None, "conf3": "old_value"}
         mock_device.configure_mock(**attrs)

--- a/tests/unit_tests/devices_test/device_dependencies_test.py
+++ b/tests/unit_tests/devices_test/device_dependencies_test.py
@@ -93,8 +93,6 @@ class MockingDeviceDependenciesTestCase1(unittest.TestCase):
         availability.BLOCKDEV_MDRAID_PLUGIN._method = availability.UnavailableMethod
         self.assertIn(availability.BLOCKDEV_MDRAID_PLUGIN, self.luks.unavailable_dependencies)
         with self.assertRaises(DependencyError):
-            ActionCreateDevice(self.luks)
-        with self.assertRaises(DependencyError):
             ActionDestroyDevice(self.dev)
 
     def _clean_up(self):


### PR DESCRIPTION
We don't need full support for the entire stack when creating a device, having dependencies just for the device the action is working with should be enough.

Resolves: rhbz#2144812