### PR TITLE
doc: Link to the LVM VDO documentation from the index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,13 @@ Contents:
    blivet/blivet
    tests/tests
 
+Technologies:
+
+.. toctree::
+   :maxdepth: 1
+
+   lvmvdo
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
Without a link the documentation is not accessible.