### PR TITLE
Support partitioning of hybrid boot disks

### DIFF
--- a/tests/unit_tests/devices_test/partition_test.py
+++ b/tests/unit_tests/devices_test/partition_test.py
@@ -68,9 +68,11 @@ class PartitionDeviceTestCase(unittest.TestCase):
 
             # weights for / and /boot are not platform-specific (except for arm)
             fmt.mountpoint = "/"
+            fmt.type = "xfs"
             self.assertEqual(dev.weight, 0)
 
             fmt.mountpoint = "/boot"
+            fmt.type = "ext4"
             self.assertEqual(dev.weight, 2000)
 
             #
@@ -92,7 +94,7 @@ class PartitionDeviceTestCase(unittest.TestCase):
 
             fmt.mountpoint = "/boot/efi"
             fmt.type = "efi"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             #
             # UEFI
@@ -102,9 +104,10 @@ class PartitionDeviceTestCase(unittest.TestCase):
             self.assertEqual(dev.weight, 5000)
 
             fmt.type = "biosboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             fmt.mountpoint = "/"
+            fmt.type = "xfs"
             self.assertEqual(dev.weight, 0)
 
             #
@@ -115,6 +118,7 @@ class PartitionDeviceTestCase(unittest.TestCase):
             arch.is_arm.return_value = True
 
             fmt.mountpoint = "/"
+            fmt.type = "xfs"
             self.assertEqual(dev.weight, -100)
 
             #
@@ -126,38 +130,41 @@ class PartitionDeviceTestCase(unittest.TestCase):
             arch.is_ipseries.return_value = False
 
             fmt.mountpoint = "/"
+            fmt.type = "xfs"
             self.assertEqual(dev.weight, 0)
 
             fmt.type = "prepboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             fmt.type = "appleboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             arch.is_pmac.return_value = True
             self.assertEqual(dev.weight, 5000)
 
             fmt.type = "prepboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             arch.is_pmac.return_value = False
             arch.is_ipseries.return_value = True
             self.assertEqual(dev.weight, 5000)
 
             fmt.type = "appleboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             fmt.mountpoint = "/boot/efi"
             fmt.type = "efi"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             fmt.type = "biosboot"
-            self.assertEqual(dev.weight, 0)
+            self.assertEqual(dev.weight, 5000)
 
             fmt.mountpoint = "/"
+            fmt.type = "xfs"
             self.assertEqual(dev.weight, 0)
 
             fmt.mountpoint = "/boot"
+            fmt.type = "ext4"
             self.assertEqual(dev.weight, 2000)
 
     def test_weight_2(self):


### PR DESCRIPTION
Anaconda needs to be able to create hybrid boot disks. For example:

```
  clearpart --all --initlabel --disklabel=gpt
  part prepboot  --size=4    --fstype=prepboot
  part biosboot  --size=1    --fstype=biosboot
  part /boot/efi --size=100  --fstype=efi
  part /boot     --size=1000 --fstype=ext4 --label=boot
  part /         --grow      --fstype xfs
```
However, this kickstart snippet is not working with two or more disks. The bootloader-related partitions should be all created on the disk the computer will boot from, but Blivet does that only for platform -specific partitions. The rest of them are created on any disk with enough space.

It looks like this can be easily fixed by setting the same weight to all of these partitions regardless of the current platform.

See: https://github.com/rhinstaller/anaconda/pull/5298