### PR TITLE
consolidated s390 device configuration

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -496,7 +496,12 @@ class ZFCPDiskDevice(DiskDevice):
         from ..zfcp import has_auto_lun_scan
 
         # zFCP auto LUN scan needs only the device ID
-        if has_auto_lun_scan(self.hba_id):
+        # If the user explicitly over-specified with a full path configuration
+        # respect this choice and emit a full path specification nonetheless.
+        errorlevel = util.run_program(["lszdev", "zfcp-lun", "--configured",
+                                       "%s:%s:%s" % (self.hba_id, self.wwpn,
+                                                     self.fcp_lun)])
+        if has_auto_lun_scan(self.hba_id) and errorlevel != 0:
             dracut_args = set(["rd.zfcp=%s" % self.hba_id])
         else:
             dracut_args = set(["rd.zfcp=%s,%s,%s" % (self.hba_id, self.wwpn, self.fcp_lun,)])

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -528,67 +528,19 @@ class DASDDevice(DiskDevice):
             :type format: :class:`~.formats.DeviceFormat` or a subclass of it
             :keyword str wwn: the disk's WWN
             :keyword busid: bus ID
-            :keyword opts: options
-            :type opts: dict with option name keys and option value values
         """
         self.busid = kwargs.pop('busid')
-        self.opts = kwargs.pop('opts')
         DiskDevice.__init__(self, device, **kwargs)
 
     @property
     def description(self):
         return "DASD device %s" % self.busid
 
-    def get_opts(self):
-        return ["%s=%s" % (k, v) for k, v in self.opts.items() if v == '1']
-
     def dracut_setup_args(self):
-        conf = "/etc/dasd.conf"
-        line = None
-        if os.path.isfile(conf):
-            f = open(conf)
-            # grab the first line that starts with our bus_id
-            for l in f.readlines():
-                if l.startswith(self.busid):
-                    line = l.rstrip()
-                    break
-
-            f.close()
-
-        # See if we got a line.  If not, grab our get_opts
-        if not line:
-            line = self.busid
-            for devopt in self.get_opts():
-                line += " %s" % devopt
-
-        # Create a translation mapping from dasd.conf format to module format
-        translate = {'use_diag': 'diag',
-                     'readonly': 'ro',
-                     'erplog': 'erplog',
-                     'failfast': 'failfast'}
-
-        # this is a really awkward way of determining if the
-        # feature found is actually desired (1, not 0), plus
-        # translating that feature into the actual kernel module
-        # value
-        opts = []
-        parts = line.split()
-        for chunk in parts[1:]:
-            try:
-                feat, val = chunk.split('=')
-                if int(val):
-                    opts.append(translate[feat])
-            except (ValueError, KeyError):
-                # If we don't know what the feature is (feat not in translate
-                # or if we get a val that doesn't cleanly convert to an int
-                # we can't do anything with it.
-                log.warning("failed to parse dasd feature %s", chunk)
-
-        if opts:
-            return set(["rd.dasd=%s(%s)" % (self.busid,
-                                            ":".join(opts))])
-        else:
-            return set(["rd.dasd=%s" % self.busid])
+        devspec = util.capture_output(["/lib/s390-tools/zdev-to-dasd_mod.dasd",
+                                       "persistent", self.busid]).strip()
+        # strip to remove trailing newline, which must not appear in zipl BLS
+        return set(["rd.dasd=%s" % devspec])
 
 
 class NVDIMMNamespaceDevice(DiskDevice):

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -202,9 +202,6 @@ class DASDDevicePopulator(DiskDevicePopulator):
     def _get_kwargs(self):
         kwargs = super(DASDDevicePopulator, self)._get_kwargs()
         kwargs["busid"] = udev.device_get_dasd_bus_id(self.data)
-        kwargs["opts"] = {}
-        for attr in ['readonly', 'use_diag', 'erplog', 'failfast']:
-            kwargs["opts"][attr] = udev.device_get_dasd_flag(self.data, attr)
 
         log.info("%s is a dasd device", udev.device_get_name(self.data))
         return kwargs

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -46,7 +46,6 @@ def logged_write_line_to_file(fn, value):
 
 zfcpsysfs = "/sys/bus/ccw/drivers/zfcp"
 scsidevsysfs = "/sys/bus/scsi/devices"
-zfcpconf = "/etc/zfcp.conf"
 
 
 def _is_lun_scan_allowed():
@@ -327,18 +326,22 @@ class zFCP:
 
     """ ZFCP utility class.
 
