### PR TITLE
spec: Bump required version of libblockdev to 3.2.0

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -18,7 +18,7 @@ Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 3.1.0
+%global libblockdevver 3.2.0
 %global libbytesizever 0.3
 %global pyudevver 0.18
 


### PR DESCRIPTION
Marking as draft for now because 3.2.0 is not released yet.