### PR TITLE
Fix the get_mount_device function

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -282,7 +282,7 @@ def get_mount_device(mountpoint):
     mountpoint = os.path.realpath(mountpoint)  # eliminate symlinks
     mount_device = None
     with open("/proc/mounts") as mounts:
-        for mnt in mounts.readline():
+        for mnt in mounts.readlines():
             try:
                 (device, path, _rest) = mnt.split(None, 2)
             except ValueError:


### PR DESCRIPTION
Iterate over lines of the `/proc/mounts` file instead of characters of the first line.
This bug was introduced in the commit 12ba6cb.