### PR TITLE
Fstab cleanup fix

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -292,7 +292,7 @@ class ActionList(object):
             # (device may not exist afterwards)
             if not skip_fstab:
                 try:
-                    entry = fstab.entry_from_device(action.device)
+                    entry = fstab.entry_from_action(action)
                 except ValueError:
                     # this device should not be in fstab
                     bae_entry = None

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -56,7 +56,10 @@ import logging
 log = logging.getLogger("blivet")
 
 
-FSTAB_PATH = "/etc/fstab"
+# Default path to fstab file. Left empty to prevent blivet from using
+# fstab functionality by default.
+# TODO Change to "/etc/fstab" at next major version
+FSTAB_PATH = ""
 
 
 @six.add_metaclass(SynchronizedMeta)


### PR DESCRIPTION
Formats with multiple layers (e.g. LUKS) were not handled properly in fstab. This resulted in fstab entries not being properly cleaned from fstab when destroy actions were executed. This fixes the issue by using different variables with correct values based on action type.