### PR TITLE
Fix skipping btrfs calls when libblockdev btrfs plugin is missing

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -40,7 +40,7 @@ from .. import util
 from ..formats import get_format, DeviceFormat
 from ..size import Size
 from ..mounts import mounts_cache
-from .. import missing_plugs
+from .. import avail_plugs
 
 import logging
 log = logging.getLogger("blivet")
@@ -382,7 +382,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
     def list_subvolumes(self, snapshots_only=False):
         subvols = []
 
-        if "btrfs" in missing_plugs:
+        if "btrfs" not in avail_plugs:
             log.debug("not listing btrfs subvolumes, libblockdev btrfs plugin is missing")
             return subvols
 

--- a/tests/unit_tests/devices_test/btrfs_test.py
+++ b/tests/unit_tests/devices_test/btrfs_test.py
@@ -83,7 +83,7 @@ class BlivetNewBtrfsVolumeDeviceTest(unittest.TestCase):
 
                 # mounted but libblockdev btrfs plugin not available
                 blockdev.reset_mock()
-                with patch("blivet.devices.btrfs.missing_plugs", new={"btrfs"}):
+                with patch("blivet.devices.btrfs.avail_plugs", new={"lvm"}):
                     vol.list_subvolumes()
                     blockdev.list_subvolumes.assert_not_called()
                     blockdev.get_default_subvolume_id.assert_not_called()


### PR DESCRIPTION
We need to check for the btrfs plugin in the set of available plugins, not in the missing plugins, because on RHEL the plugin is not missing, it's not even requested.