### PR TITLE
Avoid raising libblockdev exceptions from our code

### DIFF
--- a/blivet/devices/loop.py
+++ b/blivet/devices/loop.py
@@ -81,7 +81,11 @@ class LoopDevice(StorageDevice):
             # if our name is loopN we must already be active
             return self.name
 
-        name = blockdev.loop.get_loop_name(self.parents[0].path)
+        try:
+            name = blockdev.loop.get_loop_name(self.parents[0].path)
+        except blockdev.LoopError as e:
+            raise errors.LoopError(e)
+
         if name.startswith("loop"):
             self.name = name
 
@@ -106,7 +110,10 @@ class LoopDevice(StorageDevice):
         """ Open, or set up, a device. """
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
-        blockdev.loop.setup(self.parents[0].path)
+        try:
+            blockdev.loop.setup(self.parents[0].path)
+        except blockdev.LoopError as e:
+            raise errors.LoopError(e)
 
     def _post_setup(self):
         StorageDevice._post_setup(self)
@@ -117,7 +124,10 @@ class LoopDevice(StorageDevice):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.loop.teardown(self.path)
+        try:
+            blockdev.loop.teardown(self.path)
+        except blockdev.LoopError as e:
+            raise errors.LoopError(e)
 
     def _post_teardown(self, recursive=False):
         StorageDevice._post_teardown(self, recursive=recursive)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -247,13 +247,19 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm.vgdeactivate(self.name)
+        try:
+            blockdev.lvm.vgdeactivate(self.name)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def _create(self):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
         pv_list = [pv.path for pv in self.parents]
-        blockdev.lvm.vgcreate(self.name, pv_list, self.pe_size)
+        try:
+            blockdev.lvm.vgcreate(self.name, pv_list, self.pe_size)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def _post_create(self):
         self._complete = True
@@ -277,9 +283,12 @@ class LVMVolumeGroupDevice(ContainerDevice):
             # the same name that we want to keep/use.
             return
 
-        blockdev.lvm.vgreduce(self.name, None)
-        blockdev.lvm.vgdeactivate(self.name)
-        blockdev.lvm.vgremove(self.name)
+        try:
+            blockdev.lvm.vgreduce(self.name, None)
+            blockdev.lvm.vgdeactivate(self.name)
+            blockdev.lvm.vgremove(self.name)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def _remove(self, member):
         status = []
@@ -291,15 +300,24 @@ class LVMVolumeGroupDevice(ContainerDevice):
         # do not run pvmove on empty PVs
         member.format.update_size_info()
         if member.format.free < member.format.current_size:
-            blockdev.lvm.pvmove(member.path)
-        blockdev.lvm.vgreduce(self.name, member.path)
+            try:
+                blockdev.lvm.pvmove(member.path)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
+        try:
+            blockdev.lvm.vgreduce(self.name, member.path)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
         for (lv, status) in zip(self.lvs, status):
             if lv.status and not status:
                 lv.teardown()
 
     def _add(self, member):
-        blockdev.lvm.vgextend(self.name, member.path)
+        try:
+            blockdev.lvm.vgextend(self.name, member.path)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def _add_log_vol(self, lv):
         """ Add an LV to this VG. """
@@ -407,7 +425,10 @@ class LVMVolumeGroupDevice(ContainerDevice):
             raise ValueError("'%s' is not a valid name for %s" % (new_name, self.type))
 
         if not dry_run:
-            blockdev.lvm.vgrename(old_name, new_name)
+            try:
+                blockdev.lvm.vgrename(old_name, new_name)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
             for pv in self.pvs:
                 pv.format.vg_name = new_name
 
@@ -990,7 +1011,12 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         if not self.exists:
             raise errors.DeviceError("device has not been created")
 
-        return blockdev.dm.node_from_name(self.map_name)
+        try:
+            node = blockdev.dm.node_from_name(self.map_name)
+        except blockdev.DMError as err:
+            raise errors.LVMError(err)
+        else:
+            return node
 
     def _get_name(self):
         """ This device's name. """