-        This class will automatically online to ZFCP drives configured in
-        /tmp/fcpconfig when the startup() method gets called. It can also be
-        used to manually configure ZFCP devices through the add_fcp() method.
+        This class is used to manually configure ZFCP devices through the
+        add_fcp() method, which is used by the anaconda GUI or by kickstart.
 
-        As this class needs to make sure that /tmp/fcpconfig configured
+        As this class needs to make sure that configured
         drives are only onlined once and as it keeps a global list of all ZFCP
         devices it is implemented as a Singleton.
+
+        In particular, this class does not create objects for any other method
+        that enables ZFCP devices such as rd.zfcp= or any device auto
+        configuration. These methods make zfcp-attached SCSI disk block devices
+        available, which ZFCPDiskDevice [devices/disk.py] can directly
+        discover.
     """
 
     def __init__(self):
         self.fcpdevs = set()
-        self.has_read_config = False
         self.down = True
 
     # So that users can write zfcp() to get the singleton instance
@@ -348,46 +351,6 @@ class zFCP:
     def __deepcopy__(self, memo_dict):
         # pylint: disable=unused-argument
         return self
-
-    def read_config(self):
-        try:
-            f = open(zfcpconf, "r")
-        except OSError:
-            log.info("no %s; not configuring zfcp", zfcpconf)
-            return
-
-        lines = [x.strip().lower() for x in f.readlines()]
-        f.close()
-
-        for line in lines:
-            if line.startswith("#") or line == '':
-                continue
-
-            fields = line.split()
-
-            # zFCP auto LUN scan available
-            if len(fields) == 1:
-                devnum = fields[0]
-                wwpn = None
-                fcplun = None
-            elif len(fields) == 3:
-                devnum = fields[0]
-                wwpn = fields[1]
-                fcplun = fields[2]
-            elif len(fields) == 5:
-                # support old syntax of:
-                # devno scsiid wwpn scsilun fcplun
-                devnum = fields[0]
-                wwpn = fields[2]
-                fcplun = fields[4]
-            else:
-                log.warning("Invalid line found in %s: %s", zfcpconf, line)
-                continue
-
-            try:
-                self.add_fcp(devnum, wwpn, fcplun)
-            except ValueError as e:
-                log.warning("%s", str(e))
 
     def add_fcp(self, devnum, wwpn=None, fcplun=None):
         if wwpn and fcplun:
@@ -414,11 +377,6 @@ class zFCP:
         if not self.down:
             return
         self.down = False
-        if not self.has_read_config:
-            self.read_config()
-            self.has_read_config = True
-            # read_config calls add_fcp which calls online_device already
-            return
 
         if len(self.fcpdevs) == 0:
             return

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -559,9 +559,6 @@ class zFCP:
             f.write("%s\n" % (d,))
         f.close()
 
-        f = open(root + "/etc/modprobe.conf", "a")
-        f.write("alias scsi_hostadapter zfcp\n")
-        f.close()
 
 
 # Create ZFCP singleton

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -388,9 +388,6 @@ class ZFCPDeviceFullPath(ZFCPDeviceBase):
                          self.devnum, luns[0])
                 return True
 
-        # no other WWPNs/LUNs exists for this device number, it's safe to bring it offline
-        self._set_zfcp_device_offline()
-
         return True
 
 

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -105,8 +105,6 @@ class ZFCPDeviceBase(ABC):
         if not self.devnum:
             raise ValueError(_("You have not specified a device number or the number is invalid"))
 
-        self._device_online_path = os.path.join(zfcpsysfs, self.devnum, "online")
-
     # Force str and unicode types in case any of the properties are unicode
     def _to_string(self):
         return str(self.devnum)
@@ -117,20 +115,6 @@ class ZFCPDeviceBase(ABC):
     def __unicode__(self):
         return unicodeize(self._to_string())
 
-    def _free_device(self):
-        """Remove the device from the I/O ignore list to make it visible to the system.
-
-        :raises: ValueError if the device cannot be removed from the I/O ignore list
-        """
-
-        if not os.path.exists(self._device_online_path):
-            log.info("Freeing zFCP device %s", self.devnum)
-            util.run_program(["zfcp_cio_free", "-d", self.devnum])
-
-        if not os.path.exists(self._device_online_path):
-            raise ValueError(_("zFCP device %s not found, not even in device ignore list.") %
-                             (self.devnum,))
-
     def _set_zfcp_device_online(self):
         """Set the zFCP device online.
 
