### PR TITLE
iscsi: Extend allowed CHAP auth algorithms

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -273,6 +273,7 @@ class iSCSI(object):
         if extra is None:
             extra = dict()
         extra["node.startup"] = GLib.Variant("s", "automatic")
+        extra["node.session.auth.chap_algs"] = GLib.Variant("s", "SHA3-256,SHA256,SHA1,MD5")
 
         args = GLib.Variant("(sisisa{sv})", node_info.conn_info + (extra,))
         self._call_initiator_method("Login", args)


### PR DESCRIPTION
The downstream libiscsi uses MD5 as the only default CHAP auth algorithm. With MD5 not available in FIPS mode, this leaves an empty set of algorithms available.

---

This is completely untested, just a thought. Needs https://github.com/storaged-project/udisks/pull/1098 otherwise it's likely a no-op.

From `/etc/iscsi/iscsid.conf`:

```
# To configure which CHAP algorithms to enable set
# node.session.auth.chap_algs to a comma seperated list.
# The algorithms should be listen with most prefered first.
# Valid values are MD5, SHA1, SHA256, and SHA3-256.
# The default is MD5.
# node.session.auth.chap_algs = SHA3-256,SHA256,SHA1,MD5
```

For some reason these defaults are not honoured by the downstream `libiscsi` (subject to rewrite in the future).