### PR TITLE
Add a unique device identifier

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -419,7 +419,7 @@ class Blivet(object):
             if extended and not logical_parts:
                 log.debug("removing empty extended partition from %s", disk.name)
                 extended_name = device_path_to_name(extended.getDeviceNodeName())
-                extended = self.devicetree.get_device_by_name(extended_name)
+                extended = self.devicetree.get_device_by_device_id(extended_name)
                 self.destroy_device(extended)
 
     def get_free_space(self, disks=None, partitions=None):

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -226,6 +226,11 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
     def members(self):
         return list(self.parents)
 
+    @property
+    def device_id(self):
+        # BTRFS-<uuid>
+        return "BTRFS-%s" % self.uuid
+
     def _set_level(self, value, data):
         """ Sets a valid level for this device and level type.
 
@@ -598,6 +603,11 @@ class BTRFSSubVolumeDevice(BTRFSDevice):
     @property
     def container(self):
         return self.volume
+
+    @property
+    def device_id(self):
+        # BTRFS-<volume uuid>-<name>
+        return "BTRFS-%s-%s" % (self.volume.uuid, self.name)
 
     def setup_parents(self, orig=False):
         """ Run setup method of all parent devices. """

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -263,6 +263,16 @@ class Device(util.ObjectID):
                     doc="This device's name")
 
     @property
+    def device_id(self):
+        """ Unique ID for this device.
+
+            Note: This is an internal identifier in Blivet which is designed to be unique
+                  even for devices with the same name or label.
+                  This ID is persistent between blivet.reset() calls for existing devices.
+        """
+        return self.name
+
+    @property
     def isleaf(self):
         """ True if no other device depends on this one. """
         return not bool(self.children)

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -100,6 +100,11 @@ class DMDevice(StorageDevice):
         return self.name
 
     @property
+    def device_id(self):
+        # DM-<name>
+        return "DM-%s" % self.name
+
+    @property
     def status(self):
         try:
             return blockdev.dm.map_exists(self.map_name, True, True)

--- a/blivet/devices/luks.py
+++ b/blivet/devices/luks.py
@@ -70,6 +70,11 @@ class LUKSDevice(DMCryptDevice):
             return self.parents[0].parents[0]
         return self.parents[0]
 
+    @property
+    def device_id(self):
+        # LUKS-<name>
+        return "LUKS-%s" % self.name
+
     def _get_size(self):
         if not self.exists:
             size = self.raw_device.size - crypto.LUKS_METADATA_SIZE

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -208,6 +208,11 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ Device node representing this device. """
         return "%s/%s" % (self._dev_dir, self.map_name)
 
+    @property
+    def device_id(self):
+        # LVM-<vgname>
+        return "LVM-%s" % self.name
+
     def update_sysfs_path(self):
         """ Update this device's sysfs path. """
         log_method_call(self, self.name, status=self.status)
@@ -1175,6 +1180,11 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
     def lvname(self):
         """ The LV's name (not including VG name). """
         return self._name
+
+    @property
+    def device_id(self):
+        # LVM-<vgname>-<lvname>
+        return "LVM-%s" % self.name
 
     @property
     def complete(self):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -151,6 +151,10 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
             raise errors.DeviceError("A device with mdcontainer member must be mdbiosraidarray.")
 
     @property
