### PR TITLE
fstab: Use 'mount_type' when writing filesystem type to fstab

### DIFF
--- a/blivet/fstab.py
+++ b/blivet/fstab.py
@@ -396,7 +396,11 @@ class FSTabManager(object):
         entry.spec = self._get_spec(device)
         if entry.spec is None:
             entry.spec = getattr(device, "fstab_spec", None)
-        entry.vfstype = device.format.type
+
+        if hasattr(device.format, "mount_type") and device.format.mount_type is not None:
+            entry.vfstype = device.format.mount_type
+        else:
+            entry.vfstype = device.format.type
 
         return entry
 
@@ -434,7 +438,10 @@ class FSTabManager(object):
         if entry.spec is None:
             entry.spec = getattr(action.device, "fstab_spec", None)
 
-        entry.vfstype = action.device.format.type
+        if hasattr(action.device.format, "mount_type") and action.device.format.mount_type is not None:
+            entry.vfstype = action.device.format.mount_type
+        else:
+            entry.vfstype = action.device.format.type
 
         return entry
 

--- a/tests/unit_tests/fstab_test.py
+++ b/tests/unit_tests/fstab_test.py
@@ -8,8 +8,9 @@ import unittest
 import copy
 
 from blivet.fstab import FSTabManager, FSTabEntry, HAVE_LIBMOUNT
-from blivet.devices import DiskDevice
+from blivet.devices import DiskDevice, StratisPoolDevice, StratisFilesystemDevice
 from blivet.formats import get_format
+from blivet.size import Size
 from blivet import Blivet
 
 FSTAB_WRITE_FILE = "/tmp/test-blivet-fstab2"
@@ -99,6 +100,15 @@ class FSTabTestCase(unittest.TestCase):
 
         _entry = self.fstab.entry_from_device(device)
         self.assertEqual(_entry, FSTabEntry('/dev/test_device', '/media/fstab_test', 'ext4', None, 0, 0))
+
+    def test_entry_from_device_stratis(self):
+        pool = StratisPoolDevice("testpool", parents=[], exists=True)
+        device = StratisFilesystemDevice("testfs", parents=[pool], size=Size("1 GiB"), exists=True)
+        device.format = get_format("stratis xfs")
+        device.format.mountpoint = "/media/fstab_test"
+
+        _entry = self.fstab.entry_from_device(device)
+        self.assertEqual(_entry, FSTabEntry('/dev/stratis/testpool/testfs', '/media/fstab_test', 'xfs', None, 0, 0))
 
     def test_update(self):
 


### PR DESCRIPTION
FOr some formats the 'type' value is not valid for mounting/fstab, for example for Stratis devices we internally use 'stratis xfs' but we need to use 'xfs' for mounting and fstab.