### PR TITLE
Revert unneeded changes for shared LVM support

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -63,16 +63,11 @@ gi.require_version("BlockDev", "3.0")
 from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 if arch.is_s390():
-    _REQUESTED_PLUGIN_NAMES = set(("btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390", "nvdimm", "nvme"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390", "nvdimm", "nvme"))
 else:
-    _REQUESTED_PLUGIN_NAMES = set(("btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvdimm", "nvme"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvdimm", "nvme"))
 
 _requested_plugins = blockdev.plugin_specs_from_names(_REQUESTED_PLUGIN_NAMES)
-# XXX force non-dbus LVM plugin
-lvm_plugin = blockdev.PluginSpec()
-lvm_plugin.name = blockdev.Plugin.LVM
-lvm_plugin.so_name = "libbd_lvm.so.3"
-_requested_plugins.append(lvm_plugin)
 try:
     succ_, avail_plugs = blockdev.try_reinit(require_plugins=_requested_plugins, reload=False, log_func=log_bd_message)
 except GLib.GError as err:

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -164,10 +164,6 @@ class LVMVolumeGroupDevice(ContainerDevice):
         # >0 is fixed
         self.size_policy = self.size
 
-        if self._shared:
-            for pv in self.parents:
-                pv.format._vg_shared = True
-
     def __repr__(self):
         s = super(LVMVolumeGroupDevice, self).__repr__()
         s += ("  free = %(free)s  PE Size = %(pe_size)s  PE Count = %(pe_count)s\n"

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -95,7 +95,6 @@ class LVMPhysicalVolume(DeviceFormat):
         self.pe_start = kwargs.get("pe_start", lvm.LVM_PE_START)
         self.data_alignment = kwargs.get("data_alignment", Size(0))
         self._free = kwargs.get("free")  # None means unknown
-        self._vg_shared = False
 
         self.inconsistent_vg = False
 
@@ -155,10 +154,6 @@ class LVMPhysicalVolume(DeviceFormat):
         log_method_call(self, device=self.device,
                         type=self.type, status=self.status)
         lvm.lvm_devices_add(self.device)
-
-        if self._vg_shared:
-            log.info("Shared VG: skipping pvcreate, PV format will be created by vgcreate")
-            return
 
         ea_yes = blockdev.ExtraArg.new("-y", "")
 

--- a/tests/unit_tests/devices_test/lvm_test.py
+++ b/tests/unit_tests/devices_test/lvm_test.py
@@ -497,11 +497,6 @@ class LVMDeviceTest(unittest.TestCase):
                            size=Size("1 GiB"), exists=True)
         vg = LVMVolumeGroupDevice("testvg", parents=[pv], shared=True)
 
-        self.assertTrue(pv.format._vg_shared)
-        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
-            pv.format._create()
-            lvm.pvcreate.assert_not_called()
-
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             vg._create()
             lvm.vgcreate.assert_called_with(vg.name, [pv.path], Size("4 MiB"), shared="")


### PR DESCRIPTION
This part of #1123 was needed only for shared LVM with sanlock which we are not going to support.