+    def device_id(self):
+        return "MDRAID-%s" % self.name
+
+    @property
     def mdadm_format_uuid(self):
         """ This array's UUID, formatted for external use.
 

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -59,6 +59,11 @@ class StratisPoolDevice(StorageDevice):
         super(StratisPoolDevice, self).__init__(*args, **kwargs)
 
     @property
+    def device_id(self):
+        # STRATIS-<pool name>
+        return "STRATIS-%s" % self.name
+
+    @property
     def blockdevs(self):
         """ A list of this pool block devices """
         return self.parents[:]
@@ -215,6 +220,11 @@ class StratisFilesystemDevice(StorageDevice):
     def fsname(self):
         """ The Stratis filesystem name (not including pool name). """
         return self._name
+
+    @property
+    def device_id(self):
+        # STRATIS-<pool name>/<fsname>
+        return "STRATIS-%s/%s" % (self.pool.name, self.fsname)
 
     @property
     def pool(self):

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -585,7 +585,7 @@ class DeviceTreeBase(object):
         return result
 
     def get_device_by_id(self, id_num, incomplete=False, hidden=False):
-        """ Return a device with specified device id.
+        """ Return a device with specified id.
 
             :param int id_num: the id to look for
             :param bool incomplete: include incomplete devices in search
@@ -596,6 +596,21 @@ class DeviceTreeBase(object):
         log_method_call(self, id_num=id_num, incomplete=incomplete, hidden=hidden)
         devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
         result = six.next((d for d in devices if d.id == id_num), None)
+        log_method_return(self, result)
+        return result
+
+    def get_device_by_device_id(self, device_id, incomplete=False, hidden=False):
+        """ Return a device with specified device id.
+
+            :param str device id: the device id to look for
+            :param bool incomplete: include incomplete devices in search
+            :param bool hidden: include hidden devices in search
+            :returns: the first matching device found
+            :rtype: :class:`~.devices.Device`
+        """
+        log_method_call(self, device_id=device_id, incomplete=incomplete, hidden=hidden)
+        devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
+        result = six.next((d for d in devices if d.device_id == device_id), None)
         log_method_return(self, result)
         return result
 

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -121,7 +121,7 @@ class LUKSFormatPopulator(FormatPopulator):
             return
 
         # look up or create the mapped device
-        if not self._devicetree.get_device_by_name(self.device.format.map_name):
+        if not self._devicetree.get_device_by_device_id("LUKS-" + self.device.format.map_name):
             passphrase = luks_data.luks_devs.get(self.device.format.uuid)
             if self.device.format.configured:
                 pass

--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -58,7 +58,7 @@ class MDDevicePopulator(DevicePopulator):
             return None
 
         # try to get the device again now that we've got all the parents
-        device = self._devicetree.get_device_by_name(name, incomplete=flags.allow_imperfect_devices)
+        device = self._devicetree.get_device_by_device_id("MDRAID-" + name, incomplete=flags.allow_imperfect_devices)
 
         if device is None:
             try:
@@ -175,7 +175,7 @@ class MDFormatPopulator(FormatPopulator):
                     md_name = md_name[2:]
 
                 if md_name:
-                    array = self._devicetree.get_device_by_name(md_name, incomplete=True)
+                    array = self._devicetree.get_device_by_device_id("MDRAID-" + md_name, incomplete=True)
                     if array and array.uuid != md_uuid:
                         log.error("found multiple devices with the name %s", md_name)
 

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -46,21 +46,21 @@ class PartitionDevicePopulator(DevicePopulator):
         log_method_call(self, name=name)
         sysfs_path = udev.device_get_sysfs_path(self.data)
 
-        device = self._devicetree.get_device_by_name(name)
+        device = self._devicetree.get_device_by_device_id(name)
         if device:
             return device
 
         disk = None
         disk_name = udev.device_get_partition_disk(self.data)
         if disk_name:
-            disk = self._devicetree.get_device_by_name(disk_name)
+            disk = self._devicetree.get_device_by_device_id(disk_name)
             if disk is None:
                 # create a device instance for the disk
                 disk_info = six.next((i for i in udev.get_devices()
                                       if udev.device_get_name(i) == disk_name), None)
                 if disk_info is not None:
                     self._devicetree.handle_device(disk_info)
-                    disk = self._devicetree.get_device_by_name(disk_name)
+                    disk = self._devicetree.get_device_by_device_id(disk_name)
 
         if disk is None:
             # if the disk is still not in the tree something has gone wrong

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -192,7 +192,7 @@ class PopulatorMixin(object):
         if md_name is None:
             log.warning("No name for possibly degraded md array.")
         else:
-            device = self.get_device_by_name(md_name, incomplete=flags.allow_imperfect_devices)
+            device = self.get_device_by_device_id("MDRAID-" + md_name, incomplete=flags.allow_imperfect_devices)
 
         if device and not isinstance(device, MDRaidArrayDevice):
             log.warning("Found device %s, but it turns out not be an md array device after all.", device.name)

--- a/tests/storage_tests/devices_test/misc_test.py
+++ b/tests/storage_tests/devices_test/misc_test.py
@@ -1,0 +1,142 @@
+import os
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from ..storagetestcase import StorageTestCase
+
+import blivet
+from blivet.devices.btrfs import BTRFSVolumeDevice
+
+
+class DeviceIDTestCase(StorageTestCase):
+
+    vgname = "blivetTestVG"
+
+    @classmethod
+    def setUpClass(cls):
+        unavailable_deps = BTRFSVolumeDevice.unavailable_type_dependencies()
+        if unavailable_deps:
+            dep_str = ", ".join([d.name for d in unavailable_deps])
+            raise unittest.SkipTest("some unavailable dependencies required for this test: %s" % dep_str)
+
+    def setUp(self):
+        super().setUp()
+
+        # allow automounting to get btrfs information
+        blivet.flags.flags.auto_dev_updates = True
+
+        disks = [os.path.basename(vdev) for vdev in self.vdevs]
+        self.storage = blivet.Blivet()
+        self.storage.exclusive_disks = disks
+        self.storage.reset()
+
+        # make sure only the targetcli disks are in the devicetree
+        for disk in self.storage.disks:
+            self.assertTrue(disk.path in self.vdevs)
+            self.assertIsNone(disk.format.type)
+            self.assertFalse(disk.children)
+
+    def _clean_up(self):
+        self.storage.reset()
+        for disk in self.storage.disks:
+            if disk.path not in self.vdevs:
+                raise RuntimeError("Disk %s found in devicetree but not in disks created for tests" % disk.name)
+            self.storage.recursive_remove(disk)
+
+        self.storage.do_it()
+
+        # reset back to default
+        blivet.flags.flags.auto_dev_updates = False
+
+        return super()._clean_up()
+
+    def test_same_name_devices(self):
+        """ Test that we can handle multiple devices with the same name
+
+            This test cases creates three devices named "test": two btrfs
+            volumes and one VG and checks that reset() and get_device_by_device_id()
+            work as expected.
+        """
+
+        # BTRFS volume named "test"
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+
+        self.storage.initialize_disk(disk)
+
+        part = self.storage.new_partition(size=blivet.size.Size("1 GiB"), fmt_type="btrfs",
+                                          parents=[disk])
+        self.storage.create_device(part)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        vol = self.storage.new_btrfs(name="test", parents=[part])
+        btrfs1_uuid = vol.uuid
+        self.storage.create_device(vol)
+        self.storage.do_it()
+        self.storage.reset()
+
+        # second BTRFS volume also named "test"
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[1])
+        self.assertIsNotNone(disk)
+
+        self.storage.initialize_disk(disk)
+
+        part = self.storage.new_partition(size=blivet.size.Size("1 GiB"), fmt_type="btrfs",
+                                          parents=[disk])
+        self.storage.create_device(part)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        # XXX we actually cannot create another device with the same name
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            vol = self.storage.new_btrfs(name="test", parents=[part])
+            btrfs2_uuid = vol.uuid
+            self.storage.create_device(vol)
+            self.storage.do_it()
+            self.storage.reset()
+
+        # LVM VG named "test"
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[2])
+        self.assertIsNotNone(disk)
+
+        self.storage.initialize_disk(disk)
+
+        pv = self.storage.new_partition(size=blivet.size.Size("100 MiB"), fmt_type="lvmpv",
+                                        parents=[disk])
+        self.storage.create_device(pv)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        # XXX we actually cannot create another device with the same name
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            vg = self.storage.new_vg(name="test", parents=[pv])
+            self.storage.create_device(vg)
+            self.storage.do_it()
+            self.storage.reset()
+
+        # we should now have three devices named test
+        test_devs = [dev for dev in self.storage.devices if dev.name == "test"]
+        self.assertEqual(len(test_devs), 3)
+
+        vol1 = self.storage.devicetree.get_device_by_device_id("BTRFS-" + btrfs1_uuid)
+        self.assertIsNotNone(vol1)
+        self.assertEqual(vol1.type, "btrfs volume")
+        self.assertEqual(vol1.name, "test")
+        self.assertEqual(vol1.parents[0].path, self.vdevs[0] + "1")
+
+        vol2 = self.storage.devicetree.get_device_by_device_id("BTRFS-" + btrfs2_uuid)
+        self.assertIsNotNone(vol2)
+        self.assertEqual(vol2.type, "btrfs volume")
+        self.assertEqual(vol2.name, "test")
+        self.assertEqual(vol2.parents[0].path, self.vdevs[1] + "1")
+
+        vg = self.storage.devicetree.get_device_by_device_id("LVM-test")
+        self.assertIsNotNone(vg)
+        self.assertEqual(vg.type, "lvmvg")
+        self.assertEqual(vg.name, "test")
+        self.assertEqual(vg.parents[0].path, self.vdevs[2] + "1")

--- a/tests/unit_tests/devices_test/btrfs_test.py
+++ b/tests/unit_tests/devices_test/btrfs_test.py
@@ -55,3 +55,13 @@ class BlivetNewBtrfsVolumeDeviceTest(unittest.TestCase):
         self.assertEqual(sub.format.type, "btrfs")
         self.assertEqual(sub.size, vol.size)
         self.assertEqual(sub.volume, vol)
+
+    def test_device_id(self):
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("btrfs"),
+                           size=Size("2 GiB"), exists=False)
+
+        vol = BTRFSVolumeDevice("testvolume", parents=[bd])
+        self.assertEqual(vol.device_id, "BTRFS-" + vol.uuid)
+
+        sub = BTRFSSubVolumeDevice("testsub", parents=[vol])
+        self.assertEqual(sub.device_id, "BTRFS-" + vol.uuid + "-testsub")

--- a/tests/unit_tests/devices_test/lvm_test.py
+++ b/tests/unit_tests/devices_test/lvm_test.py
@@ -571,6 +571,16 @@ class LVMDeviceTest(unittest.TestCase):
         vg._remove_parent(pv2)
         self.assertEqual(pv2.format.vg_name, None)
 
+    def test_device_id(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1 GiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv])
+        self.assertEqual(vg.device_id, "LVM-testvg")
+
+        lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
+                                    fmt=blivet.formats.get_format("xfs"))
+        self.assertEqual(lv.device_id, "LVM-testvg-testlv")
+
 
 class TypeSpecificCallsTest(unittest.TestCase):
     def test_type_specific_calls(self):

--- a/tests/unit_tests/devices_test/md_test.py
+++ b/tests/unit_tests/devices_test/md_test.py
@@ -85,3 +85,13 @@ class MDRaidArrayDeviceTest(unittest.TestCase):
 
         with six.assertRaisesRegex(self, ValueError, "specifying chunk size is not allowed for raid1"):
             raid_array.chunk_size = Size("512 KiB")
+
+    def test_device_id(self):
+        member1 = StorageDevice("member1", fmt=blivet.formats.get_format("mdmember"),
+                                size=Size("1 GiB"))
+        member2 = StorageDevice("member2", fmt=blivet.formats.get_format("mdmember"),
+                                size=Size("1 GiB"))
+
+        raid_array = MDRaidArrayDevice(name="raid", level="raid0", member_devices=2,
+                                       total_devices=2, parents=[member1, member2])
+        self.assertEqual(raid_array.device_id, "MDRAID-raid")

--- a/tests/unit_tests/devices_test/partition_test.py
+++ b/tests/unit_tests/devices_test/partition_test.py
@@ -190,3 +190,7 @@ class PartitionDeviceTestCase(unittest.TestCase):
 
             PartitionDevice("testpart1", exists=True, parents=[disk])
             self.assertFalse(disk.is_empty)
+
+    def test_device_id(self):
+        part = PartitionDevice("req1", exists=False)
+        self.assertEqual(part.device_id, "req1")

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -104,3 +104,13 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 encrypted=True,
                                                                 passphrase="secret",
                                                                 key_file=None)
+
+    def test_device_id(self):
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("2 GiB"), exists=False)
+
+        pool = StratisPoolDevice("testpool", parents=[bd])
+        self.assertEqual(pool.device_id, "STRATIS-testpool")
+
+        fs = StratisFilesystemDevice("testfs", parents=[pool], size=Size("1 GiB"))
+        self.assertEqual(fs.device_id, "STRATIS-testpool/testfs")

--- a/tests/unit_tests/devicetree_test.py
+++ b/tests/unit_tests/devicetree_test.py
@@ -300,6 +300,29 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertIsNone(dt.get_device_by_name("dev3"))
         self.assertEqual(dt.get_device_by_name("dev3", hidden=True), dev3)
 
+    def test_get_device_by_device_id(self):
+        dt = DeviceTree()
+
+        # for StorageDevice, device_id is just name
+        dev1 = StorageDevice("dev1", exists=False, parents=[])
+        dev2 = StorageDevice("dev2", exists=False, parents=[dev1])
+        dt._add_device(dev1)
+        dt._add_device(dev2)
+
+        self.assertIsNone(dt.get_device_by_device_id("dev3"))
+        self.assertEqual(dt.get_device_by_device_id("dev2"), dev2)
+        self.assertEqual(dt.get_device_by_device_id("dev1"), dev1)
+
+        dev2.complete = False
+        self.assertEqual(dt.get_device_by_device_id("dev2"), None)
+        self.assertEqual(dt.get_device_by_device_id("dev2", incomplete=True), dev2)
+
+        dev3 = StorageDevice("dev3", exists=True, parents=[])
+        dt._add_device(dev3)
+        dt.hide(dev3)
+        self.assertIsNone(dt.get_device_by_device_id("dev3"))
+        self.assertEqual(dt.get_device_by_device_id("dev3", hidden=True), dev3)
+
     def test_recursive_remove(self):
         dt = DeviceTree()
         dev1 = StorageDevice("dev1", exists=False, parents=[])


### PR DESCRIPTION
The new `device_id` identifier is meant to be unique even for devices with the same name. The primary user for this will be Anaconda which needs an ID that will be a unique string stable between `reset()` calls.

The device ID looks as follows:
- `name` for disks, partitions and loop devices
- `LVM-<name>` for LVM VGs and LVs
- `BTRFS-<uuid>-<name>` for btrfs volumes and subvolumes
- `STRATIS-<name>` for Stratis devices
- `LUKS-<name>` for LUKS mapped devices
- `MDRAID-<name>` for MD arrays
- `DM-<name>` for generic DM devices

Btrfs is currently the only device type that allows duplicate names for volumes so UUID is used for btrfs volumes. For other devices (LVM, MD...) the device name must be unique so we can use the name with technology prefix.