### PR TITLE
Align sizes up for growable LVs

### DIFF
--- a/blivet/devices/luks.py
+++ b/blivet/devices/luks.py
@@ -86,6 +86,9 @@ class LUKSDevice(DMCryptDevice):
 
     def _set_size(self, newsize):
         if not self.exists and not self.raw_device.exists:
+            log.debug("adjusting size of %s to %s to accommodate LUKS metadata",
+                      self.raw_device.name,
+                      newsize + self.raw_device.format._header_size)
             self.raw_device.size = newsize + self.raw_device.format._header_size
 
             # just run the StorageDevice._set_size to make sure we are in the format limits

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2673,7 +2673,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         if not isinstance(newsize, Size):
             raise AttributeError("new size must be of type Size")
 
-        newsize = self.vg.align(newsize)
+        newsize = self.vg.align(newsize, roundup=self.growable)
         log.debug("trying to set lv %s size to %s", self.name, newsize)
         # Don't refuse to set size if we think there's not enough space in the
         # VG for an existing LV, since it's existence proves there is enough

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -635,11 +635,11 @@ class StorageDevice(Device):
             max_size = self.format.max_size
             min_size = self.format.min_size
             if max_size and newsize > max_size:
-                raise errors.DeviceError("device cannot be larger than %s" %
-                                         max_size, self.name)
+                raise errors.DeviceError("device %s cannot be larger than %s" %
+                                         (self.name, max_size))
             elif min_size and newsize < min_size:
-                raise errors.DeviceError("device cannot be smaller than %s" %
-                                         min_size, self.name)
+                raise errors.DeviceError("device %s cannot be smaller than %s" %
+                                         (self.name, min_size))
 
         self._size = newsize
 


### PR DESCRIPTION
Growable LVs usually start at minimum size so adjusting it down
can change the size below allowed minimum.