### PR TITLE
add udev-builtin-path_id property to zfcp-attached SCSI disks

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -469,10 +469,12 @@ class ZFCPDiskDevice(DiskDevice):
             :keyword hba_id: ???
             :keyword wwpn: ???
             :keyword fcp_lun: ???
+            :keyword id_path: string from udev-builtin-path_id
         """
         self.hba_id = kwargs.pop("hba_id")
         self.wwpn = kwargs.pop("wwpn")
         self.fcp_lun = kwargs.pop("fcp_lun")
+        self.id_path = kwargs.pop("id_path")
         DiskDevice.__init__(self, device, **kwargs)
         self._clear_local_tags()
         self.tags.add(Tags.remote)

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -223,6 +223,7 @@ class ZFCPDevicePopulator(DiskDevicePopulator):
     def _get_kwargs(self):
         kwargs = super(ZFCPDevicePopulator, self)._get_kwargs()
 
+        kwargs["id_path"] = udev.device_get_path(self.data)
         for attr in ['hba_id', 'wwpn', 'fcp_lun']:
             kwargs[attr] = udev.device_get_zfcp_attribute(self.data, attr=attr)
 

--- a/tests/unit_tests/tags_test.py
+++ b/tests/unit_tests/tags_test.py
@@ -72,7 +72,7 @@ class DeviceTagsTest(unittest.TestCase):
         fcoe_device = FcoeDiskDevice('test6', nic=None, identifier=None, id_path=None)
         self.assertIn(Tags.remote, fcoe_device.tags)
         self.assertNotIn(Tags.local, fcoe_device.tags)
-        zfcp_device = ZFCPDiskDevice('test7', hba_id=None, wwpn=None, fcp_lun=None)
+        zfcp_device = ZFCPDiskDevice('test7', hba_id=None, wwpn=None, fcp_lun=None, id_path=None)
         self.assertIn(Tags.remote, zfcp_device.tags)
         self.assertNotIn(Tags.local, zfcp_device.tags)
 


### PR DESCRIPTION
so anaconda can use it to display path_id information for multipath members

**Note**:
It would be nice to get this into RHEL9.x as well, but I'm not sure which branch I should base my PR according to CONTRIBUTING ("oldest ``x.y`` release that should include
your work"). So for starters I tried to use the latest branch for upstreaming.

@jstodola @poncovka @sharkcz