### PR TITLE
Bump required version of libblockdev to 3.0

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -57,7 +57,7 @@ def log_bd_message(level, msg):
 
 import gi
 gi.require_version("GLib", "2.0")
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 # initialize the libblockdev library
 from gi.repository import GLib

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -43,7 +43,7 @@ from .size import Size
 from .static_data import luks_data
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -24,7 +24,7 @@ import hashlib
 import os
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev
 

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 import itertools
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -24,7 +24,7 @@ import copy
 import tempfile
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 gi.require_version("GLib", "2.0")
 
 from gi.repository import BlockDev as blockdev

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/loop.py
+++ b/blivet/devices/loop.py
@@ -20,7 +20,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -31,7 +31,7 @@ from enum import Enum
 import six
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -27,7 +27,7 @@ import time
 from six.moves import reduce
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -25,7 +25,7 @@ import _ped
 from uuid import UUID
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -26,7 +26,7 @@ import re
 import six
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -21,11 +21,6 @@
 # Red Hat Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
-import gi
-gi.require_version("BlockDev", "2.0")
-
-from gi.repository import BlockDev as blockdev
-
 import os
 import importlib
 from six import add_metaclass

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -23,7 +23,7 @@
 import gi
 import os
 
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 from gi.repository import BlockDev as blockdev
 
 from ..storage_log import log_exception_info, log_method_call

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -32,7 +32,7 @@ from ..size import Size
 from .. import udev
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 import functools
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 import parted
 import _ped

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 gi.require_version("GLib", "2.0")
 
 from gi.repository import BlockDev as blockdev

--- a/blivet/populator/helpers/loop.py
+++ b/blivet/populator/helpers/loop.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 from gi.repository import BlockDev as blockdev
 
 from ... import udev

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -27,7 +27,7 @@ import parted
 from six import add_metaclass
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/static_data/lvm_info.py
+++ b/blivet/static_data/lvm_info.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -20,7 +20,7 @@
 
 import os
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/static_data/nvdimm.py
+++ b/blivet/static_data/nvdimm.py
@@ -18,7 +18,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 gi.require_version("GLib", "2.0")
 from gi.repository import BlockDev
 from gi.repository import GLib

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -28,7 +28,7 @@ from .. import safe_dbus
 from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("Gio", "2.0")
 

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -20,7 +20,7 @@
 # Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/tasks/pvtask.py
+++ b/blivet/tasks/pvtask.py
@@ -21,7 +21,7 @@
 # Red Hat Author(s): Vojtěch Trefný <vtrefny@redhat.com>
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -33,7 +33,7 @@ from .size import Size
 from .flags import flags
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -21,7 +21,7 @@ from .errors import DependencyError
 from . import safe_dbus
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -29,7 +29,7 @@ from .i18n import _
 from .util import stringize, unicodeize
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -18,7 +18,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 2.24
+%global libblockdevver 3.0
 %global libbytesizever 0.3
 %global pyudevver 0.18
 

--- a/tests/unit_tests/devices_test/device_dependencies_test.py
+++ b/tests/unit_tests/devices_test/device_dependencies_test.py
@@ -8,7 +8,7 @@ import os
 import six
 import blivet
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 from gi.repository import BlockDev as blockdev
 
 from blivet.errors import DependencyError

--- a/tests/unit_tests/devices_test/device_properties_test.py
+++ b/tests/unit_tests/devices_test/device_properties_test.py
@@ -2,7 +2,7 @@ import six
 import unittest
 
 import gi
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/tests/unit_tests/populator_test.py
+++ b/tests/unit_tests/populator_test.py
@@ -7,7 +7,7 @@ import gi
 import six
 import unittest
 
-gi.require_version("BlockDev", "2.0")
+gi.require_version("BlockDev", "3.0")
 from gi.repository import BlockDev as blockdev
 
 from blivet.devices import DiskDevice, DMDevice, FileDevice, LoopDevice


### PR DESCRIPTION
Making this separate from #1135 so we can merge it without bumping libblockdev release right now.