### PR TITLE
tests: Add a base class for stratis tests

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -55,6 +55,8 @@
         - targetcli
         - iscsi-initiator-utils
         - gfs2-utils
+        - stratisd
+        - stratis-cli
     when: ansible_distribution == 'Fedora' and test_dependencies|bool
 
 ####### CentOS 8/9
@@ -105,6 +107,8 @@
         - python3-pip
         - targetcli
         - iscsi-initiator-utils
+        - stratisd
+        - stratis-cli
     when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8' and test_dependencies|bool
 
   - name: Install paramiko using pip (not available in EPEL yet) (CentOS 9)

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -8,7 +8,7 @@ import blivet
 from blivet.devices.stratis import StratisFilesystemDevice, StratisClevisConfig
 
 
-class StratisTestCase(StorageTestCase):
+class StratisTestCaseBase(StorageTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -41,6 +41,9 @@ class StratisTestCase(StorageTestCase):
         self.storage.do_it()
 
         return super()._clean_up()
+
+
+class StratisTestCase(StratisTestCaseBase):
 
     def test_stratis_basic(self):
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
@@ -209,7 +212,7 @@ class StratisTestCase(StorageTestCase):
 
 
 @unittest.skip("Requires TPM or Tang configuration")
-class StratisTestCaseClevis(StratisTestCase):
+class StratisTestCaseClevis(StratisTestCaseBase):
 
     # XXX: we don't have Tang server, this test will be always skipped
     #      the test cases are kept here for manual testing


### PR DESCRIPTION
To avoid re-running all the test cases from StratisTestCase in StratisTestCaseClevis.