### PR TITLE
Get filesystem size from udev database

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -353,17 +353,12 @@ class FS(DeviceFormat):
         if not self.exists:
             return
 
-        self._current_info = None
         self._min_instance_size = Size(0)
         self._resizable = self.__class__._resizable
 
         # try to gather current size info
         self._size = Size(0)
-        try:
-            if self._info.available:
-                self._current_info = self._info.do_task()
-        except FSError as e:
-            log.info("Failed to obtain info for device %s: %s", self.device, e)
+        udev.settle()
         try:
             self._size = self._size_info.do_task()
         except (FSError, NotImplementedError) as e:

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -275,6 +275,16 @@ def device_get_format_version(udev_info):
     return udev_info.get("ID_FS_VERSION")
 
 
+def device_get_format_size(udev_info):
+    """ Report a device's format size as reported by udev. """
+    return udev_info.get("ID_FS_SIZE")
+
+
+def device_get_format_blocksize(udev_info):
+    """ Report a device's format block size as reported by udev. """
+    return udev_info.get("ID_FS_BLOCKSIZE")
+
+
 def device_get_uuid(udev_info):
     """ Get the UUID from the device's format as reported by udev.
 


### PR DESCRIPTION
We can now get filesystem size for all filesystems supported by us directly from udev, no need to run the filesystem specific tools.

Fixes: #1242