### PR TITLE
ci: Set custom release number for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,6 +5,8 @@ actions:
     - 'git config user.name "Blivet CI"'
     # merge the release branch to get correct version in spec
     - 'git merge --ff origin/3.9-release'
+    # bump release to 99 to always be ahead of Fedora builds
+    - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release: 99%{?dist}/\" python-blivet.spec"'
   get-current-version:
     - "python3 ./setup.py --version"
   create-archive:

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -5,7 +5,7 @@ Version: 2.0.2
 
 #%%global prerelease .b1
 # prerelease, if defined, should be something like .a1, .b1, .b2.dev1, or .c2
-Release: 2%{?prerelease}%{?dist}
+Release: 1%{?prerelease}%{?dist}
 Epoch: 1
 License: LGPL-2.1-or-later
 %global realname blivet


### PR DESCRIPTION
We want a high release number (99) for the daily builds done by Packit to make sure the Copr daily builds are always newer than the version in Fedora. We can do this in Packit config instead of bumping the release in the spec everytime.