### PR TITLE
Ignore partitions on disks without parted disk

### DIFF
--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -83,6 +83,10 @@ class PartitionDevicePopulator(DevicePopulator):
                 disk.format = get_format("disklabel", exists=True, device=disk.path)
                 disk.original_format = copy.deepcopy(disk.format)
 
+        if disk.format.parted_disk is None:
+            log.error("ignoring partition %s on %s: parted disk not found", name, disk.name)
+            return
+
         try:
             device = PartitionDevice(name, sysfs_path=sysfs_path,
                                      uuid=udev.device_get_partition_uuid(self.data),


### PR DESCRIPTION
If we don't have the parted disk object we cannot really construct a working PartitionDevice so adding partitions on these disks usually end with an exception. This change should make blivet a little bit more resilient in those situations.