### PR TITLE
Fix creating LUKS1 on disks with mixed sector size (#2188785)

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -21,6 +21,7 @@
 #
 
 import hashlib
+import os
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -135,6 +136,10 @@ def get_optimal_luks_sector_size(device):
 
 
 def is_fips_enabled():
+    if not os.path.exists("/proc/sys/crypto/fips_enabled"):
+        # if the file doesn't exist, we are definitely not in FIPS mode
+        return False
+
     with open("/proc/sys/crypto/fips_enabled", "r") as f:
         enabled = f.read()
     return enabled.strip() == "1"

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -311,7 +311,7 @@ class LUKS(DeviceFormat):
                         luks_data.pbkdf_args = self.pbkdf_args
                         log.info("PBKDF arguments for LUKS2 not specified, using defaults with memory limit %s", mem_limit)
 
-        if not self.luks_sector_size:
+        if not self.luks_sector_size and self.luks_version == "luks2":
             self.luks_sector_size = crypto.get_optimal_luks_sector_size(self.device)
 
         if self.pbkdf_args:


### PR DESCRIPTION
For disks with mixed sector size (4096 physical and 512 logical) we were wrongly adding the sector_size extra option which is not supported on LUKS1 only LUKS2.