### PR TITLE
Translate vendor id 0x1af4 to Virtio Block Device (#1242117)

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -137,7 +137,11 @@ class DiskDevice(StorageDevice):
 
     @property
     def description(self):
-        return " ".join(s for s in (self.vendor, self.model, self.wwn) if s)
+        # On Virtio block devices the vendor is 0x1af4, make it more friendly
+        if self.vendor == "0x1af4":
+            return "Virtio Block Device"
+        else:
+            return " ".join(s for s in (self.vendor, self.model, self.wwn) if s)
 
     def _pre_destroy(self):
         """ Destroy the device. """


### PR DESCRIPTION
The vendor information used to come from parted which reports virtio blk devices as 'Virtio Block Device'. The sysfs vendor entry has always been 0x1af4 which isn't very descriptive. So in disk.description check for the exception and return "Virtio Block Device". disk.vendor is left as-is, only the user friendly description is modified.

Resolves: rhbz#1242117