### PR TITLE
tests: Do not set logging when loading gpt_test

### DIFF
--- a/tests/vmtests/gpt_test.py
+++ b/tests/vmtests/gpt_test.py
@@ -14,8 +14,6 @@ from blivet.util import set_up_logging
 
 import parted
 
-set_up_logging()
-
 
 class GPTTestBase(VMBackedTestCase):
 
@@ -33,6 +31,12 @@ class GPTTestBase(VMBackedTestCase):
         self.swap = None
         self.usrluks = None
         self.usr = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        set_up_logging()
 
     def set_up_disks(self):
         disklabel.DiskLabel.set_default_label_type("gpt")


### PR DESCRIPTION
We don't want to set logging when skipping the test case so it cannot be defined on the module level.