### PR TITLE
Use libblockdev FS plugin for fsminsize

### DIFF
--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -565,6 +565,9 @@ BLOCKDEV_NTFS_MKFS = blockdev_fs_plugin_operation(BlockDevFSMethod(FSOperation.M
 BLOCKDEV_VFAT_MKFS = blockdev_fs_plugin_operation(BlockDevFSMethod(FSOperation.MKFS, blockdev.fs.can_mkfs, "vfat"))
 BLOCKDEV_F2FS_MKFS = blockdev_fs_plugin_operation(BlockDevFSMethod(FSOperation.MKFS, blockdev.fs.can_mkfs, "f2fs"))
 
+BLOCKDEV_EXT_MIN_SIZE = blockdev_fs_plugin_operation(BlockDevFSMethod(FSOperation.LABEL, blockdev.fs.can_get_min_size, "ntfs"))
+BLOCKDEV_NTFS_MIN_SIZE = blockdev_fs_plugin_operation(BlockDevFSMethod(FSOperation.LABEL, blockdev.fs.can_get_min_size, "ntfs"))
+
 # libblockdev plugins
 # we can't just check if the plugin is loaded, we also need to make sure
 # that all technologies required by us our supported (some may be missing
@@ -590,10 +593,7 @@ E2FSCK_APP = application("e2fsck")
 FSCK_HFSPLUS_APP = application("fsck.hfsplus")
 XFSREPAIR_APP = application("xfs_repair")
 FSCK_F2FS_APP = application("fsck.f2fs")
-
-# resize (for min size)
 NTFSRESIZE_APP = application("ntfsresize")
-RESIZE2FS_APP = application("resize2fs")
 
 # mkfs
 MKFS_GFS2_APP = application("mkfs.gfs2")

--- a/blivet/tasks/fsminsize.py
+++ b/blivet/tasks/fsminsize.py
@@ -22,12 +22,15 @@
 import abc
 
 from ..errors import FSError
-from .. import util
 from ..size import Size
 
 from . import availability
 from . import fstask
 from . import task
+
+import gi
+gi.require_version("BlockDev", "3.0")
+from gi.repository import BlockDev
 
 
 class FSMinSize(task.BasicApplication, fstask.FSTask, metaclass=abc.ABCMeta):
@@ -35,29 +38,6 @@ class FSMinSize(task.BasicApplication, fstask.FSTask, metaclass=abc.ABCMeta):
     """ An abstract class that represents min size information extraction. """
 
     description = "minimum filesystem size"
-
-    options = abc.abstractproperty(doc="Options for use with app.")
-
-    def _resize_command(self):
-        return [str(self.ext)] + self.options + [self.fs.device]
-
-    def _get_resize_info(self):
-        """ Get info from fsresize program.
-
-            :rtype: str
-            :returns: output returned by fsresize program
-        """
-        error_msg = None
-        try:
-            (rc, out) = util.run_program_and_capture_output(self._resize_command())
-            if rc:
-                error_msg = "failed to gather info from resize program: %d" % rc
-        except OSError as e:
-            error_msg = "failed to gather info from resize program: %s" % e
-
-        if error_msg:
-            raise FSError(error_msg)
-        return out
 
     @abc.abstractmethod
     def do_task(self):  # pylint: disable=arguments-differ
@@ -71,97 +51,25 @@ class FSMinSize(task.BasicApplication, fstask.FSTask, metaclass=abc.ABCMeta):
 
 
 class Ext2FSMinSize(FSMinSize):
-
-    ext = availability.RESIZE2FS_APP
-    options = ["-P"]
-
-    @property
-    def depends_on(self):
-        return [self.fs._info]
-
-    def _extract_block_size(self):
-        """ Extract block size from filesystem info.
-
-            :returns: block size of fileystem or None
-            :rtype: :class:`~.size.Size` or NoneType
-        """
-        if self.fs._current_info is None:
-            return None
-
-        return Size(self.fs._current_info.block_size)
-
-    def _extract_num_blocks(self, info):
-        """ Extract the number of blocks from the resizefs info.
-
-           :returns: the number of blocks or None
-           :rtype: int or NoneType
-        """
-        num_blocks = None
-        for line in info.splitlines():
-            (text, _sep, value) = line.partition(":")
-            if "minimum size of the filesystem" not in text:
-                continue
-
-            try:
-                num_blocks = int(value.strip())
-                break
-            except ValueError:
-                break
-
-        return num_blocks
+    ext = availability.BLOCKDEV_EXT_MIN_SIZE
 
     def do_task(self):  # pylint: disable=arguments-differ
         error_msgs = self.availability_errors
         if error_msgs:
             raise FSError("\n".join(error_msgs))
 
-        block_size = self._extract_block_size()
-        if block_size is None:
-            raise FSError("failed to get block size for %s filesystem on %s" % (self.fs.mount_type, self.fs.device))
-
-        resize_info = self._get_resize_info()
-        num_blocks = self._extract_num_blocks(resize_info)
-        if num_blocks is None:
-            raise FSError("failed to get minimum block number for %s filesystem on %s" % (self.fs.mount_type, self.fs.device))
-
-        return block_size * num_blocks
+        return Size(BlockDev.fs.ext2_get_min_size(self.fs.device))
 
 
 class NTFSMinSize(FSMinSize):
-
-    ext = availability.NTFSRESIZE_APP
-    options = ["-m"]
-
-    def _extract_min_size(self, info):
-        """ Extract the minimum size from the resizefs info.
-
-            :param str info: info obtained from resizefs prog
-            :rtype: :class:`~.size.Size` or NoneType
-            :returns: the minimum size, or None
-        """
-        min_size = None
-        for line in info.splitlines():
-            (text, _sep, value) = line.partition(":")
-            if "Minsize" not in text:
-                continue
-
-            try:
-                min_size = Size("%d MB" % int(value.strip()))
-            except ValueError:
-                break
-
-        return min_size
+    ext = availability.BLOCKDEV_NTFS_MIN_SIZE
 
     def do_task(self):  # pylint: disable=arguments-differ
         error_msgs = self.availability_errors
         if error_msgs:
             raise FSError("\n".join(error_msgs))
 
-        resize_info = self._get_resize_info()
-        min_size = self._extract_min_size(resize_info)
-        if min_size is None:
-            raise FSError("Unable to discover minimum size of filesystem on %s" % self.fs.device)
-        return min_size
+        return Size(BlockDev.fs.ntfs_get_min_size(self.fs.device))
 
 
 class UnimplementedFSMinSize(fstask.UnimplementedFSTask):

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -18,7 +18,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 3.0
+%global libblockdevver 3.1.0
 %global libbytesizever 0.3
 %global pyudevver 0.18
 


### PR DESCRIPTION
This was not part of #1163 because libblockdev originally didn't support getting filesystem min size using the resize tools. We now have the required version of libblockdev available everywhere so we can switch the fsminsize task to the FS plugin too.