@@ -1065,7 +1091,10 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm.lvdeactivate(self.vg.name, self._name)
+        try:
+            blockdev.lvm.lvdeactivate(self.vg.name, self._name)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def _post_teardown(self, recursive=False):
         try:
@@ -1110,7 +1139,10 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
             raise ValueError("'%s' is not a valid name for %s" % (new_name, self.type))
 
         if not dry_run:
-            blockdev.lvm.lvrename(self.vg.name, old_name, new_name)
+            try:
+                blockdev.lvm.lvrename(self.vg.name, old_name, new_name)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
 
     @property
     def lvname(self):
@@ -1493,7 +1525,11 @@ class LVMSnapshotMixin(object):
             pass
 
         udev.settle()
-        blockdev.lvm.lvsnapshotmerge(self.vg.name, self.lvname)
+
+        try:
+            blockdev.lvm.lvsnapshotmerge(self.vg.name, self.lvname)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     @util.requires_property("is_snapshot_lv")
     def _update_format_from_origin(self):
@@ -1546,7 +1582,10 @@ class LVMSnapshotMixin(object):
         """ Create the device. """
         if not self.is_thin_lv:
             log_method_call(self, self.name, status=self.status)
-            blockdev.lvm.lvsnapshotcreate(self.vg.name, self.origin.lvname, self._name, self.size)
+            try:
+                blockdev.lvm.lvsnapshotcreate(self.vg.name, self.origin.lvname, self._name, self.size)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
         else:
             pool_name = None
             if not self.origin.is_thin_lv:
@@ -1554,8 +1593,11 @@ class LVMSnapshotMixin(object):
                 # to use
                 pool_name = self.pool.lvname
 
-            blockdev.lvm.thsnapshotcreate(self.vg.name, self.origin.lvname, self._name,
-                                          pool_name=pool_name)
+            try:
+                blockdev.lvm.thsnapshotcreate(self.vg.name, self.origin.lvname, self._name,
+                                              pool_name=pool_name)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
 
     def _post_create(self):
         DMDevice._post_create(self)
@@ -1570,7 +1612,10 @@ class LVMSnapshotMixin(object):
         # old-style snapshots' status is tied to the origin's so we never
         # explicitly activate or deactivate them and we have to tell lvremove
         # that it is okay to remove the active snapshot
-        blockdev.lvm.lvremove(self.vg.name, self._name, force=True)
+        try:
+            blockdev.lvm.lvremove(self.vg.name, self._name, force=True)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def depends_on(self, dep):
         if self.is_thin_lv:
@@ -1745,13 +1790,19 @@ class LVMThinPoolMixin(object):
                 extra["chunksize"] = str(int(self.chunk_size))
             data_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.data)
             meta_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.meta)
-            blockdev.lvm.thpool_convert(self.vg.name, data_lv.lvname, meta_lv.lvname, self.lvname, **extra)
+            try:
+                blockdev.lvm.thpool_convert(self.vg.name, data_lv.lvname, meta_lv.lvname, self.lvname, **extra)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
             # TODO: update the names of the internal LVs here
         else:
-            blockdev.lvm.thpoolcreate(self.vg.name, self.lvname, self.size,
-                                      md_size=self.metadata_size,
-                                      chunk_size=self.chunk_size,
-                                      profile=profile_name)
+            try:
+                blockdev.lvm.thpoolcreate(self.vg.name, self.lvname, self.size,
+                                          md_size=self.metadata_size,
+                                          chunk_size=self.chunk_size,
+                                          profile=profile_name)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
 
     def dracut_setup_args(self):
         return set()
@@ -1843,8 +1894,11 @@ class LVMThinLogicalVolumeMixin(object):
     def _create(self):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
