### PR TITLE
pylint: Use 'exit' instead of 'do_exit' for pylint.lint.Run

### DIFF
--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -109,7 +109,7 @@ class CensorshipLinter():
 
         pylint.lint.Run(args,
                         reporter=TextReporter(self._stdout),
-                        do_exit=False)
+                        exit=False)
 
         return self._process_output()
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -86,8 +86,8 @@ def _should_skip(distro=None, version=None, arch=None, reason=None):  # pylint: 
 
     # DISTRO, VERSION and ARCH variables are set in main, we don't need to
     # call hostnamectl etc. for every test run
-    if (distro is None or DISTRO in distro) and (version is None or VERSION in version) and \
-       (arch is None or ARCH in arch):
+    if ((distro is None or DISTRO in distro) and (version is None or VERSION in version) and  # pylint: disable=used-before-assignment
+       (arch is None or ARCH in arch)):  # pylint: disable=used-before-assignment
         return True
 
     return False


### PR DESCRIPTION
The 'do_exit' keyword argument has been deprecated for a while and finally removed in pylinr 3.0.