### PR TITLE
Fix getting LUKS subsystem for existing LUKS formats

### DIFF
--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -139,6 +139,8 @@ class LUKSFormatPopulator(FormatPopulator):
             elif info.hw_encryption == blockdev.CryptoLUKSHWEncryptionType.OPAL_HW_ONLY:
                 kwargs["luks_version"] = "luks2-hw-opal-only"
 
+            kwargs["subsystem"] = info.subsystem
+
         return kwargs
 
     def run(self):


### PR DESCRIPTION
Accidentally removed in 319e6a6ede8f9468f56458ed8d14110536cf88d8