### PR TITLE
Add RISCV64 architecture helper [is_riscv64()] for arch module.

### DIFF
--- a/blivet/arch.py
+++ b/blivet/arch.py
@@ -349,6 +349,15 @@ def is_arm():
     return os.uname()[4].startswith('arm')
 
 
+def is_riscv64():
+    """
+    :return: True if the hardware supports RISCV64, False otherwise.
+    :rtype: boolean
+
+    """
+    return os.uname()[4] == 'riscv64'
+
+
 def is_loongarch(bits=None):
     """
     :return: True if the hardware supports loongarch, False otherwise.
@@ -405,6 +414,8 @@ def get_arch():
         return 'alpha'
     elif is_arm():
         return 'arm'
+    elif is_riscv64():
+        return 'riscv64'
     elif is_loongarch(bits=32):
         return 'loongarch32'
     elif is_loongarch(bits=64):


### PR DESCRIPTION
This merge request is required to keep the pyAnaconda code clean at :
-  https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/modules/storage/platform.py#L493

After this contribution, the idea is to explicitly call the blivet.arch.is_riscv64() helper in the switch/case of pyanaconda/modules/storage/platform.py#L493 in order to correctly determine riscv64 architecture.