### PR TITLE
Allow using multiple "contexts" for LUKS

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -106,6 +106,17 @@ class KeyslotContextList(object):
         else:
             return self.__contexts
 
+    def clear_contexts(self, ctype=None):
+        """ Remove ALL keyslot contexts of given type (or any type) from this list
+        """
+        if ctype is None:
+            self.__contexts = []
+        else:
+            for cxt in self.__contexts[:]:
+                if cxt.ctype == ctype:
+                    self.__contexts.remove(cxt)
+            self.__sort()
+
     def add_passphrase(self, passphrase, priority=1):
         """ Add a passphrase keyslot context to this list
         """

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -56,6 +56,126 @@ DEFAULT_INTEGRITY_ALGORITHM = "crc32c"
 MAX_JOURNAL_SIZE = 131072 * SECTOR_SIZE
 
 
+class KeyslotContextList(object):
+
+    def __init__(self):
+        self.__contexts = []
+
+    def __len__(self):
+        return len(self.__contexts)
+
+    def __sort(self):
+        """ Sort contexts based on priority """
+        self.__contexts.sort(key=lambda cxt: cxt.priority, reverse=True)
+
+    @property
+    def valid(self):
+        """ Is at least one of the contexts set valid (non-empty passphrase, existing key file...)
+        """
+        if not self.__contexts:
+            return False
+        return any(cxt.valid for cxt in self.__contexts)
+
+    def get_context(self, ctype=None):
+        """ Get highest priority context with given type (or any type)
+            from this list
+        """
+        if not self.__contexts:
+            return None
+
+        if ctype:
+            contexts = [cxt for cxt in self.__contexts if cxt.ctype == ctype]
+            if not contexts:
+                return None
+            return contexts[0]
+        else:
+            return self.__contexts[0]
+
+    def get_contexts(self, ctype=None):
+        """ Get highest priority contexts of all contexts with given type (or any type)
+            from this list
+        """
+        if not self.__contexts:
+            return None
+
+        if ctype:
+            contexts = [cxt for cxt in self.__contexts if cxt.ctype == ctype]
+            if not contexts:
+                return None
+            return contexts
+        else:
+            return self.__contexts
+
+    def add_passphrase(self, passphrase, priority=1):
+        """ Add a passphrase keyslot context to this list
+        """
+        context = KeyslotContext(passphrase=passphrase, priority=priority)
+        self.__contexts.append(context)
+        self.__sort()
+
+    def remove_passphrase(self, passphrase):
+        """ Remove ALL keylost contexts with given passphrase from this list
+        """
+        for cxt in self.__contexts[:]:
+            if cxt.is_passphrase and cxt._passphrase == passphrase:
+                self.__contexts.remove(cxt)
+        self.__sort()
+
+    def add_keyfile(self, keyfile, priority=0):
+        """ Add a passphrase keyfile context to this list
+        """
+        context = KeyslotContext(keyfile=keyfile, priority=priority)
+        self.__contexts.append(context)
+        self.__sort()
+
+    def remove_keyfile(self, keyfile):
+        """ Remove ALL keylost contexts with given keyfile from this list
+        """
+        for cxt in self.__contexts[:]:
+            if cxt.is_keyfile and cxt._keyfile == keyfile:
+                self.__contexts.remove(cxt)
+        self.__sort()
+
+
+class KeyslotContext(object):
+    ctype = None
+    _context = None
+
+    def __init__(self, passphrase=None, keyfile=None, priority=0):
+        self.priority = priority
+        self._key_file = None
+        self._passphrase = None
+
+        if passphrase:
+            self.ctype = "passphrase"
+            self._passphrase = passphrase
+            self._context = BlockDev.CryptoKeyslotContext(passphrase=passphrase)
+            if not self.priority:
+                # set higher priority for passphrase
+                self.priority = 1
+        elif keyfile:
+            self.ctype = "keyfile"
+            self._key_file = keyfile
+            self._context = BlockDev.CryptoKeyslotContext(keyfile=keyfile)
+        else:
+            raise ValueError("At least one 'passphrase' and 'keyfile' must be specified")
+
+    @property
+    def valid(self):
+        if self.is_passphrase:
+            return True
+        if self.is_keyfile:
+            return os.access(self._key_file, os.R_OK)
+
+    @property
+    def is_passphrase(self):
+        return self.ctype == "passphrase"
+
+    @property
+    def is_keyfile(self):
+        return self.ctype == "keyfile"
+
+
 def calculate_luks2_max_memory():
     """ Calculates maximum RAM that will be used during LUKS format.
         The calculation is based on currently available (free) memory.

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -147,6 +147,21 @@ class KeyslotContextList(object):
                 self.__contexts.remove(cxt)
         self.__sort()
 
+    def add_context(self, context):
+        """ Add given context to this list
+        """
+        self.__contexts.append(context)
+        self.__sort()
+
+    def remove_context(self, context):
+        """ Remove ALL keyslot contexts matching the given context (e.g. same passphrase or key file)
+            from this list
+        """
+        if context.is_passphrase:
+            return self.remove_passphrase(context._passphrase)
+        elif context.is_keyfile:
+            return self.remove_keyfile(context._key_file)
+
 
 class KeyslotContext(object):
     ctype = None

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -231,7 +231,12 @@ class LUKS(DeviceFormat):
 
     def _set_passphrase(self, passphrase):
         """ Set the passphrase used to access this device. """
-        self.contexts.add_passphrase(passphrase=passphrase, priority=100)
+        if not passphrase:
+            # fallback to keep this API backward compatible --> setting passphrase
+            # to "None" will remove ALL passphrase contexts
+            self.contexts.clear_contexts(ctype="passphrase")
+        else:
+            self.contexts.add_passphrase(passphrase=passphrase, priority=100)
 
     passphrase = property(fset=_set_passphrase)
 
@@ -468,7 +473,12 @@ class LUKS(DeviceFormat):
 
     @key_file.setter
     def key_file(self, keyfile):
-        self.contexts.add_keyfile(keyfile=keyfile, priority=50)
+        if not keyfile:
+            # fallback to keep this API backward compatible --> setting keyfile
+            # to "None" will remove ALL keyfile contexts
+            self.contexts.clear_contexts(ctype="keyfile")
+        else:
+            self.contexts.add_keyfile(keyfile=keyfile, priority=50)
 
     def add_passphrase(self, passphrase):
         """ Add a new passphrase.

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -112,6 +112,21 @@ class LUKS(DeviceFormat):
                 attribute be set before the :meth:`create` method runs. Note
                 that you can specify the device at the last moment by specifying
                 it via the 'device' kwarg to the :meth:`create` method.
