### PR TITLE
Fix crash when scanning degraded/not fully assembled MD arrays

### DIFF
--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -58,7 +58,8 @@ class MDDevicePopulator(DevicePopulator):
             return None
 
         # try to get the device again now that we've got all the parents
-        device = self._devicetree.get_device_by_device_id("MDRAID-" + name, incomplete=flags.allow_imperfect_devices)
+        if name:
+            device = self._devicetree.get_device_by_device_id("MDRAID-" + name, incomplete=flags.allow_imperfect_devices)
 
         if device is None:
             try:


### PR DESCRIPTION
When we don't have the array name we cannot construct device ID for the devicetree lookup, we need to let the code fallback to other means like UUID.