### PR TITLE
Fix creating Stratis filesystem without size specified

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -203,6 +203,8 @@ class StratisFilesystemDevice(StorageDevice):
     _min_size = Size("512 MiB")
 
     def __init__(self, name, parents=None, size=None, uuid=None, exists=False):
+        if size is None:
+            size = devicelibs.stratis.STRATIS_FS_SIZE
         if not exists and parents[0].free_space <= devicelibs.stratis.filesystem_md_size(size):
             raise StratisError("cannot create new stratis filesystem, not enough free space in the pool")
 

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -105,6 +105,56 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 passphrase="secret",
                                                                 key_file=None)
 
+    def test_new_stratis_no_size(self):
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("2 GiB"), exists=False)
+
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd])
+        self.assertEqual(pool.name, "testpool")
+        self.assertEqual(pool.size, bd.size)
+
+        with patch("blivet.devicelibs.stratis.pool_used", lambda _d, _e: Size("512 MiB")):
+            self.assertAlmostEqual(pool.free_space, Size("1.5 GiB"))
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            fs = b.new_stratis_filesystem(name="testfs", parents=[pool])
+
+        self.assertEqual(fs.name, "testpool/testfs")
+        self.assertEqual(fs.path, "/dev/stratis/%s" % fs.name)
+        self.assertEqual(fs.size, Size("1 TiB"))
+        self.assertEqual(fs.pool, pool)
+        self.assertEqual(fs.format.type, "stratis xfs")
+        # for 1 TiB filesystem, metadata should take around 1 GiB
+        self.assertAlmostEqual(fs.used_size, Size("1 GiB"), delta=Size("50 MiB"))
+
+        b.create_device(pool)
+        b.create_device(fs)
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(pool, "_pre_create"):
+                with patch.object(pool, "_post_create"):
+                    pool.create()
+                    stratis_dbus.create_pool.assert_called_with(name='testpool',
+                                                                devices=['/dev/bd1'],
+                                                                encrypted=False,
+                                                                passphrase=None,
+                                                                key_file=None)
+
+        # we would get this from pool._post_create
+        pool.uuid = "c4fc9ebe-e173-4cab-8d81-cc6abddbe02d"
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(fs, "_pre_create"):
+                with patch.object(fs, "_post_create"):
+                    fs.create()
+                    stratis_dbus.create_filesystem.assert_called_with(name="testfs",
+                                                                      pool_uuid="c4fc9ebe-e173-4cab-8d81-cc6abddbe02d",
+                                                                      fs_size=Size("1 TiB"))
+
     def test_device_id(self):
         bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
                            size=Size("2 GiB"), exists=False)


### PR DESCRIPTION
We do allow creating Stratis FS without specifying its size which simply means creating the default 1 TiB filesystem.