### PR TITLE
ci: Run dnf update in packit tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,6 +37,11 @@ jobs:
   trigger: pull_request
   targets:
   - fedora-latest-stable
+  tf_extra_params:
+    environments:
+      - artifacts:
+        - type: repository-file
+          id: https://copr.fedorainfracloud.org/coprs/g/storage/blivet-daily/repo/fedora-$releasever/group_storage-blivet-daily-fedora-$releasever.repo
 
 # run tests for udisks consumers, see plans/ with `revdeps == yes`
 - job: tests

--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -10,6 +10,7 @@ prepare:
     script:
       - sudo dnf install -y 'dnf-command(copr)'
       - sudo dnf copr enable -y @storage/blivet-daily
+      - sudo dnf -y update --refresh
 
   - name: ansible
     how: ansible
@@ -17,4 +18,4 @@ prepare:
 
 execute:
     how: tmt
-    script: sudo make test
+    script: sudo make check


### PR DESCRIPTION
The daily builds copr repository is enabled after installing the packages so we need to run an update to get the latest version of libblockdev.