### PR TITLE
Prefer UUID for fstab spec for DM devices too

### DIFF
--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -98,11 +98,6 @@ class DMDevice(StorageDevice):
         return d
 
     @property
-    def fstab_spec(self):
-        """ Return the device specifier for use in /etc/fstab. """
-        return self.path
-
-    @property
     def map_name(self):
         """ This device's device-mapper map name """
         return self.name


### PR DESCRIPTION
We now have multiple use cases that require using UUID in fstab for all devices so we should remove the exception for LVM and other DM devices.