-        blockdev.lvm.thlvcreate(self.vg.name, self.pool.lvname, self.lvname,
-                                self.size)
+        try:
+            blockdev.lvm.thlvcreate(self.vg.name, self.pool.lvname, self.lvname,
+                                    self.size)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     def remove_hook(self, modparent=True):
         if modparent:
@@ -1987,10 +2041,13 @@ class LVMVDOPoolMixin(object):
         else:
             write_policy = blockdev.LVMVDOWritePolicy.AUTO
 
-        blockdev.lvm.vdo_pool_create(self.vg.name, self.vdo_lv.lvname, self.lvname,
-                                     self.size, self.vdo_lv.size, self.index_memory,
-                                     self.compression, self.deduplication,
-                                     write_policy)
+        try:
+            blockdev.lvm.vdo_pool_create(self.vg.name, self.vdo_lv.lvname, self.lvname,
+                                         self.size, self.vdo_lv.size, self.index_memory,
+                                         self.compression, self.deduplication,
+                                         write_policy)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     @util.requires_property("is_vdo_pool")
     def _set_compression(self, new_compression, old_compression, dry_run):
@@ -2001,10 +2058,13 @@ class LVMVDOPoolMixin(object):
             raise ValueError("compression is already %s on this VDO pool" % ("enabled" if new_compression else "disabled"))
 
         if not dry_run:
-            if new_compression:
-                blockdev.lvm.vdo_enable_compression(self.vg.name, self.lvname)
-            else:
-                blockdev.lvm.vdo_disable_compression(self.vg.name, self.lvname)
+            try:
+                if new_compression:
+                    blockdev.lvm.vdo_enable_compression(self.vg.name, self.lvname)
+                else:
+                    blockdev.lvm.vdo_disable_compression(self.vg.name, self.lvname)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
 
     @util.requires_property("is_vdo_pool")
     def _set_deduplication(self, new_deduplication, old_deduplication, dry_run):
@@ -2015,10 +2075,13 @@ class LVMVDOPoolMixin(object):
             raise ValueError("deduplication is already %s on this VDO pool" % ("enabled" if new_deduplication else "disabled"))
 
         if not dry_run:
-            if new_deduplication:
-                blockdev.lvm.vdo_enable_deduplication(self.vg.name, self.lvname)
-            else:
-                blockdev.lvm.vdo_disable_deduplication(self.vg.name, self.lvname)
+            try:
+                if new_deduplication:
+                    blockdev.lvm.vdo_enable_deduplication(self.vg.name, self.lvname)
+                else:
+                    blockdev.lvm.vdo_disable_deduplication(self.vg.name, self.lvname)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
 
 
 class LVMVDOLogicalVolumeMixin(object):
@@ -2248,13 +2311,19 @@ class LVMCachePoolMixin(object):
                 extra["cachemode"] = self._cache_mode
             data_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.data)
             meta_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.meta)
-            blockdev.lvm.cache_pool_convert(self.vg.name, data_lv.lvname, meta_lv.lvname, self.lvname, **extra)
+            try:
+                blockdev.lvm.cache_pool_convert(self.vg.name, data_lv.lvname, meta_lv.lvname, self.lvname, **extra)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
         else:
-            blockdev.lvm.cache_create_pool(self.vg.name, self.lvname, self.size,
-                                           self.metadata_size,
-                                           cache_mode,
-                                           0,
-                                           [spec.pv.path for spec in self._pv_specs])
+            try:
+                blockdev.lvm.cache_create_pool(self.vg.name, self.lvname, self.size,
+                                               self.metadata_size,
+                                               cache_mode,
+                                               0,
+                                               [spec.pv.path for spec in self._pv_specs])
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
         if self._attach_to:
             self._attach_to.attach_cache(self)
 
@@ -2643,7 +2712,10 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
         ignore_skip_activation = self.is_snapshot_lv or self.ignore_skip_activation > 0
-        blockdev.lvm.lvactivate(self.vg.name, self._name, ignore_skip=ignore_skip_activation)
+        try:
+            blockdev.lvm.lvactivate(self.vg.name, self._name, ignore_skip=ignore_skip_activation)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     @type_specific
     def _pre_create(self):
