### PR TITLE
spec: Fix dependency on libblockdev-s390

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -72,10 +72,7 @@ Recommends: libblockdev-mpath >= %{libblockdevver}
 Recommends: libblockdev-nvme >= %{libblockdevver}
 Recommends: libblockdev-part >= %{libblockdevver}
 Recommends: libblockdev-swap >= %{libblockdevver}
-
-%ifarch s390 s390x
 Recommends: libblockdev-s390 >= %{libblockdevver}
-%endif
 
 Requires: python3-bytesize >= %{libbytesizever}
 Requires: util-linux >= %{utillinuxver}


### PR DESCRIPTION
We are a noarch package so we cannot have architecture-specific dependencies. "Recommends" ignores missing packages so we can ignore that libblockdev-s390 is available only on s390x.