### PR TITLE
ci: Change branch for Anaconda tests from 'master' to 'main'

### DIFF
--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      TARGET_BRANCH: 'master'
+      TARGET_BRANCH: 'main'
 
     steps:
       - name: Clone Anaconda repository
@@ -34,7 +34,7 @@ jobs:
         run: |
           # Run anaconda-ci container with blivet and anaconda attached.
           # Steps in the container:
-          # - Download anaconda-ci:master container (Rawhide)
+          # - Download anaconda-ci:main container (Rawhide)
           # - Remove already existing blivet RPM in the container.
           # - Install dependencies for blivet.
           # - Install blivet to the container.

--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -41,7 +41,7 @@ jobs:
           # - Run Anaconda tests.
           podman run -i --rm -v ./blivet:/blivet:z -v ./anaconda:/anaconda:z quay.io/rhinstaller/anaconda-ci:$TARGET_BRANCH sh -c " \
               set -xe; \
-              dnf remove -y python3-blivet; \
+              rpm -e --nodeps python3-blivet blivet-data; \
               dnf install -y python3-blockdev libblockdev-plugins-all python3-bytesize libbytesize python3-pyparted python3-libmount parted libselinux-python3; \
               cd /blivet; \
               python3 ./setup.py install; \


### PR DESCRIPTION
Anaconda renamed their default branch.