### PR TITLE
Fix DMDevice hard dependency on kpartx

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -225,7 +225,7 @@ class MultipathDevice(DMDevice):
     _packages = ["device-mapper-multipath"]
     _partitionable = True
     _is_disk = True
-    _external_dependencies = [availability.MULTIPATH_APP]
+    _external_dependencies = [availability.MULTIPATH_APP, availability.KPARTX_APP]
 
     def __init__(self, name, fmt=None, size=None, wwn=None,
                  parents=None, sysfs_path=''):

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -47,10 +47,7 @@ class DMDevice(StorageDevice):
     """ A device-mapper device """
     _type = "dm"
     _dev_dir = "/dev/mapper"
-    _external_dependencies = [
-        availability.KPARTX_APP,
-        availability.BLOCKDEV_DM_PLUGIN
-    ]
+    _external_dependencies = [availability.BLOCKDEV_DM_PLUGIN]
 
     def __init__(self, name, fmt=None, size=None, dm_uuid=None, uuid=None,
                  target=None, exists=False, parents=None, sysfs_path=''):

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -127,6 +127,10 @@ class DMDevice(StorageDevice):
 
     def setup_partitions(self):
         log_method_call(self, name=self.name)
+        if not availability.KPARTX_APP.available:
+            log.warning("'kpartx' not available, not activating partitions on %s", self.path)
+            return
+
         rc = util.run_program(["kpartx", "-a", "-s", self.path])
         if rc:
             raise errors.DMError("partition activation failed for '%s'" % self.name)
@@ -134,6 +138,9 @@ class DMDevice(StorageDevice):
 
     def teardown_partitions(self):
         log_method_call(self, name=self.name)
+        if not availability.KPARTX_APP.available:
+            log.warning("'kpartx' not available, not deactivating partitions on %s", self.path)
+            return
         rc = util.run_program(["kpartx", "-d", "-s", self.path])
         if rc:
             raise errors.DMError("partition deactivation failed for '%s'" % self.name)

--- a/tests/unit_tests/devices_test/lvm_test.py
+++ b/tests/unit_tests/devices_test/lvm_test.py
@@ -904,10 +904,9 @@ class BlivetLVMVDODependenciesTest(BlivetLVMUnitTest):
                                   size=blivet.size.Size("40 GiB"))
 
         # Dependencies check: for VDO types these should be combination of "normal"
-        # LVM dependencies (LVM libblockdev plugin + kpartx and DM plugin from DMDevice)
+        # LVM dependencies (LVM libblockdev plugin and DM plugin from DMDevice)
         # and LVM VDO technology from the LVM plugin
-        lvm_vdo_dependencies = ["kpartx",
-                                "libblockdev dm plugin",
+        lvm_vdo_dependencies = ["libblockdev dm plugin",
                                 "libblockdev lvm plugin",
                                 "libblockdev lvm plugin (vdo technology)"]
         pool_deps = [d.name for d in vdopool.external_dependencies]
@@ -930,8 +929,7 @@ class BlivetLVMVDODependenciesTest(BlivetLVMUnitTest):
                                      size=blivet.size.Size("1 GiB"))
 
         normalvl_deps = [d.name for d in normallv.external_dependencies]
-        six.assertCountEqual(self, normalvl_deps, ["kpartx",
-                                                   "libblockdev dm plugin",
+        six.assertCountEqual(self, normalvl_deps, ["libblockdev dm plugin",
                                                    "libblockdev lvm plugin"])
 
         with patch("blivet.devices.lvm.LVMVDOPoolMixin._external_dependencies",


### PR DESCRIPTION
`DMDevice` now depends on `kpartx` which means all DM devices (LUKS, LVM etc.) depend on `kpartx` which is really needed only for multipath. This PR moves the dependency to multipath and also allows avoids unnecessary exceptions when `kpartx` is not available.