### PR TITLE
Do not add new PVs to the LVM devices file if it doesn't exist and VG…

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -84,6 +84,9 @@ if hasattr(blockdev.LVMTech, "DEVICES"):
 else:
     HAVE_LVMDEVICES = False
 
+
+LVM_DEVICES_FILE = "/etc/lvm/devices/system.devices"
+
 # list of devices that LVM is allowed to use
 # with LVM >= 2.0.13 we'll use this for the --devices option and when creating
 # the /etc/lvm/devices/system.devices file

--- a/tests/unit_tests/formats_tests/__init__.py
+++ b/tests/unit_tests/formats_tests/__init__.py
@@ -2,6 +2,7 @@ from .device_test import *
 from .disklabel_test import *
 from .init_test import *
 from .luks_test import *
+from .lvmpv_test import *
 from .methods_test import *
 from .misc_test import *
 from .selinux_test import *

--- a/tests/unit_tests/formats_tests/lvmpv_test.py
+++ b/tests/unit_tests/formats_tests/lvmpv_test.py
@@ -1,0 +1,73 @@
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from contextlib import contextmanager
+
+import unittest
+
+from blivet.formats.lvmpv import LVMPhysicalVolume
+
+
+class LVMPVNodevTestCase(unittest.TestCase):
+
+    @contextmanager
+    def patches(self):
+        patchers = dict()
+        mocks = dict()
+
+        patchers["blockdev"] = patch("blivet.formats.lvmpv.blockdev")
+        patchers["lvm"] = patch("blivet.formats.lvmpv.lvm")
+        patchers["vgs_info"] = patch("blivet.formats.lvmpv.vgs_info")
+        patchers["os"] = patch("blivet.formats.lvmpv.os")
+
+        for name, patcher in patchers.items():
+            mocks[name] = patcher.start()
+
+        yield mocks
+
+        for patcher in patchers.values():
+            patcher.stop()
+
+    def test_lvm_devices(self):
+        fmt = LVMPhysicalVolume(device="/dev/test")
+
+        with self.patches() as mock:
+            # LVM devices file not enabled/supported -> devices_add should not be called
+            mock["lvm"].HAVE_LVMDEVICES = False
+
+            fmt._create()
+
+            mock["blockdev"].lvm.devices_add.assert_not_called()
+
+        with self.patches() as mock:
+            # LVM devices file enabled and devices file exists -> devices_add should be called
+            mock["lvm"].HAVE_LVMDEVICES = True
+            mock["os"].path.exists.return_value = True
+
+            fmt._create()
+
+            mock["blockdev"].lvm.devices_add.assert_called_with("/dev/test")
+
+        with self.patches() as mock:
+            # LVM devices file enabled and devices file doesn't exist
+            # and no existing VGs present -> devices_add should be called
+            mock["lvm"].HAVE_LVMDEVICES = True
+            mock["os"].path.exists.return_value = False
+            mock["vgs_info"].cache = {}
+
+            fmt._create()
+
+            mock["blockdev"].lvm.devices_add.assert_called_with("/dev/test")
+
+        with self.patches() as mock:
+            # LVM devices file enabled and devices file doesn't exist
+            # and existing VGs present -> devices_add should not be called
+            mock["lvm"].HAVE_LVMDEVICES = True
+            mock["os"].path.exists.return_value = False
+            mock["vgs_info"].cache = {"fake_vg_uuid": "fake_vg_data"}
+
+            fmt._create()
+
+            mock["blockdev"].lvm.devices_add.assert_not_called()


### PR DESCRIPTION
…s are present

If there is a preexisting VG on the system when we create a new PV and the LVM devices file doesn't exist we will create it and add only the new PV to it which means the preexisting VG will now be ignored by LVM tools. This change skips adding newly created PVs to the devices file in the same way 'pvcreate' and 'vgcreate' do.