@@ -2681,8 +2753,11 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             if self._stripe_size:
                 extra["stripesize"] = str(int(self._stripe_size.convert_to("KiB")))
 
-            blockdev.lvm.lvcreate(self.vg.name, self._name, self.size,
-                                  type=self.seg_type, pv_list=pvs, **extra)
+            try:
+                blockdev.lvm.lvcreate(self.vg.name, self._name, self.size,
+                                      type=self.seg_type, pv_list=pvs, **extra)
+            except blockdev.LVMError as err:
+                raise errors.LVMError(err)
         else:
             fast_pvs = [pv.path for pv in self.cache.fast_pvs]
 
@@ -2705,12 +2780,18 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             # fast PVs may be required for allocation of the LV (it may span over the slow PVs and parts of
             # fast PVs)
             if self.cache.type == "cache":
-                mode = blockdev.lvm.cache_get_mode_from_str(self.cache.mode)
-                blockdev.lvm.cache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size, self.cache.md_size,
-                                                    mode, 0, util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+                try:
+                    mode = blockdev.lvm.cache_get_mode_from_str(self.cache.mode)
+                    blockdev.lvm.cache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size, self.cache.md_size,
+                                                        mode, 0, util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+                except blockdev.LVMError as err:
+                    raise errors.LVMError(err)
             else:
-                blockdev.lvm.writecache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size,
-                                                         util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+                try:
+                    blockdev.lvm.writecache_create_cached_lv(self.vg.name, self._name, self.size, self.cache.size,
+                                                             util.dedup_list(slow_pvs + fast_pvs), fast_pvs)
+                except blockdev.LVMError as err:
+                    raise errors.LVMError(err)
 
     @type_specific
     def _post_create(self):
@@ -2730,7 +2811,10 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     def _destroy(self):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
-        blockdev.lvm.lvremove(self.vg.name, self._name)
+        try:
+            blockdev.lvm.lvremove(self.vg.name, self._name)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     @type_specific
     def resize(self):
@@ -2745,7 +2829,11 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
             self.format.teardown()
 
         udev.settle()
-        blockdev.lvm.lvresize(self.vg.name, self._name, self.size)
+
+        try:
+            blockdev.lvm.lvresize(self.vg.name, self._name, self.size)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
 
     @type_specific
     def _add_log_vol(self, lv):
@@ -2856,7 +2944,10 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     def attach_cache(self, cache_pool_lv):
         if self.is_thin_lv or self.is_snapshot_lv or self.is_internal_lv:
             raise errors.DeviceError("Cannot attach a cache pool to the '%s' LV" % self.name)
-        blockdev.lvm.cache_attach(self.vg.name, self.lvname, cache_pool_lv.lvname)
+        try:
+            blockdev.lvm.cache_attach(self.vg.name, self.lvname, cache_pool_lv.lvname)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
         self._cache = LVMCache(self, size=cache_pool_lv.size, exists=True)
 
     def attach_writecache(self, writecache_lv):
@@ -3023,8 +3114,11 @@ class LVMCache(Cache):
 
     def detach(self):
         vg_name = self._cached_lv.vg.name
