### PR TITLE
blivet fstab method change

### DIFF
--- a/tests/unit_tests/fstab_test.py
+++ b/tests/unit_tests/fstab_test.py
@@ -174,7 +174,7 @@ class FSTabTestCase(unittest.TestCase):
         dev1.format.mountpoint = "/mnt/mountpath"
         b.devicetree._add_device(dev1)
 
-        dev2 = self.fstab.find_device(b, "/dev/sda_dummy")
+        dev2 = self.fstab.find_device(b.devicetree, "/dev/sda_dummy")
 
         self.assertEqual(dev1, dev2)
 
@@ -190,6 +190,6 @@ class FSTabTestCase(unittest.TestCase):
         dev1.format.mountpoint = "/mnt/mountpath"
         b.devicetree._add_device(dev1)
 
-        dev2 = self.fstab.get_device(b, "/dev/sda_dummy", "/mnt/mountpath", "xfs", ["defaults"])
+        dev2 = self.fstab.get_device(b.devicetree, "/dev/sda_dummy", "/mnt/mountpath", "xfs", ["defaults"])
 
         self.assertEqual(dev1, dev2)


### PR DESCRIPTION
Blivet fstab methods `get_device()` and `find_device()` took `Blivet` object as a first parameter. However, for anaconda (primary customer for the blivet change) usecase the `Blivet` object does not always exist, only the `Devicetree`. Mentioned methods do not need anything else besides `Devicetree` from blivet object.

This changes those methods interfaces to accept `Devicetree` instead of `Blivet` as the first parameter.

Unit tests modified accordingly.
Storage role should not be affected by this change.