### PR TITLE
nvme: Require additional rpms for dracut

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -725,7 +725,8 @@ class NVMeFabricsNamespaceDevice(NVMeNamespaceDevice, NetworkStorageDevice):
 
     """ NVMe fabrics namespace """
     _type = "nvme-fabrics"
-    _packages = ["nvme-cli"]
+    # dracut '95nvmf' module dependencies
+    _packages = ["nvme-cli", "dracut-network"]
 
     def __init__(self, device, **kwargs):
         """


### PR DESCRIPTION
The '95nvmf' dracut module needs a couple more packages for the NBFT (NVMe over TCP) to work - such as networking. Local PCIe NVMe devices have no special needs.