### PR TITLE
Fix skipping MD tests on CentOS 9

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -24,7 +24,7 @@
 
 ---
 
-- test: storage_tests.devices_test.md_test.MDTestCase
+- test: storage_tests.devices_test.md_test.(MDTestCase|MDLUKSTestCase)
   skip_on:
     - distro: "centos"
       version: "9"


### PR DESCRIPTION
We added new test cases that also need to be skipped.