### PR TITLE
Fix running tests in FIPS mode 

### DIFF
--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -105,7 +105,7 @@ class StratisTestCase(StratisTestCaseBase):
         blivet.partitioning.do_partitioning(self.storage)
 
         pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd],
-                                             encrypted=True, passphrase="abcde")
+                                             encrypted=True, passphrase="fipsneeds8chars")
         self.storage.create_device(pool)
 
         self.storage.do_it()
@@ -260,7 +260,7 @@ class StratisTestCaseClevis(StratisTestCaseBase):
         blivet.partitioning.do_partitioning(self.storage)
 
         pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd],
-                                             encrypted=True, passphrase="abcde",
+                                             encrypted=True, passphrase="fipsneeds8chars",
                                              clevis=StratisClevisConfig(pin="tpm2"))
         self.storage.create_device(pool)
 


### PR DESCRIPTION
Follow up for 68708e347ef7b2f98312c76aa80366091dd4aade, two more places where the passphrase is too short for FIPS mode.

Resolves: RHEL-8029