### PR TITLE
Make sure that LUKS.has_key always returns a boolean value

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -129,8 +129,8 @@ class StratisPoolDevice(StorageDevice):
 
     @property
     def has_key(self):
-        return ((self.__passphrase not in ["", None]) or
-                (self._key_file and os.access(self._key_file, os.R_OK)))
+        return bool((self.__passphrase not in ["", None]) or
+                    (self._key_file and os.access(self._key_file, os.R_OK)))
 
     def _pre_create(self):
         super(StratisPoolDevice, self)._pre_create()

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -212,8 +212,8 @@ class LUKS(DeviceFormat):
 
     @property
     def has_key(self):
-        return ((self.__passphrase not in ["", None]) or
-                (self._key_file and os.access(self._key_file, os.R_OK)))
+        return bool((self.__passphrase not in ["", None]) or
+                    (self._key_file and os.access(self._key_file, os.R_OK)))
 
     @property
     def formattable(self):

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -112,8 +112,8 @@ class StratisBlockdev(DeviceFormat):
 
     @property
     def has_key(self):
-        return ((self.__passphrase not in ["", None]) or
-                (self._key_file and os.access(self._key_file, os.R_OK)))
+        return bool((self.__passphrase not in ["", None]) or
+                    (self._key_file and os.access(self._key_file, os.R_OK)))
 
     def unlock_pool(self):
         if not self.locked_pool:


### PR DESCRIPTION
We don't want to return 'None' here.

Related: https://github.com/rhinstaller/anaconda/pull/4873