### PR TITLE
Add partition type human-readable string to PartitionDevice

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -63,9 +63,9 @@ gi.require_version("BlockDev", "3.0")
 from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 if arch.is_s390():
-    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390", "nvme", "fs"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "s390", "nvme", "fs", "part"))
 else:
-    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvme", "fs"))
+    _REQUESTED_PLUGIN_NAMES = set(("lvm", "btrfs", "swap", "crypto", "loop", "mdraid", "mpath", "dm", "nvme", "fs", "part"))
 
 blockdev.utils_set_log_level(syslog.LOG_INFO)
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -66,6 +66,7 @@ Recommends: libblockdev-lvm >= %{libblockdevver}
 Recommends: libblockdev-mdraid >= %{libblockdevver}
 Recommends: libblockdev-mpath >= %{libblockdevver}
 Recommends: libblockdev-nvme >= %{libblockdevver}
+Recommends: libblockdev-part >= %{libblockdevver}
 Recommends: libblockdev-swap >= %{libblockdevver}
 
 %ifarch s390 s390x

--- a/tests/storage_tests/devices_test/lvm_test.py
+++ b/tests/storage_tests/devices_test/lvm_test.py
@@ -1,6 +1,9 @@
 import os
 import shutil
 import subprocess
+from uuid import UUID
+
+import parted
 
 from ..storagetestcase import StorageTestCase
 
@@ -100,6 +103,11 @@ class LVMTestCase(StorageTestCase):
         pv = self.storage.devicetree.get_device_by_path(self.vdevs[0] + "1")
         self.assertIsNone(pv.format.vg_name)
         self.assertIsNone(pv.format.vg_uuid)
+
+        # not really related to LVM, but we want to test the partition types somewhere
+        if hasattr(parted.Partition, "type_uuid"):
+            self.assertEqual(pv.part_type_uuid, UUID('e6d6d379-f507-44c2-a23c-238f2a3df928'))
+            self.assertEqual(pv.part_type_name, "Linux LVM")
 
     def test_lvm_thin(self):
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])


### PR DESCRIPTION
Unfortunately parted doesn't have the human readable strings so if we don't want to simply copy the table from libfdisk, we need to start using libblockdev part plugin to get it.

Fixes: #1258