### PR TITLE
Do not raise not implemented exception when checking if btrfs is empty

### DIFF
--- a/blivet/devicelibs/btrfs.py
+++ b/blivet/devicelibs/btrfs.py
@@ -64,5 +64,8 @@ def get_mountpoint_subvolumes(mountpoint):
         subvols = BlockDev.btrfs.list_subvolumes(mountpoint)
     except BlockDev.BtrfsError as e:
         raise BTRFSError(str(e))
+    except BlockDev.BlockDevNotImplementedError:
+        log.warning("cannot get list of subvolumes: libblockdev btrfs plugin not available")
+        return []
     else:
         return [s.path for s in subvols]


### PR DESCRIPTION
If we don't have libblockdev btrfs plugin we cannot check if the btrfs filesystem is empty.