### PR TITLE
LUKS HW-OPAL support

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -47,6 +47,9 @@ LUKS_VERSIONS = {"luks1": BlockDev.CryptoLUKSVersion.LUKS1,
                  "luks2": BlockDev.CryptoLUKSVersion.LUKS2}
 DEFAULT_LUKS_VERSION = "luks2"
 
+OPAL_TYPES = {"luks2-hw-opal": BlockDev.CryptoLUKSHWEncryptionType.OPAL_HW_AND_SW,
+              "luks2-hw-opal-only": BlockDev.CryptoLUKSHWEncryptionType.OPAL_HW_ONLY}
+
 DEFAULT_INTEGRITY_ALGORITHM = "crc32c"
 
 # from linux/drivers/md/dm-integrity.c

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -419,7 +419,7 @@ class StorageDevice(Device):
 
     @property
     def protected(self):
-        return self.readonly or self._protected
+        return self.readonly or self._protected or self.format.protected
 
     @protected.setter
     def protected(self, value):

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -158,6 +158,7 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
     _check = False
     _hidden = False                     # hide devices with this formatting?
     _ks_mountpoint = None
+    _protected = False
 
     _resize_class = fsresize.UnimplementedFSResize
     _size_info_class = fssize.UnimplementedFSSize
@@ -684,6 +685,11 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
     def packages(self):
         """ Packages required to manage formats of this type. """
         return self._packages
+
+    @property
+    def protected(self):
+        """ Is this format protected? """
+        return self._protected
 
     @property
     def resizable(self):

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -102,8 +102,8 @@ class LUKS(DeviceFormat):
             :type luks_sector_size: int
             :keyword subsystem: LUKS subsystem
             :type subsystem: str
-            :keyword opal_passphrase: OPAL admin passphrase
-            :type opal_passphrase: str
+            :keyword opal_admin_passphrase: OPAL admin passphrase
+            :type opal_admin_passphrase: str
 
             .. note::
 
@@ -185,7 +185,7 @@ class LUKS(DeviceFormat):
         if self.luks_sector_size and self.luks_version != "luks2":
             raise ValueError("Sector size argument is valid only for LUKS version 2.")
 
-        self.__opal_passphrase = kwargs.get("opal_passphrase")
+        self.__opal_admin_passphrase = kwargs.get("opal_admin_passphrase")
 
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
@@ -229,11 +229,11 @@ class LUKS(DeviceFormat):
 
     passphrase = property(fset=_set_passphrase)
 
-    def _set_opal_passphrase(self, opal_passphrase):
+    def _set_opal_admin_passphrase(self, opal_admin_passphrase):
         """ Set the OPAL admin passphrase for this device. """
-        self.__opal_passphrase = opal_passphrase
+        self.__opal_admin_passphrase = opal_admin_passphrase
 
-    opal_passphrase = property(fset=_set_opal_passphrase)
+    opal_admin_passphrase = property(fset=_set_opal_admin_passphrase)
 
     @property
     def has_key(self):
@@ -390,9 +390,9 @@ class LUKS(DeviceFormat):
             raise LUKSError("Passphrase or key file must be set for LUKS create")
 
         if self.is_opal:
-            if not self.__opal_passphrase:
+            if not self.__opal_admin_passphrase:
                 raise LUKSError("OPAL admin passphrase must be specified when creating LUKS HW-OPAL format")
-            opal_context = blockdev.CryptoKeyslotContext(passphrase=self.__opal_passphrase)
+            opal_context = blockdev.CryptoKeyslotContext(passphrase=self.__opal_admin_passphrase)
 
         try:
             if self.is_opal:

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -259,6 +259,13 @@ class LUKS(DeviceFormat):
             return False
         return super(LUKS, self).resizable
 
+    @property
+    def protected(self):
+        if self.is_opal and self.exists:
+            # cannot remove LUKS HW-OPAL without admin password
+            return True
+        return False
+
     def update_size_info(self):
         """ Update this format's current size. """
 

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -127,6 +127,15 @@ class LUKSFormatPopulator(FormatPopulator):
             kwargs["name"] = "luks-%s" % udev.device_get_uuid(self.data)
 
         kwargs["luks_version"] = "luks%s" % udev.device_get_format_version(self.data)
+        kwargs["label"] = udev.device_get_label(self.data)
+
+        try:
+            info = blockdev.crypto.luks_info(self.device.path)
+        except blockdev.CryptoError as e:
+            log.warning("Failed to get information about LUKS format on %s: %s", self.device, str(e))
+        else:
+            kwargs["subsystem"] = info.subsystem
+
         return kwargs
 
     def run(self):

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -134,7 +134,10 @@ class LUKSFormatPopulator(FormatPopulator):
         except blockdev.CryptoError as e:
             log.warning("Failed to get information about LUKS format on %s: %s", self.device, str(e))
         else:
-            kwargs["subsystem"] = info.subsystem
+            if info.hw_encryption == blockdev.CryptoLUKSHWEncryptionType.OPAL_HW_AND_SW:
+                kwargs["luks_version"] = "luks2-hw-opal"
+            elif info.hw_encryption == blockdev.CryptoLUKSHWEncryptionType.OPAL_HW_ONLY:
+                kwargs["luks_version"] = "luks2-hw-opal-only"
 
         return kwargs
 

--- a/plans/blivet-gui.fmf
+++ b/plans/blivet-gui.fmf
@@ -6,6 +6,16 @@ adjust+:
   enabled: true
 
 prepare:
