### PR TITLE
misc: Add support for installing dependencies on CentOS 1O Stream

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -59,25 +59,21 @@
         - stratis-cli
     when: ansible_distribution == 'Fedora' and test_dependencies|bool
 
-####### CentOS 8/9
+####### CentOS 9/10
   - name: Install basic build tools (CentOS)
     package: name=make state=present
     when: ansible_distribution == 'CentOS'
 
   - name: Enable EPEL repository (CentOS)
     package: name=epel-release state=present
+    when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '9'
+
+  - name: Install dnf-plugins-core for dnf config-manager and builddep (CentOS)
+    package: name=dnf-plugins-core state=present
     when: ansible_distribution == 'CentOS'
 
-  - name: Enable powertools repository (CentOS 8)
-    command: yum config-manager --set-enabled powertools
-    when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8'
-
-  - name: Enable CRB repository (CentOS 9)
-    command: yum config-manager --set-enabled crb
-    when: ansible_distribution == 'CentOS'  and ansible_distribution_major_version == '9'
-
-  - name: Install dnf-plugins-core for dnf builddep (CentOS)
-    package: name=dnf-plugins-core state=present
+  - name: Enable CRB repository (CentOS)
+    command: dnf config-manager --set-enabled crb
     when: ansible_distribution == 'CentOS'
 
   - name: Install build dependencies (CentOS)
@@ -95,8 +91,6 @@
         - dosfstools
         - e2fsprogs
         - xfsprogs
-        - python3-coverage
-        - python3-pycodestyle
         - python3-pyudev
         - python3-pyparted
         - libselinux-python3
@@ -109,11 +103,24 @@
         - iscsi-initiator-utils
         - stratisd
         - stratis-cli
-    when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '8' and test_dependencies|bool
+    when: ansible_distribution == 'CentOS' and test_dependencies|bool
 
-  - name: Install paramiko using pip (not available in EPEL yet) (CentOS 9)
-    pip: name=paramiko executable=pip3
+  - name: Install additional test dependencies (CentOS 9)
+    package:
+      state: present
+      name:
+        - python3-coverage
+        - python3-pycodestyle
     when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '9' and test_dependencies|bool
+
+  - name: Install coverage and pycodestyle using pip (CentOS 10)
+    pip:
+      name: ['coverage', 'pycodestyle']
+    when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '10' and test_dependencies|bool
+
+  - name: Install paramiko using pip
+    pip: name=paramiko executable=pip3
+    when: ansible_distribution == 'CentOS' and test_dependencies|bool
 
   - name: Install pocketlint using pip (CentOS)
     pip: name=pocketlint executable=pip3


### PR DESCRIPTION
Everything except coverage and pycodestyle is available in the repositories and we can install these two from pypi.