### PR TITLE
Do not set memory limit for LUKS2 when running in FIPS mode

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -132,3 +132,9 @@ def get_optimal_luks_sector_size(device):
         # 512 logical block size which will make it harder to combine these in a single
         # LVM volume group if used as PVs
         return SECTOR_SIZE
+
+
+def is_fips_enabled():
+    with open("/proc/sys/crypto/fips_enabled", "r") as f:
+        enabled = f.read()
+    return enabled.strip() == "1"

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -6,9 +6,14 @@ except ImportError:
 import unittest
 
 from blivet.formats.luks import LUKS
+from blivet.size import Size
+from blivet.static_data import luks_data
 
 
 class LUKSNodevTestCase(unittest.TestCase):
+    def setUp(self):
+        luks_data.pbkdf_args = None
+
     def test_create_discard_option(self):
         # flags.discard_new=False --> no discard
         fmt = LUKS(exists=False)
@@ -50,6 +55,31 @@ class LUKSNodevTestCase(unittest.TestCase):
         # no default for non-XTS modes
         fmt = LUKS(cipher="aes-cbc-plain64")
         self.assertEqual(fmt.key_size, 0)
+
+    def test_luks2_pbkdf_memory_fips(self):
+        fmt = LUKS()
+        with patch("blivet.formats.luks.blockdev.crypto") as bd:
+            # fips enabled, pbkdf memory should not be set
+            with patch("blivet.formats.luks.crypto") as crypto:
+                attrs = {"is_fips_enabled.return_value": True,
+                         "get_optimal_luks_sector_size.return_value": 0,
+                         "calculate_luks2_max_memory.return_value": Size("256 MiB")}
+                crypto.configure_mock(**attrs)
+
+                fmt._create()
+                crypto.calculate_luks2_max_memory.assert_not_called()
+                self.assertIsNone(bd.luks_format.call_args[1]["extra"])
+
+            # fips disabled, pbkdf memory should be set
+            with patch("blivet.formats.luks.crypto") as crypto:
+                attrs = {"is_fips_enabled.return_value": False,
+                         "get_optimal_luks_sector_size.return_value": 0,
+                         "calculate_luks2_max_memory.return_value": Size("256 MiB")}
+                crypto.configure_mock(**attrs)
+
+                fmt._create()
+                crypto.calculate_luks2_max_memory.assert_called()
+                self.assertEqual(bd.luks_format.call_args[1]["extra"].pbkdf.max_memory_kb, 256 * 1024)
 
     def test_sector_size(self):
         fmt = LUKS()

--- a/tests/unit_tests/formats_tests/methods_test.py
+++ b/tests/unit_tests/formats_tests/methods_test.py
@@ -367,7 +367,8 @@ class LUKSMethodsTestCase(FormatMethodsTestCase):
     def _test_create_backend(self):
         self.format.exists = False
         with patch("blivet.devicelibs.crypto.get_optimal_luks_sector_size", return_value=512):
-            self.format.create()
+            with patch("blivet.devicelibs.crypto.is_fips_enabled", return_value=False):
+                self.format.create()
         self.assertTrue(self.patches["blockdev"].crypto.luks_format.called)  # pylint: disable=no-member
 
     def _test_setup_backend(self):


### PR DESCRIPTION
With FIPS enabled LUKS uses pbkdf and not argon so the memory limit is not a valid parameter.