-        ret = blockdev.lvm.cache_pool_name(vg_name, self._cached_lv.lvname)
-        blockdev.lvm.cache_detach(vg_name, self._cached_lv.lvname, False)
+        try:
+            ret = blockdev.lvm.cache_pool_name(vg_name, self._cached_lv.lvname)
+            blockdev.lvm.cache_detach(vg_name, self._cached_lv.lvname, False)
+        except blockdev.LVMError as err:
+            raise errors.LVMError(err)
         return ret
 
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -269,8 +269,11 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
            :returns: estimated superblock size
            :rtype: :class:`~.size.Size`
         """
-        return blockdev.md.get_superblock_size(raw_array_size,
-                                               version=self.metadata_version)
+        try:
+            return blockdev.md.get_superblock_size(raw_array_size,
+                                                   version=self.metadata_version)
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
 
     @property
     def size(self):
@@ -514,7 +517,10 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
             member.setup(orig=orig)
             disks.append(member.path)
 
-        blockdev.md.activate(self.path, members=disks, uuid=self.mdadm_format_uuid)
+        try:
+            blockdev.md.activate(self.path, members=disks, uuid=self.mdadm_format_uuid)
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
 
     def _post_teardown(self, recursive=False):
         super(MDRaidArrayDevice, self)._post_teardown(recursive=recursive)
@@ -542,7 +548,10 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         # file exists, we want to deactivate it. mdraid has too many
         # states.
         if self.exists and os.path.exists(self.path):
-            blockdev.md.deactivate(self.path)
+            try:
+                blockdev.md.deactivate(self.path)
+            except blockdev.MDRaidError as err:
+                raise errors.MDRaidError(err)
 
         self._post_teardown(recursive=recursive)
 
@@ -561,7 +570,11 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         # update our uuid attribute with the new array's UUID
         # XXX this won't work for containers since no UUID is reported for them
-        info = blockdev.md.detail(self.path)
+        try:
+            info = blockdev.md.detail(self.path)
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
+
         self.uuid = info.uuid
         for member in self.members:
             member.format.md_uuid = self.uuid
@@ -583,10 +596,13 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
                 except blockdev.LVMError as e:
                     log.error("Failed to remove stale volume group from newly-created md array %s: %s",
                               self.path, str(e))
-                    raise
+                    raise errors.MDRaidError(e)
 
             # lvm says it is a pv whether or not there is vg metadata, so wipe the pv signature
-            blockdev.lvm.pvremove(self.path)
+            try:
+                blockdev.lvm.pvremove(self.path)
+            except blockdev.LVMError as err:
+                raise errors.MDRaidError(err)
 
         remove_stale_lvm()
 
@@ -601,24 +617,30 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         level = None
         if self.level:
             level = str(self.level)
-        blockdev.md.create(self.path, level, disks, spares,
-                           version=self.metadata_version,
-                           bitmap=self.create_bitmap,
-                           chunk_size=int(self.chunk_size))
+        try:
+            blockdev.md.create(self.path, level, disks, spares,
+                               version=self.metadata_version,
+                               bitmap=self.create_bitmap,
+                               chunk_size=int(self.chunk_size))
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
         udev.settle()
 
     def _remove(self, member):
         self.setup()
         # see if the device must be marked as failed before it can be removed
         fail = (self.member_status(member) == "in_sync")
-        blockdev.md.remove(self.path, member.path, fail)
+        try:
+            blockdev.md.remove(self.path, member.path, fail)
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
 
     def _add(self, member):
         """ Add a member device to an array.
 
            :param str member: the member's path
 
