### PR TITLE
Remove support for the MD linear RAID level

### DIFF
--- a/blivet/devicelibs/mdraid.py
+++ b/blivet/devicelibs/mdraid.py
@@ -45,6 +45,6 @@ class MDRaidLevels(raid.RAIDLevels):
             hasattr(level, 'get_size')
 
 
-raid_levels = MDRaidLevels(["raid0", "raid1", "raid4", "raid5", "raid6", "raid10", "linear"])
+raid_levels = MDRaidLevels(["raid0", "raid1", "raid4", "raid5", "raid6", "raid10"])
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_MDRAID_PLUGIN]


### PR DESCRIPTION
The md-linear kernel module is deprecated and will be removed in the future.