### PR TITLE
Set log level to INFO for libblockdev

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -67,6 +67,8 @@ if arch.is_s390():
 else:
     _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvme", "fs"))
 
+blockdev.utils_set_log_level(syslog.LOG_INFO)
+
 _requested_plugins = blockdev.plugin_specs_from_names(_REQUESTED_PLUGIN_NAMES)
 try:
     succ_, avail_plugs = blockdev.try_reinit(require_plugins=_requested_plugins, reload=False, log_func=log_bd_message)


### PR DESCRIPTION
Default log level is WARNING and we want to log even INFO messages for libblockdev. INFO level contains for example also all commands and their output that we want to log to program.log.