### PR TITLE
Align sizes up for growable LVs

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2673,7 +2673,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         if not isinstance(newsize, Size):
             raise AttributeError("new size must be of type Size")
 
-        newsize = self.vg.align(newsize)
+        newsize = self.vg.align(newsize, roundup=self.growable)
         log.debug("trying to set lv %s size to %s", self.name, newsize)
         # Don't refuse to set size if we think there's not enough space in the
         # VG for an existing LV, since it's existence proves there is enough


### PR DESCRIPTION
Growable LVs usually start at minimum size so adjusting it down can change the size below allowed minimum.

Resolves: RHEL-45180