### PR TITLE
DBus: remove extra callback invocations

### DIFF
--- a/blivet/dbus/blivet.py
+++ b/blivet/dbus/blivet.py
@@ -141,12 +141,6 @@ class DBusBlivet(DBusObject):
         self._manager.add_object(added)
 
     def _action_executed(self, action):
-        if action.is_destroy:
-            if action.is_device:
-                self._device_removed(action.device, keep=False)
-            elif action.is_format:
-                self._format_removed(action.device, action.format, keep=False)
-
         self._action_removed(action)
 
     def _list_dbus_devices(self, removed=False):


### PR DESCRIPTION
The device_added/device_removed/format_added/format_removed callbacks are for changes to blivet's model -- not when changes are written to disk.