### PR TITLE
Do not crash when libblockdev LVM plugin is not available

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -77,7 +77,7 @@ safe_name_characters = "0-9a-zA-Z._-"
 if hasattr(blockdev.LVMTech, "DEVICES"):
     try:
         blockdev.lvm.is_tech_avail(blockdev.LVMTech.DEVICES, 0)  # pylint: disable=no-member
-    except blockdev.LVMError:
+    except (blockdev.LVMError, blockdev.BlockDevNotImplementedError):
         HAVE_LVMDEVICES = False
     else:
         HAVE_LVMDEVICES = True


### PR DESCRIPTION
The check for LVM devices support is executed on import so we need to catch the BlockDevNotImplementedError exception as well, otherwise blivet will crash even without calling any LVM related code.