### PR TITLE
makeupdates: Ignore that getopt is deprecated

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -20,7 +20,7 @@
 #
 # Author: David Cantrell <dcantrell@redhat.com>
 
-import getopt
+import getopt  # pylint: disable=deprecated-module
 import os
 import shutil
 import subprocess


### PR DESCRIPTION
getopt is "soft deprecated" starting with Python 3.13. Pylint warns about this but getopt is not going to be removed, it's just not being actively developed any more. We should switch to argopt in the future, but for now we can just ignore the warning.