### PR TITLE
Revert "tests: Skip test_lvcreate_type on CentOS/RHEL 9"

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -23,9 +23,3 @@
 # - all "skips" can specified as a list, for example 'version: [10, 11]'
 
 ---
-
-- test: storage_tests.devices_test.lvm_test.LVMTestCase.test_lvm_raid
-  skip_on:
-    - distro: "centos"
-      version: "9"
-      reason: "Creating RAID 1 LV on CentOS/RHEL 9 causes a system deadlock"


### PR DESCRIPTION
This reverts commit 16b90071145d2d0f19a38f3003561a0cc9d6e281.

The kernel issue was resolved, we no longer need to skip the test.