### PR TITLE
pylint: Remove the "EXCEPTIONS" section from pylintrc

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -371,11 +371,3 @@ int-import-graph=
 # Force import order to recognize a module as part of the standard
 # compatibility libraries.
 known-standard-library=
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception


### PR DESCRIPTION
Latest pylint changed the required format of this section and we want the default configuration for this anyway.