### PR TITLE
Use just name as device ID for multipath devices (#2327619)

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -255,6 +255,10 @@ class MultipathDevice(DMDevice):
         self.wwn = wwn or None
 
     @property
+    def device_id(self):
+        return self.name
+
+    @property
     def model(self):
         if not self.parents:
             return ""


### PR DESCRIPTION
Anaconda relies on disks using name as device ID because it needs to be able to process the disks from kickstart without using blivet. For this use case multipath devices are basically disks so we should just use name here as well.