### PR TITLE
Use correct LUKS metadata size for LUKS 2

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -35,7 +35,6 @@ from .deviceaction import ActionCreateDevice, ActionCreateFormat, ActionDestroyD
 from .deviceaction import ActionDestroyFormat, ActionResizeDevice, ActionResizeFormat
 from .devicelibs.edd import get_edd_dict
 from .devicelibs.btrfs import MAIN_VOLUME_ID
-from .devicelibs.crypto import LUKS_METADATA_SIZE
 from .errors import StorageError, DependencyError
 from .size import Size
 from .devicetree import DeviceTree
@@ -988,16 +987,16 @@ class Blivet(object, metaclass=SynchronizedMeta):
         if device.format.resizable:
             if device.format.type == "luks" and device.children:
                 # resize the luks format
-                actions.append(ActionResizeFormat(device, new_size - LUKS_METADATA_SIZE))
+                actions.append(ActionResizeFormat(device, new_size - device.format._header_size))
 
                 luks_dev = device.children[0]
                 if luks_dev.resizable:
                     # resize the luks device
-                    actions.append(ActionResizeDevice(luks_dev, new_size - LUKS_METADATA_SIZE))
+                    actions.append(ActionResizeDevice(luks_dev, new_size - device.format._header_size))
 
                 if luks_dev.format.resizable:
                     # resize the format on the luks device
-                    actions.append(ActionResizeFormat(luks_dev, new_size - LUKS_METADATA_SIZE))
+                    actions.append(ActionResizeFormat(luks_dev, new_size - device.format._header_size))
             else:
                 actions.append(ActionResizeFormat(device, new_size))
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -425,9 +425,9 @@ class DeviceFactory(object):
     def encrypted(self, value):
         if not self.encrypted and value and self.size:
             # encrypted, bump size up with LUKS metadata size
-            self.size += get_format("luks").min_size
+            self.size += get_format("luks", luks_version=self.luks_version).min_size
         elif self.encrypted and not value and self.size:
-            self.size -= get_format("luks").min_size
+            self.size -= get_format("luks", luks_version=self.luks_version).min_size
 
         self._encrypted = value
 

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -35,7 +35,9 @@ from ..util import total_memory, available_memory, run_program_and_capture_outpu
 import logging
 log = logging.getLogger("blivet")
 
-LUKS_METADATA_SIZE = Size("2 MiB")
+LUKS1_METADATA_SIZE = Size("2 MiB")
+LUKS2_METADATA_SIZE = Size("16 MiB")
+LUKS_METADATA_SIZE = LUKS2_METADATA_SIZE  # luks2 is default
 MIN_CREATE_ENTROPY = 256  # bits
 SECTOR_SIZE = Size("512 B")
 

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -39,7 +39,6 @@ log = logging.getLogger("blivet")
 from .device import Device
 from .network import NetworkStorageDevice
 from .lib import LINUX_SECTOR_SIZE
-from ..devicelibs.crypto import LUKS_METADATA_SIZE
 
 
 class StorageDevice(Device):
@@ -699,7 +698,7 @@ class StorageDevice(Device):
         """ The minimum size this device can be. """
         if self.format.type == "luks" and self.children:
             if self.resizable:
-                min_size = self.children[0].min_size + LUKS_METADATA_SIZE
+                min_size = self.children[0].min_size + self.format._header_size
             else:
                 min_size = self.current_size
         else:

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -120,6 +120,12 @@ class LUKS(DeviceFormat):
         self.map_name = kwargs.get("name")
         self.luks_version = kwargs.get("luks_version") or crypto.DEFAULT_LUKS_VERSION
 
+        if self.luks_version == "luks2":
+            self._header_size = crypto.LUKS2_METADATA_SIZE
+        else:
+            self._header_size = crypto.LUKS1_METADATA_SIZE
+        self._min_size = self._header_size
+
         if not self.exists and self.luks_version not in crypto.LUKS_VERSIONS.keys():
             raise ValueError("Unknown or unsupported LUKS version '%s'" % self.luks_version)
 

--- a/tests/unit_tests/devices_test/device_size_test.py
+++ b/tests/unit_tests/devices_test/device_size_test.py
@@ -5,6 +5,7 @@ from blivet.devicelibs import crypto
 from blivet.devices import StorageDevice, LUKSDevice
 from blivet import errors
 from blivet.formats import get_format
+from blivet.formats.luks import LUKS
 from blivet.size import Size
 
 
@@ -108,6 +109,7 @@ class LUKSDeviceSizeTest(StorageDeviceSizeTest):
     def _get_device(self, *args, **kwargs):
         exists = kwargs.get("exists", False)
         parent = StorageDevice(*args, size=kwargs["size"] + crypto.LUKS_METADATA_SIZE, exists=exists)
+        parent.format = LUKS()
         return LUKSDevice(*args, **kwargs, parents=[parent])
 
     def test_size_getter(self):

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -114,3 +114,17 @@ class LUKSNodevTestCase(unittest.TestCase):
                     fmt._create()
                     crypto.luks_format.assert_called()
                     self.assertIsNone(crypto.luks_format.call_args[1]["extra"])
+
+    def test_header_size(self):
+        fmt = LUKS(luks_version="luks2")
+        self.assertEqual(fmt._header_size, Size("16 MiB"))
+        self.assertEqual(fmt._min_size, Size("16 MiB"))
+
+        fmt = LUKS(luks_version="luks1")
+        self.assertEqual(fmt._header_size, Size("2 MiB"))
+        self.assertEqual(fmt._min_size, Size("2 MiB"))
+
+        # default is luks2
+        fmt = LUKS()
+        self.assertEqual(fmt._header_size, Size("16 MiB"))
+        self.assertEqual(fmt._min_size, Size("16 MiB"))


### PR DESCRIPTION
When creating or resizing LUKS 2 devices we need to take the bigger metadata into account (16 MiB for LUKS2 but just 2 MiB for LUKS1).