### PR TITLE
tests: Try waiting after partition creation for XFS resize test

### DIFF
--- a/tests/storage_tests/formats_test/fs_test.py
+++ b/tests/storage_tests/formats_test/fs_test.py
@@ -11,6 +11,7 @@ from blivet.formats import get_format
 from blivet.devices import PartitionDevice, DiskDevice
 from blivet.flags import flags
 from blivet.util import capture_output
+from blivet import udev
 
 from .loopbackedtestcase import LoopBackedTestCase
 
@@ -149,6 +150,7 @@ class XFSTestCase(fstesting.FSAsRoot):
         pend = pstart + int(Size(size) / disk.format.parted_device.sectorSize)
         disk.format.add_partition(pstart, pend, parted.PARTITION_NORMAL)
         disk.format.parted_disk.commit()
+        udev.settle()
         part = disk.format.parted_disk.getPartitionBySector(pstart)
 
         device = PartitionDevice(os.path.basename(part.path))


### PR DESCRIPTION
The test randomly fails to find the newly created partition so lets try waiting a bit with udev settle.