### PR TITLE
Revert "Remove support for the MD linear RAID level"

### DIFF
--- a/blivet/devicelibs/mdraid.py
+++ b/blivet/devicelibs/mdraid.py
@@ -45,6 +45,6 @@ class MDRaidLevels(raid.RAIDLevels):
             hasattr(level, 'get_size')
 
 
-raid_levels = MDRaidLevels(["raid0", "raid1", "raid4", "raid5", "raid6", "raid10"])
+raid_levels = MDRaidLevels(["raid0", "raid1", "raid4", "raid5", "raid6", "raid10", "linear"])
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_MDRAID_PLUGIN]


### PR DESCRIPTION
This reverts commit a21c4fa61f75f6c900f152651308ac9b457a62da.

The removal of the kernel module was reverted and apparently a lot of people use it.