### PR TITLE
LVMPV format size

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -534,40 +534,55 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         self._reserved_percent = value
 
-    def _get_pv_usable_space(self, pv):
+    def _get_pv_metadata_space(self, pv):
+        """ Returns how much space will be used by VG metadata in given PV
+            This depends on type of the PV, PE size and PE start.
+        """
         if isinstance(pv, MDRaidArrayDevice):
-            return self.align(pv.size - 2 * pv.format.pe_start)
+            return 2 * pv.format.pe_start
         else:
-            return self.align(pv.size - pv.format.pe_start)
+            return pv.format.pe_start
+
+    def _get_pv_usable_space(self, pv):
+        """ Return how much space can be actually used on given PV.
+            This takes into account:
+             - VG metadata that is/will be stored in this PV
+             - the actual PV format size (which might differ from
+               the underlying block device size)
+        """
+
+        if pv.format.exists and pv.format.size and self.exists:
+            # PV format exists, we got its size and VG also exists
+            # -> all metadata is already accounted in the PV format size
+            return pv.format.size
+        elif pv.format.exists and pv.format.size and not self.exists:
+            # PV format exists, we got its size, but the VG doesn't exist
+            # -> metadata size is not accounted in the PV format size
+            return self.align(pv.format.size - self._get_pv_metadata_space(pv))
+        else:
+            # something else -> either the PV format is not yet created or
+            # we for some reason failed to get size of the format, either way
+            # lets use the underlying block device size and calculate the
+            # metadata size ourselves
+            return self.align(pv.size - self._get_pv_metadata_space(pv))
 
     @property
     def lvm_metadata_space(self):
-        """ The amount of the space LVM metadata cost us in this VG's PVs """
-        # NOTE: we either specify data alignment in a PV or the default is used
-        #       which is both handled by pv.format.pe_start, but LVM takes into
-        #       account also the underlying block device which means that e.g.
-        #       for an MD RAID device, it tries to align everything also to chunk
-        #       size and alignment offset of such device which may result in up
-        #       to a twice as big non-data area
-        # TODO: move this to either LVMPhysicalVolume's pe_start property once
-        #       formats know about their devices or to a new LVMPhysicalVolumeDevice
-        #       class once it exists
-        diff = Size(0)
-        for pv in self.pvs:
-            diff += pv.size - self._get_pv_usable_space(pv)
-
-        return diff
+        """ The amount of the space LVM metadata cost us in this VG's PVs
+            Note: we either specify data alignment in a PV or the default is used
+                  which is both handled by pv.format.pe_start, but LVM takes into
+                  account also the underlying block device which means that e.g.
+                  for an MD RAID device, it tries to align everything also to chunk
+                  size and alignment offset of such device which may result in up
+                  to a twice as big non-data area
+        """
+        return sum(self._get_pv_metadata_space(pv) for pv in self.pvs)
 
     @property
     def size(self):
         """ The size of this VG """
         # TODO: just ask lvm if isModified returns False
-
-        # sum up the sizes of the PVs, subtract the unusable (meta data) space
-        size = sum(pv.size for pv in self.pvs)
-        size -= self.lvm_metadata_space
-
-        return size
+        return sum(self._get_pv_usable_space(pv) for pv in self.pvs)
 
     @property
     def extents(self):

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -102,6 +102,8 @@ class LVMPhysicalVolume(DeviceFormat):
         # when set to True, blivet will try to resize the PV to fill all available space
         self._grow_to_fill = False
 
