### PR TITLE
Remove support for Python 2 from spec and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON?=python3
+PYTHON=python3
 PKG_INSTALL?=dnf
 
 L10N_REPOSITORY=git@github.com:storaged-project/blivet-weblate.git

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -1,21 +1,3 @@
-%define is_rhel 0%{?rhel} != 0
-
-# python3 is not available on RHEL <=7
-%if %{is_rhel} && 0%{?rhel} <= 7
-# disable python3 by default
-%bcond_with python3
-%else
-%bcond_without python3
-%endif
-
-# python2 is not available on RHEL > 7 and not needed on Fedora > 28
-%if 0%{?rhel} > 7 || 0%{?fedora} > 28
-# disable python2 by default
-%bcond_with python2
-%else
-%bcond_without python2
-%endif
-
 Summary:  A python module for system storage configuration
 Name: python-blivet
 Url: https://storageapis.wordpress.com/projects/blivet
@@ -59,7 +41,6 @@ Conflicts: python3-blivet < 1:2.0.0
 The %{realname}-data package provides data files required by the %{realname}
 python module.
 
-%if %{with python3}
 %package -n python3-%{realname}
 Summary: A python3 package for examining and modifying storage configuration.
 
@@ -98,86 +79,19 @@ Requires: %{realname}-data = %{epoch}:%{version}-%{release}
 
 Obsoletes: blivet-data < 1:2.0.0
 
-%if %{without python2}
-# the version here needs to be updated to actual version when this happened
-Obsoletes: python2-blivet < 1:2.0.2-2
-Obsoletes: python-blivet < 1:2.0.2-2
-%else
-Obsoletes: python-blivet < 1:2.0.0
-%endif
-
 %description -n python3-%{realname}
 The python3-%{realname} is a python3 package for examining and modifying storage
 configuration.
-%endif
-
-%if %{with python2}
-%package -n python2-%{realname}
-Summary: A python2 package for examining and modifying storage configuration.
-
-%{?python_provide:%python_provide python2-%{realname}}
-
-BuildRequires: gettext
-BuildRequires: python2-devel
-
-%if %{is_rhel}
-BuildRequires: python-setuptools
-%else
-BuildRequires: python2-setuptools
-%endif
-
-Requires: python2
-Requires: python-six
-Requires: python-pyudev >= %{pyudevver}
-Requires: parted >= %{partedver}
-Requires: pyparted >= %{pypartedver}
-Requires: libselinux-python
-Requires: python-blockdev >= %{libblockdevver}
-Recommends: libblockdev-btrfs >= %{libblockdevver}
-Recommends: libblockdev-crypto >= %{libblockdevver}
-Recommends: libblockdev-dm >= %{libblockdevver}
-Recommends: libblockdev-fs >= %{libblockdevver}
-Recommends: libblockdev-kbd >= %{libblockdevver}
-Recommends: libblockdev-loop >= %{libblockdevver}
-Recommends: libblockdev-lvm >= %{libblockdevver}
-Recommends: libblockdev-mdraid >= %{libblockdevver}
-Recommends: libblockdev-mpath >= %{libblockdevver}
-Recommends: libblockdev-part >= %{libblockdevver}
-Recommends: libblockdev-swap >= %{libblockdevver}
-Recommends: libblockdev-s390 >= %{libblockdevver}
-Requires: python-bytesize >= %{libbytesizever}
-Requires: util-linux >= %{utillinuxver}
-Requires: lsof
-Requires: python-hawkey
-Requires: %{realname}-data = %{epoch}:%{version}-%{release}
-
-%if %{is_rhel}
-Requires: udev
-Requires: pygobject3
-%else
-Requires: systemd-udev
-Requires: python-gobject-base
-%endif
-
-Obsoletes: blivet-data < 1:2.0.0
-Obsoletes: python-blivet < 1:2.0.0
-
-%description -n python2-%{realname}
-The python2-%{realname} is a python2 package for examining and modifying storage
-configuration.
-%endif
 
 %prep
 %autosetup -n %{realname}-%{realversion} -N
 %autosetup -n %{realname}-%{realversion} -b1 -p1
 
 %build
-%{?with_python2:make PYTHON=%{__python2}}
-%{?with_python3:make PYTHON=%{__python3}}
+make
 
 %install
-%{?with_python2:make PYTHON=%{__python2} DESTDIR=%{buildroot} install}
-%{?with_python3:make PYTHON=%{__python3} DESTDIR=%{buildroot} install}
+make DESTDIR=%{buildroot} install
 
 %find_lang %{realname}
 
@@ -187,19 +101,10 @@ configuration.
 %{_libexecdir}/*
 %{_unitdir}/*
 
-%if %{with python2}
-%files -n python2-%{realname}
-%license COPYING
-%doc README.md ChangeLog examples
-%{python2_sitelib}/*
-%endif
-
-%if %{with python3}
 %files -n python3-%{realname}
 %license COPYING
 %doc README.md ChangeLog examples
 %{python3_sitelib}/*
-%endif
 
 %changelog
 * Tue Mar 20 2018 Miro Hrončok <mhroncok@redhat.com> - 1:2.0.2-2

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,6 @@ setup(name='blivet',
       classifiers=["Development Status :: 5 - Production/Stable",
                    "Intended Audience :: Developers",
                    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-                   "Programming Language :: Python :: 2",
                    "Programming Language :: Python :: 3",
                    "Operating System :: POSIX :: Linux"]
      )


### PR DESCRIPTION
Python 2 EOL was 3 years ago so we can stop supporting it now.

I'd like to do a bigger cleanup in the future (like removing the `six` module), but for now we can just remove Python 2 from the build and release process.