+  - name: copr
+    how: shell
+    script:
+      - sudo dnf install -y 'dnf-command(copr)'
+      - sudo dnf copr enable -y @storage/blivet-daily
+      # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
+
+  - name: ansible
     how: ansible
     playbook:
         - https://raw.githubusercontent.com/storaged-project/blivet-gui/main/misc/install-test-dependencies.yml

--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -10,6 +10,9 @@ prepare:
     script:
       - sudo dnf install -y 'dnf-command(copr)'
       - sudo dnf copr enable -y @storage/blivet-daily
+      # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
 
   - name: ansible
     how: ansible

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -139,7 +139,7 @@ class LUKSNodevTestCase(unittest.TestCase):
         self.assertTrue(fmt.is_opal)
         self.assertTrue(fmt.protected)
 
-        fmt = LUKS(luks_version="luks2-hw-opal", passphrase="passphrase", opal_passphrase="passphrase")
+        fmt = LUKS(luks_version="luks2-hw-opal", passphrase="passphrase", opal_admin_passphrase="passphrase")
         with patch("blivet.devicelibs.crypto.calculate_luks2_max_memory", return_value=None):
             with patch("blivet.devicelibs.crypto.get_optimal_luks_sector_size", return_value=512):
                 with patch("blivet.devices.lvm.blockdev.crypto") as crypto:
@@ -151,7 +151,7 @@ class LUKSNodevTestCase(unittest.TestCase):
                     self.assertEqual(crypto.opal_format.call_args[1]["cipher"], "aes-xts-plain64")
                     self.assertEqual(crypto.opal_format.call_args[1]["key_size"], 512)
 
-        fmt = LUKS(luks_version="luks2-hw-opal-only", passphrase="passphrase", opal_passphrase="passphrase")
+        fmt = LUKS(luks_version="luks2-hw-opal-only", passphrase="passphrase", opal_admin_passphrase="passphrase")
         with patch("blivet.devicelibs.crypto.calculate_luks2_max_memory", return_value=None):
             with patch("blivet.devicelibs.crypto.get_optimal_luks_sector_size", return_value=512):
                 with patch("blivet.devices.lvm.blockdev.crypto") as crypto:

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -128,3 +128,12 @@ class LUKSNodevTestCase(unittest.TestCase):
         fmt = LUKS()
         self.assertEqual(fmt._header_size, Size("16 MiB"))
         self.assertEqual(fmt._min_size, Size("16 MiB"))
+
+    def test_luks_opal(self):
+        fmt = LUKS(exists=True)
+        self.assertFalse(fmt.is_opal)
+        self.assertFalse(fmt.protected)
+
+        fmt = LUKS(subsystem="HW-OPAL")
+        self.assertTrue(fmt.is_opal)
+        self.assertTrue(fmt.protected)

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from blivet.formats.luks import LUKS
 from blivet.size import Size
 from blivet.static_data import luks_data
+from blivet import blockdev
 
 
 class LUKSNodevTestCase(unittest.TestCase):
@@ -134,6 +135,32 @@ class LUKSNodevTestCase(unittest.TestCase):
         self.assertFalse(fmt.is_opal)
         self.assertFalse(fmt.protected)
 
-        fmt = LUKS(subsystem="HW-OPAL")
+        fmt = LUKS(luks_version="luks2-hw-opal", exists=True)
         self.assertTrue(fmt.is_opal)
         self.assertTrue(fmt.protected)
+
+        fmt = LUKS(luks_version="luks2-hw-opal", passphrase="passphrase", opal_passphrase="passphrase")
+        with patch("blivet.devicelibs.crypto.calculate_luks2_max_memory", return_value=None):
+            with patch("blivet.devicelibs.crypto.get_optimal_luks_sector_size", return_value=512):
+                with patch("blivet.devices.lvm.blockdev.crypto") as crypto:
+                    fmt._create()
+                    crypto.luks_format.assert_not_called()
+                    crypto.opal_format.assert_called()
+                    self.assertEqual(crypto.opal_format.call_args[1]["hw_encryption"],
+                                     blockdev.CryptoLUKSHWEncryptionType.OPAL_HW_AND_SW)
+                    self.assertEqual(crypto.opal_format.call_args[1]["cipher"], "aes-xts-plain64")
+                    self.assertEqual(crypto.opal_format.call_args[1]["key_size"], 512)
+
+        fmt = LUKS(luks_version="luks2-hw-opal-only", passphrase="passphrase", opal_passphrase="passphrase")
+        with patch("blivet.devicelibs.crypto.calculate_luks2_max_memory", return_value=None):
+            with patch("blivet.devicelibs.crypto.get_optimal_luks_sector_size", return_value=512):
+                with patch("blivet.devices.lvm.blockdev.crypto") as crypto:
+                    fmt._create()
+                    crypto.luks_format.assert_not_called()
+                    crypto.opal_format.assert_called()
+                    self.assertEqual(crypto.opal_format.call_args[1]["hw_encryption"],
+                                     blockdev.CryptoLUKSHWEncryptionType.OPAL_HW_ONLY)
+
+                    # cipher and key size are not valid for HW encryption only
+                    self.assertEqual(crypto.opal_format.call_args[1]["cipher"], None)
+                    self.assertEqual(crypto.opal_format.call_args[1]["key_size"], 0)


### PR DESCRIPTION
Work in progress support for creating and managing OPAL self encrypting drives with LUKS. This for now contains only support for recognizing pre-existing LUKS HW-OPAL devices, because this doesn't require any additional support from libblockdev (which creating and removing these devices will require).