### PR TITLE
devicetree: resolve devices also with the PARTUUID=.. naming

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -634,7 +634,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
         """
         # find device in the tree
         device = None
-        if devspec.startswith("UUID="):
+        if devspec.startswith("UUID=") or devspec.startswith("PARTUUID="):
             # device-by-uuid
             uuid = devspec.partition("=")[2]
             if ((uuid.startswith('"') and uuid.endswith('"')) or

--- a/tests/unit_tests/devicetree_test.py
+++ b/tests/unit_tests/devicetree_test.py
@@ -57,6 +57,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertEqual(dt.resolve_device("LABEL=%s" % dev1_label), dev1)
         self.assertEqual(dt.resolve_device("UUID=%s" % dev1_label), None)
         self.assertEqual(dt.resolve_device("UUID=%s" % dev1_uuid), dev1)
+        self.assertEqual(dt.resolve_device("PARTUUID=%s" % dev1_uuid), dev1)
         self.assertEqual(dt.resolve_device("/dev/dev1"), dev1)
 
         self.assertEqual(dt.resolve_device("dev2"), dev2)


### PR DESCRIPTION
This identifier should be handled as well. It's met in debian fstab.