### PR TITLE
Use name as device ID for BIOS RAID arrays (#2335009)

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -794,6 +794,10 @@ class MDBiosRaidArrayDevice(MDRaidArrayDevice):
         return self._size
 
     @property
+    def device_id(self):
+        return self.name
+
+    @property
     def description(self):
         levelstr = self.level.nick if self.level.nick else self.level.name
         return "BIOS RAID set (%s)" % levelstr


### PR DESCRIPTION
These are treated as disks so we should use just the name, the same way we do for disks. The names of the BIOS arrays are unique enought to hopefuly not cause any issues.