+
+            .. note::
+
+                Setting passphrase and key file kwargs is considered deprecated, the new
+                API to set "keyslot contexts" should be used instead: see the `contexts`
+                property and the `crypto.KeyslotContextList` class.
+                This new API allows setting multiple passphrases and or key files for the
+                LUKS device and will allow using more types of LUKS key slots (kernel keyring,
+                TPM, FIDO etc.) in the future. Setting multiple contexts for a non-existing LUKS
+                format means all the specified passphrases and key files will be used when
+                creating the format: specifying two passphrase contexts and one key file context
+                will mean the new LUKS format will be created with three key slots.
+                For existing LUKS devices if you set multiple contexts, only the highest priority
+                context (by default the first passphrase context) will be used when activating the
+                LUKS device.
         """
         log_method_call(self, **kwargs)
         DeviceFormat.__init__(self, **kwargs)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -160,7 +160,7 @@ class LUKS(DeviceFormat):
                 # default to the max (512 bits) for xts
                 self.key_size = 512
 
-        self.contexts = crypto.KeyslotContextList()
+        self._contexts = crypto.KeyslotContextList()
 
         passphrase = kwargs.get("passphrase", None)
         if passphrase:
@@ -243,6 +243,14 @@ class LUKS(DeviceFormat):
         else:
             name = "%s (%s)" % (_(self._locked_name), _(self._name))
         return name
+
+    @property
+    def contexts(self):
+        """ Passphrases and key files set for this LUKS format. For non-existing LUKS formats
+            these will be added as key slots when creating the format, for existing LUKS formats
+            at least one context needs to be set to be able to activate the format.
+        """
+        return self._contexts
 
     def _set_passphrase(self, passphrase):
         """ Set the passphrase used to access this device. """

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -87,10 +87,8 @@ class LUKSResize(task.BasicApplication, dfresize.DFResizeTask):
         """ Resizes the LUKS format. """
         try:
             if self.luks.luks_version == "luks2":
-                if self.luks._LUKS__passphrase:
-                    context = blockdev.CryptoKeyslotContext(passphrase=self.luks._LUKS__passphrase)
-                elif self.luks._key_file:
-                    context = blockdev.CryptoKeyslotContext(keyfile=self.luks._key_file)
+                if self.luks.contexts:
+                    context = self.luks.contexts.get_context()._context
                 else:
                     # context for resize can be NULL -- this means the key is already in the keyring
                     context = None

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -84,8 +84,8 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.fmt.teardown()
 
         # remove the original passphrase
-        self.fmt.passphrase = "password"
-        self.fmt.remove_passphrase()
+        self.fmt.remove_passphrase("password")
+        self.fmt.passphrase = None
 
         # now setup should fail
         with self.assertRaises(LUKSError):

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -134,6 +134,108 @@ class LUKSTestCaseLUKS2(LUKSTestCase):
 del LUKSTestCase
 
 
+class LUKSContextTestCase(loopbackedtestcase.LoopBackedTestCase):
+
+    def __init__(self, methodName='run_test'):
+        super(LUKSContextTestCase, self).__init__(methodName=methodName, device_spec=[Size("100 MiB")])
+
+    def setUp(self):
+        super().setUp()
+        self.fmt = LUKS()
+        self.fmt.device = self.loop_devices[0]
+
+    def _clean_up(self):
+        self.fmt.teardown()
+        super()._clean_up()
+
+    def test_passphrase_context(self):
+        self.assertFalse(self.fmt.has_key)
+
+        self.fmt.contexts.add_passphrase("passphrase")
+        self.assertTrue(self.fmt.has_key)
+
+        self.fmt.create()
+        self.fmt.setup()
+
+    def test_keyfile_context(self):
+        self.assertFalse(self.fmt.has_key)
+
+        self.fmt.contexts.add_keyfile("/non/existing")
+        self.assertFalse(self.fmt.has_key)
+
+        self.fmt.contexts.clear_contexts()
+
+        with tempfile.NamedTemporaryFile(prefix="blivet_test") as temp:
+            temp.write(b"password2")
+            temp.flush()
+
+            # create the luks format with both passphrase and keyfile
+            self.fmt.contexts.add_keyfile(temp.name)
+            self.assertTrue(self.fmt.has_key)
+            self.fmt.create()
+
+            self.fmt.setup()
+            self.fmt.teardown()
+
+    def test_multiple_contexts(self):
+        self.fmt.contexts.add_passphrase("passphrase")
+        self.fmt.contexts.add_passphrase("passphrase1")
+
+        with tempfile.NamedTemporaryFile(prefix="blivet_test") as temp:
+            temp.write(b"password2")
+            temp.flush()
+
+            # create the luks format with both passphrase and keyfile
+            self.fmt.contexts.add_keyfile(temp.name)
+            self.fmt.create()
+
+            # we should now have three key slots, lets test one by one
+            self.fmt.contexts.clear_contexts()
+
+            # first passphrase
+            self.fmt.contexts.clear_contexts()
+            self.fmt.contexts.add_passphrase("passphrase")
+            self.fmt.setup()
+            self.fmt.teardown()
+
+            # second passphrase
+            self.fmt.contexts.clear_contexts()
+            self.fmt.contexts.add_passphrase("passphrase1")
+            self.fmt.setup()
+            self.fmt.teardown()
+
+            # keyfile
+            self.fmt.contexts.clear_contexts()
+            self.fmt.contexts.add_keyfile(temp.name)
+            self.fmt.setup()
+            self.fmt.teardown()
+
+    def test_add_remove_context(self):
+        self.fmt.contexts.add_passphrase("passphrase")
+        self.fmt.create()
+
+        # add new passphrase and test it
+        self.fmt.add_key(crypto.KeyslotContext(passphrase="passphrase1"))
+        self.fmt.contexts.clear_contexts()
+        self.fmt.contexts.add_passphrase("passphrase1")
+        self.fmt.setup()
+        self.fmt.teardown()
+
+        # remove the passphrase and test that the old one can still be used
+        self.fmt.remove_key(crypto.KeyslotContext(passphrase="passphrase1"))
+        self.fmt.contexts.clear_contexts()
+        self.fmt.contexts.add_passphrase("passphrase1")
+
+        # removed passphrase should no longer be usable
+        with self.assertRaises(LUKSError):
+            self.fmt.setup()
+
+        self.fmt.contexts.clear_contexts()
+        self.fmt.contexts.add_passphrase("passphrase")
+        self.fmt.setup()
+        self.fmt.teardown()
+
+
 @unittest.skipUnless(Integrity._plugin.available, "Integrity support not available")
 class IntegrityTestCase(loopbackedtestcase.LoopBackedTestCase):
 

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -104,16 +104,16 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
             temp.flush()
 
             # create the luks format with both passphrase and keyfile
-            self.fmt._key_file = temp.name
+            self.fmt.key_file = temp.name
             self.fmt.create()
 
             # open first with just password
-            self.fmt._key_file = None
+            self.fmt.key_file = None
             self.fmt.setup()
             self.fmt.teardown()
 
             # now with keyfile
-            self.fmt._key_file = temp.name
+            self.fmt.key_file = temp.name
             self.fmt.passphrase = None
             self.fmt.setup()
             self.fmt.teardown()


### PR DESCRIPTION
Currently only one passphrase and one key file can be specified when creating new LUKS, this change allows specifying multiple different "contexts" for when creating a new or unlocking an existing LUKS device. For now only passphrase and key file contexts are supported, but this change will also allow adding support for new types of contexts (kernel keyring, TPM etc.) in the future.

The change is made to be backwards compatible so "passphrase" can still be specified for the LUKS format, it will just internally create a new passphrase context so no changes are needed for existing code.