@@ -138,10 +122,8 @@ class ZFCPDeviceBase(ABC):
         """
 
         try:
-            with open(self._device_online_path) as f:
-                devonline = f.readline().strip()
-            if devonline != "1":
-                logged_write_line_to_file(self._device_online_path, "1")
+            util.run_program(["chzdev", "--enable", "zfcp-host", self.devnum,
+                              "--yes", "--no-root-update", "--force"])
         except OSError as e:
             raise ValueError(_("Could not set zFCP device %(devnum)s "
                                "online (%(e)s).")
@@ -154,7 +136,8 @@ class ZFCPDeviceBase(ABC):
         """
 
         try:
-            logged_write_line_to_file(self._device_online_path, "0")
+            util.run_program(["chzdev", "--disable", "zfcp-host", self.devnum,
+                              "--yes", "--no-root-update", "--force"])
         except OSError as e:
             raise ValueError(_("Could not set zFCP device %(devnum)s "
                                "offline (%(e)s).")
@@ -167,16 +150,13 @@ class ZFCPDeviceBase(ABC):
         :returns: True or False
         """
 
+    @abstractmethod
     def online_device(self):
         """Initialize the device and make its storage block device(s) ready to use.
 
         :returns: True if success
         :raises: ValueError if the device cannot be initialized
         """
-
-        self._free_device()
-        self._set_zfcp_device_online()
-        return True
 
     def offline_scsi_device(self):
         """Find SCSI devices associated to the zFCP device and remove them from the system."""
@@ -242,25 +222,15 @@ class ZFCPDeviceFullPath(ZFCPDeviceBase):
         :raises: ValueError if the device cannot be initialized
         """
 
-        super().online_device()
-
         portdir = "%s/%s/%s" % (zfcpsysfs, self.devnum, self.wwpn)
-        unitadd = "%s/unit_add" % (portdir)
         unitdir = "%s/%s" % (portdir, self.fcplun)
-        failed = "%s/failed" % (unitdir)
-
-        # Activating using devnum, WWPN, and LUN despite available zFCP auto LUN scan should still
-        # be possible as this method was used as a workaround until the support for zFCP auto LUN
-        # scan devices has been implemented. Just log a warning message and continue.
-        if has_auto_lun_scan(self.devnum):
-            log.warning("zFCP device %s in NPIV mode brought online. All LUNs will be activated "
-                        "automatically although WWPN and LUN have been provided.", self.devnum)
 
         # create the sysfs directory for the LUN/unit
         if not os.path.exists(unitdir):
             try:
-                logged_write_line_to_file(unitadd, self.fcplun)
-                udev.settle()
+                util.run_program(["chzdev", "--enable", "zfcp-lun",
+                                  "%s:%s:%s" % (self.devnum, self.wwpn, self.fcplun),
+                                  "--yes", "--no-root-update", "--force"])
             except OSError as e:
                 raise ValueError(_("Could not add LUN %(fcplun)s to WWPN "
                                    "%(wwpn)s on zFCP device %(devnum)s "
@@ -274,48 +244,23 @@ class ZFCPDeviceFullPath(ZFCPDeviceBase):
                                  'wwpn': self.wwpn,
                                  'devnum': self.devnum})
 
-        # check the state of the LUN
-        fail = "0"
-        try:
-            f = open(failed, "r")
-            fail = f.readline().strip()
-            f.close()
-        except OSError as e:
-            raise ValueError(_("Could not read failed attribute of LUN "
-                               "%(fcplun)s at WWPN %(wwpn)s on zFCP device "
-                               "%(devnum)s (%(e)s).")
-                             % {'fcplun': self.fcplun,
-                                 'wwpn': self.wwpn,
-                                 'devnum': self.devnum,
-                                 'e': e})
-        if fail != "0":
-            self.offline_device()
-            raise ValueError(_("Failed LUN %(fcplun)s at WWPN %(wwpn)s on "
-                               "zFCP device %(devnum)s removed again.")
-                             % {'fcplun': self.fcplun,
-                                 'wwpn': self.wwpn,
-                                 'devnum': self.devnum})
+        # Activating using devnum, WWPN, and LUN despite available zFCP auto LUN scan should still
+        # be possible as this method was used as a workaround until the support for zFCP auto LUN
+        # scan devices has been implemented. Just log a warning message and continue.
+        if has_auto_lun_scan(self.devnum):
+            log.warning("zFCP device %s in NPIV mode brought online. All LUNs will be activated "
+                        "automatically although WWPN and LUN have been provided.", self.devnum)
 
         return True
 
     def offline_device(self):
         """Remove the zFCP device from the system."""
 
-        unitremove = "%s/%s/%s/unit_remove" % (zfcpsysfs, self.devnum, self.wwpn)
-        devdir = "%s/%s" % (zfcpsysfs, self.devnum)
-
-        try:
-            self.offline_scsi_device()
-        except OSError as e:
-            raise ValueError(_("Could not correctly delete SCSI device of "
-                               "zFCP %(devnum)s %(wwpn)s %(fcplun)s "
-                               "(%(e)s).")
-                             % {'devnum': self.devnum, 'wwpn': self.wwpn,
-                                 'fcplun': self.fcplun, 'e': e})
-
         # remove the LUN
         try:
-            logged_write_line_to_file(unitremove, self.fcplun)
+            util.run_program(["chzdev", "--disable", "zfcp-lun",
+                              "%s:%s:%s" % (self.devnum, self.wwpn, self.fcplun),
+                              "--yes", "--no-root-update", "--force"])
         except OSError as e:
             raise ValueError(_("Could not remove LUN %(fcplun)s at WWPN "
                                "%(wwpn)s on zFCP device %(devnum)s "
@@ -344,7 +289,7 @@ class ZFCPDeviceAutoLunScan(ZFCPDeviceBase):
         :raises: ValueError if the device cannot be initialized
         """
 
-        super().online_device()
+        self._set_zfcp_device_online()
 
         if not has_auto_lun_scan(self.devnum):
             raise ValueError(_("zFCP device %s cannot use auto LUN scan.") % self)
@@ -484,13 +429,7 @@ class zFCP:
                 log.warning("%s", str(e))
 
     def write(self, root):
-        if len(self.fcpdevs) == 0:
-            return
-        f = open(root + zfcpconf, "w")
-        for d in self.fcpdevs:
-            f.write("%s\n" % (d,))
-        f.close()
-
+        pass
 
 
 # Create ZFCP singleton

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,6 +21,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 %global libblockdevver 3.0
 %global libbytesizever 0.3
 %global pyudevver 0.18
+%global s390utilscorever 2.31.0
 
 BuildArch: noarch
 
@@ -69,7 +70,7 @@ Recommends: libblockdev-swap >= %{libblockdevver}
 
 %ifarch s390 s390x
 Recommends: libblockdev-s390 >= %{libblockdevver}
-Requires: s390utils-core
+Requires: s390utils-core >= %{s390utilscorever}
 %endif
 
 Requires: python3-bytesize >= %{libbytesizever}

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -69,6 +69,7 @@ Recommends: libblockdev-swap >= %{libblockdevver}
 
 %ifarch s390 s390x
 Recommends: libblockdev-s390 >= %{libblockdevver}
+Requires: s390utils-core
 %endif
 
 Requires: python3-bytesize >= %{libbytesizever}


### PR DESCRIPTION
Consolidate the persistent and dynamic configuration of s390-specific devices in Linux distributions by delegating the configuration to the existing framework `zdev` from s390-tools.

This pull request prepares consolidated s390 device configuration in `anaconda`.
The top commit [see its description] **depends** on a certain commit from https://github.com/ibm-s390-linux/s390-tools/pull/158 and thus https://github.com/ibm-s390-linux/s390-tools/releases/tag/v2.31.0.

Zdev's job is to perform low-level configuration after which the user gets architecture-independent objects such as block devices, or SCSI devices. Those can and should in turn be configured with existing common code mechanisms. So there's a clear separated layering for configuration duties.

In particular, the s390-specific devices currently are: DASD (traditional disk), and ZFCP (scsi). Zdev has a stable command line user interface and abstracts from sysfs and from a persistent configuration representation. Zdev encapsulates configuration details. Systems management code can simply delegate configuration to zdev and thus reduce architecture-specific code.

_This improves user experience, serviceability, maintainability, and reduces test effort._

@jstodola @poncovka @sharkcz

Even though this is a draft pull request, I would appreciate review comments.
It's only a draft until we sorted out the dependencies and merge order of pull requests for different related projects.