-           :raises: blockdev.MDRaidError
+           :raises: :class:`~.errors.MDRaidError`
         """
         self.setup()
 
@@ -630,7 +652,10 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         except errors.RaidError:
             pass
 
-        blockdev.md.add(self.path, member.path, raid_devs=raid_devices)
+        try:
+            blockdev.md.add(self.path, member.path, raid_devs=raid_devices)
+        except blockdev.MDRaidError as err:
+            raise errors.MDRaidError(err)
 
     @property
     def format_args(self):

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -194,6 +194,17 @@ class StratisError(StorageError):
     pass
 
 
+class LoopError(StorageError):
+    pass
+
+
+class MDRaidError(StorageError):
+    pass
+
+
+class LVMError(StorageError):
+    pass
+
 # DeviceTree
 
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -150,10 +150,16 @@ class LVMPhysicalVolume(DeviceFormat):
             with lvm.empty_lvm_devices():
                 # with lvmdbusd we need to call the pvcreate without --devices otherwise lvmdbusd
                 # wouldn't be able to find the newly created pv and the call would fail
-                blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
+                try:
+                    blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
+                except blockdev.LVMError as e:
+                    raise PhysicalVolumeError(e)
                 self.lvmdevices_add()
         else:
-            blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
+            try:
+                blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment, extra=[ea_yes])
+            except blockdev.LVMError as e:
+                raise PhysicalVolumeError(e)
 
     def _destroy(self, **kwargs):
         log_method_call(self, device=self.device,

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -28,6 +28,7 @@ from gi.repository import BlockDev as blockdev
 from ..storage_log import log_method_call
 from parted import PARTITION_RAID
 from . import DeviceFormat, register_device_format
+from ..errors import MDMemberError
 from ..i18n import N_
 from ..tasks import availability
 
@@ -88,7 +89,10 @@ class MDRaidMember(DeviceFormat):
         return super(MDRaidMember, self).supported and self._plugin.available
 
     def _destroy(self, **kwargs):
-        blockdev.md.destroy(self.device)
+        try:
+            blockdev.md.destroy(self.device)
+        except blockdev.MDRaidError as e:
+            raise MDMemberError(e)
 
     @property
     def destroyable(self):

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -144,7 +144,10 @@ class SwapSpace(DeviceFormat):
             if not self.label_format_ok(self.label):
                 raise SwapSpaceError("bad label format")
 
-            blockdev.swap.mkswap(self.device, self.label)
+            try:
+                blockdev.swap.mkswap(self.device, self.label)
+            except blockdev.SwapError as err:
+                raise SwapSpaceError("Failed to change label on %s: %s" % (self.device, str(err)))
 
     label = property(lambda s: s._get_label(), lambda s, l: s._set_label(l),
                      doc="the label for this swap space")
@@ -194,18 +197,31 @@ class SwapSpace(DeviceFormat):
     @property
     def status(self):
         """ Device status. """
-        return self.exists and blockdev.swap.swapstatus(self.device)
+        if not self.exists:
+            return False
+        try:
+            status = blockdev.swap.swapstatus(self.device)
+        except blockdev.SwapError as err:
+            raise SwapSpaceError("Failed to get swap status for %s: %s" % (self.device, str(err)))
+        else:
+            return status
 
     def _setup(self, **kwargs):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
-        blockdev.swap.swapon(self.device, priority=self.priority)
+        try:
+            blockdev.swap.swapon(self.device, priority=self.priority)
+        except blockdev.SwapError as err:
+            raise SwapSpaceError("Failed to activate swap %s: %s" % (self.device, str(err)))
 
     def _teardown(self, **kwargs):
         """ Close, or tear down, a device. """
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
-        blockdev.swap.swapoff(self.device)
+        try:
+            blockdev.swap.swapoff(self.device)
+        except blockdev.SwapError as err:
+            raise SwapSpaceError("Failed to deactivate swap %s: %s" % (self.device, str(err)))
 
         udev.settle()
 
@@ -213,12 +229,18 @@ class SwapSpace(DeviceFormat):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
         if self.uuid is None:
-            blockdev.swap.mkswap(self.device, label=self.label)
+            try:
+                blockdev.swap.mkswap(self.device, label=self.label)
+            except blockdev.SwapError as err:
+                raise SwapSpaceError(str(err))
         else:
             if not self.uuid_format_ok(self.uuid):
                 raise FSWriteUUIDError("bad UUID format for swap filesystem")
-            blockdev.swap.mkswap(self.device, label=self.label,
-                                 extra={"-U": self.uuid})
+            try:
+                blockdev.swap.mkswap(self.device, label=self.label,
+                                     extra={"-U": self.uuid})
+            except blockdev.SwapError as err:
+                raise SwapSpaceError(str(err))
 
 
 register_device_format(SwapSpace)


### PR DESCRIPTION
We shouldn't force our users to import libblockdev just to be able to catch storage exceptions. This commit makes sure all libblockdev calls are protected with try-except and we raise our own exceptions like StorageError.

Fixes: #1014