### PR TITLE
Generate UUID for newly created btrfs volumes

### DIFF
--- a/tests/storage_tests/devices_test/btrfs_test.py
+++ b/tests/storage_tests/devices_test/btrfs_test.py
@@ -64,6 +64,9 @@ class BtrfsTestCase(StorageTestCase):
         vol = self.storage.new_btrfs(name=self.volname, parents=[part])
         self.storage.create_device(vol)
 
+        self.assertIsNotNone(vol.uuid)
+        pre_uuid = vol.uuid
+
         sub = self.storage.new_btrfs_sub_volume(parents=[vol], name="blivetTestSubVol")
         self.storage.create_device(sub)
 
@@ -88,6 +91,7 @@ class BtrfsTestCase(StorageTestCase):
         self.assertEqual(vol.format.container_uuid, vol.uuid)
         self.assertEqual(len(vol.parents), 1)
         self.assertEqual(vol.parents[0].name, part.name)
+        self.assertEqual(vol.uuid, pre_uuid)
 
         sub = self.storage.devicetree.get_device_by_name("blivetTestSubVol")
         self.assertIsNotNone(sub)

--- a/tests/unit_tests/devices_test/__init__.py
+++ b/tests/unit_tests/devices_test/__init__.py
@@ -10,3 +10,4 @@ from .md_test import *
 from .network_test import *
 from .partition_test import *
 from .stratis_test import *
+from .btrfs_test import *

--- a/tests/unit_tests/devices_test/btrfs_test.py
+++ b/tests/unit_tests/devices_test/btrfs_test.py
@@ -1,0 +1,57 @@
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+import blivet
+
+from blivet.devices import StorageDevice
+from blivet.devices import BTRFSVolumeDevice
+from blivet.devices import BTRFSSubVolumeDevice
+from blivet.size import Size
+
+
+DEVICE_CLASSES = [
+    BTRFSVolumeDevice,
+    BTRFSSubVolumeDevice,
+    StorageDevice
+]
+
+
+@unittest.skipUnless(not any(x.unavailable_type_dependencies() for x in DEVICE_CLASSES), "some unsupported device classes required for this test")
+class BlivetNewBtrfsVolumeDeviceTest(unittest.TestCase):
+    def test_new_btrfs(self):
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("btrfs"),
+                           size=Size("2 GiB"), exists=False)
+
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            vol = b.new_btrfs(name="testvolume", parents=[bd])
+        self.assertEqual(vol.name, "testvolume")
+        self.assertEqual(vol.size, bd.size)
+        self.assertIsNotNone(vol.format)
+        self.assertEqual(vol.format.type, "btrfs")
+
+        b.create_device(vol)
+
+        with patch("blivet.devices.btrfs.blockdev.btrfs") as blockdev:
+            with patch.object(vol, "_pre_create"):
+                with patch.object(vol, "_post_create"):
+                    vol.create()
+                    blockdev.create_volume.assert_called_with(['/dev/bd1'],
+                                                              label='testvolume',
+                                                              data_level=None,
+                                                              md_level=None,
+                                                              extra={'-U': vol.uuid})
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            sub = b.new_btrfs_sub_volume(name="testsub", parents=[vol])
+
+        self.assertIsNotNone(sub.format)
+        self.assertEqual(sub.format.type, "btrfs")
+        self.assertEqual(sub.size, vol.size)
+        self.assertEqual(sub.volume, vol)

--- a/tests/unit_tests/devices_test/device_properties_test.py
+++ b/tests/unit_tests/devices_test/device_properties_test.py
@@ -631,7 +631,8 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
                          metadata_level=xform(self.assertIsNone),
                          parents=xform(lambda x, m: self.assertEqual(len(x), 1, m)),
                          size=xform(lambda x, m: self.assertEqual(x, BTRFS_MIN_MEMBER_SIZE, m)),
-                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)))
+                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)),
+                         uuid=xform(self.assertIsNotNone))
 
         self.state_check(self.dev2,
                          target_size=xform(lambda x, m: self.assertEqual(x, BTRFS_MIN_MEMBER_SIZE, m)),
@@ -649,7 +650,8 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
                          metadata_level=xform(self.assertIsNone),
                          parents=xform(lambda x, m: self.assertEqual(len(x), 1, m)),
                          size=xform(lambda x, m: self.assertEqual(x, Size("500 MiB"), m)),
-                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)))
+                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)),
+                         uuid=xform(self.assertIsNotNone))
 
         with six.assertRaisesRegex(self, ValueError, "BTRFSDevice.*must have at least one parent"):
             BTRFSVolumeDevice("dev")
@@ -738,7 +740,8 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
                          metadata_level=xform(self.assertIsNone),
                          parents=xform(lambda x, m: self.assertEqual(len(x), 1, m)),
                          size=xform(lambda x, m: self.assertEqual(x, BTRFS_MIN_MEMBER_SIZE, m)),
-                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)))
+                         type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)),
+                         uuid=xform(self.assertIsNotNone))
 
         self.assertEqual(snap.isleaf, True)
         self.assertEqual(snap.direct, True)


### PR DESCRIPTION
We want to have a predictable UUID when creating btrfs volumes so
we can have a unique identifier that is same for the volume before
and after it is created.