### PR TITLE
ci: Update branches in GitHub actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: static-analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI_IMAGE: fedora:latest
       CI_CONTAINER: blivet-tests

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,12 +3,10 @@ name: Static Analysis
 on:
   pull_request:
     branches:
-     - 3.*-devel
-     - master
+     - main
   push:
     branches:
-     - 3.*-devel
-     - master
+     - main
   schedule:
     - cron: 0 0 * * 0
 


### PR DESCRIPTION
'main' is the only development branch now, see #1274