### PR TITLE
Modified passphrase in stratis test

### DIFF
--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -230,7 +230,7 @@ class StratisTestCaseClevis(StratisTestCaseBase):
         blivet.partitioning.do_partitioning(self.storage)
 
         pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd],
-                                             encrypted=True, passphrase="abcde",
+                                             encrypted=True, passphrase="fipsneeds8chars",
                                              clevis=StratisClevisConfig(pin="tang",
                                                                         tang_url=self._tang_server,
                                                                         tang_thumbprint=None))


### PR DESCRIPTION
FIPS requires at least 8 chars long passphrase. Dummy passphrase used in stratis test was too short causing encryption
tests with FIPS enabled to fail.

Changed passphrase.

fixes RHEL-45173, RHEL-8029