### PR TITLE
Kickstart data fixes

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -498,8 +498,8 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
 
     def populate_ksdata(self, data):
         super(BTRFSVolumeDevice, self).populate_ksdata(data)
-        data.data_level = self.data_level.name if self.data_level else None
-        data.metadata_level = self.metadata_level.name if self.metadata_level else None
+        data.dataLevel = self.data_level.name if self.data_level else None
+        data.metaDataLevel = self.metadata_level.name if self.metadata_level else None
         data.devices = ["btrfs.%d" % p.id for p in self.parents]
         data.preexist = self.exists
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1151,7 +1151,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
 
             if self.req_grow:
                 # base size could be literal or percentage
-                data.max_size_mb = self.req_max_size.convert_to(MiB)
+                data.maxSizeMB = self.req_max_size.convert_to(MiB)
         elif data.resize:
             data.size = self.target_size.convert_to(MiB)
 

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -1033,12 +1033,14 @@ class PartitionDevice(StorageDevice):
             if self.req_grow:
                 data.maxSizeMB = self.req_max_size.convert_to(MiB)
 
-            # data.disk = self.disk.name                      # by-id
             if self.req_disks and len(self.req_disks) == 1:
                 data.disk = self.disk.name
             data.primOnly = self.req_primary
         else:
-            data.onPart = self.name                     # by-id
+            if self.format and self.format.uuid:
+                data.onPart = "UUID=" + self.format.uuid
+            else:
+                data.onPart = self.name
 
             if data.resize:
                 # on s390x in particular, fractional sizes are reported, which

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -1031,14 +1031,14 @@ class PartitionDevice(StorageDevice):
             data.size = self.req_base_size.round_to_nearest(MiB, rounding=ROUND_DOWN).convert_to(spec=MiB)
             data.grow = self.req_grow
             if self.req_grow:
-                data.max_size_mb = self.req_max_size.convert_to(MiB)
+                data.maxSizeMB = self.req_max_size.convert_to(MiB)
 
             # data.disk = self.disk.name                      # by-id
             if self.req_disks and len(self.req_disks) == 1:
                 data.disk = self.disk.name
-            data.prim_only = self.req_primary
+            data.primOnly = self.req_primary
         else:
-            data.on_part = self.name                     # by-id
+            data.onPart = self.name                     # by-id
 
             if data.resize:
                 # on s390x in particular, fractional sizes are reported, which


### PR DESCRIPTION
This is intended to replace #1110, we have a lot more pykickstart attributes that are wrong that just the `on_part`/`onPart` one.