### PR TITLE
Fix pylint 'possibly-used-before-assignment' warnings

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -155,6 +155,8 @@ def set_key(key_desc, passphrase, key_file):
         fd = read
     elif key_file:
         fd = os.open(key_file, os.O_RDONLY)
+    else:
+        raise RuntimeError("Passphrase or key file must be provided")
 
     fd_list = Gio.UnixFDList()
     fd_list.append(fd)

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -752,6 +752,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                         break
             elif options:
                 attr = None
+                val = None
                 if "subvol=" in options:
                     attr = "name"
                     val = util.get_option_value("subvol", options)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -400,6 +400,8 @@ class LUKS(DeviceFormat):
             context = blockdev.CryptoKeyslotContext(passphrase=self.__passphrase)
         elif self._key_file:
             context = blockdev.CryptoKeyslotContext(keyfile=self._key_file)
+        else:
+            raise LUKSError("luks device not configured")
 
         ncontext = blockdev.CryptoKeyslotContext(passphrase=passphrase)
 

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -283,6 +283,8 @@ class BlockDevFSMethod(Method):
                     avail, _mode, utility = self.check_fn(self.fstype)
                 elif self.operation == FSOperation.MKFS:
                     avail, _options, utility = self.check_fn(self.fstype)
+                else:
+                    raise RuntimeError("Unknown operation")
             except blockdev.FSError as e:
                 return [str(e)]
             if not avail:

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -86,6 +86,8 @@ def get_device(sysfs_path=None, device_node=None):
             device = pyudev.Devices.from_sys_path(global_udev, sysfs_path)
         elif device_node is not None:
             device = pyudev.Devices.from_device_file(global_udev, device_node)
+        else:
+            raise RuntimeError("At least one of 'sysfs_path' and 'device_node' must be specified")
     except pyudev.DeviceNotFoundError as e:
         log.error(e)
         result = None

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -23,10 +23,11 @@ class BlivetLintConfig(CensorshipConfig):
             FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
             FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
             FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
-            FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify|arguments-renamed|redundant-u-string-prefix)'"),
+            FalsePositive(r"Bad option value '(subprocess-popen-preexec-fn|try-except-raise|environment-modify|arguments-renamed|redundant-u-string-prefix|possibly-used-before-assignment)'"),
             FalsePositive(r"Instance of '(Action.*Device|Action.*Format|Action.*Member|Device|DeviceAction|DeviceFormat|Event|ObjectID|PartitionDevice|StorageDevice|BTRFS.*Device|LoopDevice)' has no 'id' member$"),
             FalsePositive(r"Instance of 'GError' has no 'message' member"),  # overriding currently broken local pylint disable
-            FalsePositive(r"No name '.*' in module 'libmount'")
+            FalsePositive(r"No name '.*' in module 'libmount'"),
+            FalsePositive(r"Unknown option value for 'disable', expected a valid pylint message and got 'possibly-used-before-assignment'")
         ]
 
     def _files(self):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -134,8 +134,8 @@ def _should_skip(distro=None, version=None, arch=None, reason=None):  # pylint: 
 
     # DISTRO, VERSION and ARCH variables are set in main, we don't need to
     # call hostnamectl etc. for every test run
-    if ((distro is None or DISTRO in distro) and (version is None or VERSION in version) and  # pylint: disable=used-before-assignment
-       (arch is None or ARCH in arch)):  # pylint: disable=used-before-assignment
+    if ((distro is None or DISTRO in distro) and (version is None or VERSION in version) and  # pylint: disable=used-before-assignment,possibly-used-before-assignment
+       (arch is None or ARCH in arch)):  # pylint: disable=used-before-assignment,possibly-used-before-assignment
         return True
 
     return False


### PR DESCRIPTION
The latest pylint introduced a new warning for values possibly used before assignment.