+        self._target_size = self._size
+
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
         s += ("  vg_name = %(vg_name)s  vg_uuid = %(vg_uuid)s"

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -120,6 +120,8 @@ class LVMFormatPopulator(FormatPopulator):
                 log.warning("PV %s has no pe_start", name)
             if pv_info.pv_free:
                 kwargs["free"] = Size(pv_info.pv_free)
+            if pv_info.pv_size:
+                kwargs["size"] = Size(pv_info.pv_size)
 
         return kwargs
 

--- a/blivet/tasks/pvtask.py
+++ b/blivet/tasks/pvtask.py
@@ -27,6 +27,7 @@ from gi.repository import BlockDev as blockdev
 
 from ..errors import PhysicalVolumeError
 from ..size import Size, B
+from ..static_data import pvs_info
 
 from . import availability
 from . import task
@@ -55,13 +56,12 @@ class PVSize(task.BasicApplication):
             :raises :class:`~.errors.PhysicalVolumeError`: if size cannot be obtained
         """
 
-        try:
-            pv_info = blockdev.lvm.pvinfo(self.pv.device)
-            pv_size = pv_info.pv_size
-        except blockdev.LVMError as e:
-            raise PhysicalVolumeError(e)
+        pvs_info.drop_cache()
+        pv_info = pvs_info.cache.get(self.pv.device)
+        if pv_info is None:
+            raise PhysicalVolumeError("Failed to get PV info for %s" % self.pv.device)
 
-        return Size(pv_size)
+        return Size(pv_info.pv_size)
 
 
 class PVResize(task.BasicApplication, dfresize.DFResizeTask):

--- a/tests/storage_tests/devices_test/lvm_test.py
+++ b/tests/storage_tests/devices_test/lvm_test.py
@@ -531,3 +531,53 @@ class LVMTestCase(StorageTestCase):
         self.assertIsNotNone(vg)
         self.assertEqual(len(vg.pvs), 1)
         self.assertEqual(vg.pvs[0].name, pv2.name)
+
+    def test_lvm_pv_size(self):
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.storage.initialize_disk(disk)
+
+        pv = self.storage.new_partition(size=blivet.size.Size("100 MiB"), fmt_type="lvmpv",
+                                        parents=[disk])
+        self.storage.create_device(pv)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        pv = self.storage.devicetree.get_device_by_name(pv.name)
+        self.assertIsNotNone(pv)
+
+        pv.format.update_size_info()
+        self.assertTrue(pv.format.resizable)
+
+        ac = blivet.deviceaction.ActionResizeFormat(pv, blivet.size.Size("50 MiB"))
+        self.storage.devicetree.actions.add(ac)
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        pv = self.storage.devicetree.get_device_by_name(pv.name)
+        self.assertIsNotNone(pv)
+        self.assertEqual(pv.format.size, blivet.size.Size("50 MiB"))
+        pv_size = self._get_pv_size(pv.path)
+        self.assertEqual(pv_size, pv.format.size)
+
+        vg = self.storage.new_vg(name=self.vgname, parents=[pv])
+        self.storage.create_device(vg)
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        pv = self.storage.devicetree.get_device_by_name(pv.name)
+        self.assertIsNotNone(pv)
+        pv_size = self._get_pv_size(pv.path)
+        self.assertEqual(pv_size, pv.format.size)
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)

--- a/tests/storage_tests/devices_test/lvm_test.py
+++ b/tests/storage_tests/devices_test/lvm_test.py
@@ -28,6 +28,18 @@ class LVMTestCase(StorageTestCase):
             self.assertIsNone(disk.format.type)
             self.assertFalse(disk.children)
 
+    def _get_pv_size(self, pv):
+        out = subprocess.check_output(["pvs", "-o", "pv_size", "--noheadings", "--nosuffix", "--units=b", pv])
+        return blivet.size.Size(out.decode().strip())
+
+    def _get_vg_size(self, vg):
+        out = subprocess.check_output(["vgs", "-o", "vg_size", "--noheadings", "--nosuffix", "--units=b", vg])
+        return blivet.size.Size(out.decode().strip())
+
+    def _get_vg_free(self, vg):
+        out = subprocess.check_output(["vgs", "-o", "vg_free", "--noheadings", "--nosuffix", "--units=b", vg])
+        return blivet.size.Size(out.decode().strip())
+
     def _clean_up(self):
         self.storage.reset()
         for disk in self.storage.disks:
@@ -77,6 +89,8 @@ class LVMTestCase(StorageTestCase):
         self.assertIsInstance(pv, blivet.devices.PartitionDevice)
         self.assertIsNotNone(pv.format)
         self.assertEqual(pv.format.type, "lvmpv")
+        pv_size = self._get_pv_size(pv.path)
+        self.assertEqual(pv.format.size, pv_size)
 
         vg = self.storage.devicetree.get_device_by_name(self.vgname)
         self.assertIsNotNone(vg)
@@ -87,6 +101,10 @@ class LVMTestCase(StorageTestCase):
         self.assertEqual(pv.format.vg_uuid, vg.uuid)
         self.assertEqual(len(vg.parents), 1)
         self.assertEqual(vg.parents[0], pv)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
 
         lv = self.storage.devicetree.get_device_by_name("%s-blivetTestLV" % self.vgname)
         self.assertIsNotNone(lv)
@@ -139,6 +157,13 @@ class LVMTestCase(StorageTestCase):
         self.storage.do_it()
         self.storage.reset()
 
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
+
         pool = self.storage.devicetree.get_device_by_name("%s-blivetTestPool" % self.vgname)
         self.assertIsNotNone(pool)
         self.assertTrue(pool.is_thin_pool)
@@ -184,6 +209,14 @@ class LVMTestCase(StorageTestCase):
 
         self.storage.do_it()
         self.storage.reset()
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space + vg.reserved_space)
 
         raidlv = self.storage.devicetree.get_device_by_name("%s-blivetTestRAIDLV" % self.vgname)
         self.assertIsNotNone(raidlv)
@@ -241,6 +274,13 @@ class LVMTestCase(StorageTestCase):
         self.storage.do_it()
         self.storage.reset()
 
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
+
         cachedlv = self.storage.devicetree.get_device_by_name("%s-blivetTestCachedLV" % self.vgname)
         self.assertIsNotNone(cachedlv)
         self.assertTrue(cachedlv.cached)
@@ -279,6 +319,13 @@ class LVMTestCase(StorageTestCase):
 
         self.storage.do_it()
         self.storage.reset()
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
 
         cachedlv = self.storage.devicetree.get_device_by_name("%s-blivetTestCachedLV" % self.vgname)
         self.assertIsNotNone(cachedlv)
@@ -334,6 +381,13 @@ class LVMTestCase(StorageTestCase):
         self.storage.do_it()
         self.storage.reset()
 
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
+
         cachedlv = self.storage.devicetree.get_device_by_name("%s-blivetTestCachedLV" % self.vgname)
         self.assertIsNotNone(cachedlv)
 
@@ -348,6 +402,13 @@ class LVMTestCase(StorageTestCase):
 
         self.storage.do_it()
         self.storage.reset()
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
 
         cachedlv = self.storage.devicetree.get_device_by_name("%s-blivetTestCachedLV" % self.vgname)
         self.assertIsNotNone(cachedlv)
@@ -378,6 +439,13 @@ class LVMTestCase(StorageTestCase):
 
         self.storage.do_it()
 
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
+
         # create a second PV
         disk2 = self.storage.devicetree.get_device_by_path(self.vdevs[1])
         self.assertIsNotNone(disk2)
@@ -392,6 +460,17 @@ class LVMTestCase(StorageTestCase):
         self.storage.do_it()
         self.storage.reset()
 
+        pv1 = self.storage.devicetree.get_device_by_name(pv1.name)
+        pv1_size = self._get_pv_size(pv1.path)
+        self.assertEqual(pv1.format.size, pv1_size)
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
+
         # add the PV to the existing VG
         vg = self.storage.devicetree.get_device_by_name(self.vgname)
         pv2 = self.storage.devicetree.get_device_by_name(pv2.name)
@@ -399,6 +478,17 @@ class LVMTestCase(StorageTestCase):
         ac = blivet.deviceaction.ActionAddMember(vg, pv2)
         self.storage.devicetree.actions.add(ac)
         self.storage.do_it()
+
+        pv2 = self.storage.devicetree.get_device_by_name(pv2.name)
+        pv2_size = self._get_pv_size(pv2.path)
+        self.assertEqual(pv2.format.size, pv2_size)
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
 
         self.assertEqual(pv2.format.vg_name, vg.name)
 
@@ -420,6 +510,17 @@ class LVMTestCase(StorageTestCase):
         self.storage.devicetree.actions.add(ac)
 
         self.storage.do_it()
+
+        pv2 = self.storage.devicetree.get_device_by_name(pv2.name)
+        pv2_size = self._get_pv_size(pv2.path)
+        self.assertEqual(pv2.format.size, pv2_size)
+
+        vg = self.storage.devicetree.get_device_by_name(self.vgname)
+        self.assertIsNotNone(vg)
+        vg_size = self._get_vg_size(vg.name)
+        self.assertEqual(vg_size, vg.size)
+        vg_free = self._get_vg_free(vg.name)
+        self.assertEqual(vg_free, vg.free_space)
 
         self.assertIsNone(pv1.format.type)
 

--- a/tests/unit_tests/populator_test.py
+++ b/tests/unit_tests/populator_test.py
@@ -1055,6 +1055,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         pv_info.vg_uuid = sentinel.vg_uuid
         pv_info.pe_start = 0
         pv_info.pv_free = 0
+        pv_info.pv_size = "10g"
 
         vg_device = Mock()
         vg_device.id = 0
@@ -1086,6 +1087,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
         pv_info.vg_extent_count = 2500
         pv_info.vg_free_count = 0
         pv_info.vg_pv_count = 1
+        pv_info.pv_size = "10g"
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:
             mock_pvs_cache.return_value = {device.path: pv_info}


### PR DESCRIPTION
This makes the LVM code to check the actual LVM PV format size instead of assuming it's always the same size as the underlying block device.

Fixes: #1320 