### PR TITLE
Include btrfs volumes names/labels in DeviceTreeBase.names

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -151,7 +151,6 @@ class DeviceTreeBase(object):
         for dev in self._devices + self._hidden:
             # don't include "req%d" partition names
             if (dev.type != "partition" or not dev.name.startswith("req")) and \
-               dev.type != "btrfs volume" and \
                dev.name not in names:
                 names.append(dev.name)
 


### PR DESCRIPTION
Btrfs Volumes use label of the filesystem as name in blivet, which isn't really a name, so it doesn't have to be unique, but not having it unique causes problems in both Blivet and Anaconda where we assume device name is a unique identifier. Not having the name in the list of names means newly created devices can get the same name as an already existing (or scheduled to be created) device.

-----------

@dwlehman btrfs volumes were explicitly excluded even before https://github.com/storaged-project/blivet/pull/688 Do you know about any issues adding btrfs volumes names to the list could cause? We are currently having two bugs reported related to this and the new Anaconda WebUI: https://bugzilla.redhat.com/show_bug.cgi?id=2237375 and https://bugzilla.redhat.com/show_bug.cgi?id=2237375