### PR TITLE
 Added missing fstab object to SwapSpace

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -281,6 +281,8 @@ class ActionList(object):
         devices = devices or []
         self._pre_process(devices=devices)
 
+        skip_fstab = fstab is None or fstab.dest_file is None
+
         for action in self._actions[:]:
             log.info("executing action: %s", action)
             if dry_run:
@@ -288,7 +290,7 @@ class ActionList(object):
 
             # get (b)efore (a)ction.(e)xecute fstab entry
             # (device may not exist afterwards)
-            if fstab is not None:
+            if not skip_fstab:
                 try:
                     entry = fstab.entry_from_device(action.device)
                 except ValueError:
@@ -328,7 +330,7 @@ class ActionList(object):
                 self._completed_actions.append(self._actions.pop(0))
                 _callbacks.action_executed(action=action)
 
-                if fstab is not None:
+                if not skip_fstab:
                     fstab.update(action, bae_entry)
                     fstab.write()
 

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -24,6 +24,7 @@ import os
 
 from parted import PARTITION_SWAP, fileSystemType
 from ..errors import FSWriteUUIDError, SwapSpaceError
+from ..fstab import FSTabOptions
 from ..storage_log import log_method_call
 from ..tasks import availability
 from ..tasks import fsuuid
@@ -77,6 +78,8 @@ class SwapSpace(DeviceFormat):
         """
         log_method_call(self, **kwargs)
         DeviceFormat.__init__(self, **kwargs)
+
+        self.fstab = FSTabOptions()
 
         self.priority = kwargs.get("priority", -1)
         self.label = kwargs.get("label")

--- a/blivet/fstab.py
+++ b/blivet/fstab.py
@@ -629,7 +629,7 @@ class FSTabManager(object):
                 new_entry = self._copy_fs_entry(entry)
                 clean_table.add_fs(new_entry)
             else:
-                log.warning("Fstab entry: '%s' is not complete, it will not be written into the file", entry)
+                log.warning("Fstab entry: '%s' is incomplete, it will not be written into the file", entry)
             entry = self._table.next_fs()
 
         if os.path.exists(dest_file):

--- a/tests/storage_tests/fstab_test.py
+++ b/tests/storage_tests/fstab_test.py
@@ -96,3 +96,22 @@ class FstabTestCase(StorageTestCase):
                 contents = f.read()
                 self.assertFalse("blivetTestLVMine" in contents)
                 self.assertFalse("/mnt/test2" in contents)
+
+    def test_swap_creation(self):
+        # test swap creation for presence of FSTabOptions object
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            fstab_path = os.path.join(tmpdirname, 'fstab')
+
+            # change write path of blivet.fstab
+            self.storage.fstab.dest_file = fstab_path
+
+            self.storage.format_device(disk, blivet.formats.get_format("swap"))
+
+            try:
+                self.storage.do_it()
+            except AttributeError as e:
+                if "has no attribute 'fstab'" in str(e):
+                    self.fail("swap creation test failed on missing FSTabOptions object: %s" % str(e))


### PR DESCRIPTION
Anaconda tests revealed missing `FSTabOptions` object in `SwapSpace` class.
This issue is related to the recent merge of fstab rework #1119 which
added this object to `FS` class. `SwapSpace` does not inherit from `FS` and
was overlooked. This change adds the missing object.
    
It also adds logic that skips all fstab related operations if fstab file
is not to be written (i.e. `fstab.dest_file is None`). The reason for this is to
eliminate the risk of potential issues caused by unused component.
    
The test for above has been added as well.