### PR TITLE
Do not remove PVs from devices file if disabled or doesn't exists

### DIFF
--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -166,6 +166,11 @@ class LVMPhysicalVolume(DeviceFormat):
         if not lvm.HAVE_LVMDEVICES:
             raise PhysicalVolumeError("LVM devices file feature is not supported")
 
+        if not os.path.exists(lvm.LVM_DEVICES_FILE):
+            log.debug("Not removing %s from devices file: %s doesn't exist",
+                      self.device, lvm.LVM_DEVICES_FILE)
+            return
+
         try:
             blockdev.lvm.devices_delete(self.device)
         except blockdev.LVMError as e:

--- a/tests/unit_tests/formats_tests/lvmpv_test.py
+++ b/tests/unit_tests/formats_tests/lvmpv_test.py
@@ -41,6 +41,11 @@ class LVMPVNodevTestCase(unittest.TestCase):
 
             mock["blockdev"].lvm.devices_add.assert_not_called()
 
+            # LVM devices file not enabled/supported -> devices_delete should not be called
+            fmt._destroy()
+
+            mock["blockdev"].lvm.devices_delete.assert_not_called()
+
         with self.patches() as mock:
             # LVM devices file enabled and devices file exists -> devices_add should be called
             mock["lvm"].HAVE_LVMDEVICES = True
@@ -49,6 +54,11 @@ class LVMPVNodevTestCase(unittest.TestCase):
             fmt._create()
 
             mock["blockdev"].lvm.devices_add.assert_called_with("/dev/test")
+
+            # LVM devices file enabled and devices file exists -> devices_delete should be called
+            fmt._destroy()
+
+            mock["blockdev"].lvm.devices_delete.assert_called_with("/dev/test")
 
         with self.patches() as mock:
             # LVM devices file enabled and devices file doesn't exist
@@ -61,6 +71,12 @@ class LVMPVNodevTestCase(unittest.TestCase):
 
             mock["blockdev"].lvm.devices_add.assert_called_with("/dev/test")
 
+            # LVM devices file enabled but devices file doesn't exist
+            # -> devices_delete should not be called
+            fmt._destroy()
+
+            mock["blockdev"].lvm.devices_delete.assert_not_called()
+
         with self.patches() as mock:
             # LVM devices file enabled and devices file doesn't exist
             # and existing VGs present -> devices_add should not be called
@@ -71,3 +87,9 @@ class LVMPVNodevTestCase(unittest.TestCase):
             fmt._create()
 
             mock["blockdev"].lvm.devices_add.assert_not_called()
+
+            # LVM devices file enabled but devices file doesn't exist
+            # -> devices_delete should not be called
+            fmt._destroy()
+
+            mock["blockdev"].lvm.devices_delete.assert_not_called()


### PR DESCRIPTION
When the file doesn't exists the 'lvmdevices --deldev' call will fail but it will still create the devices file. This means we now have an empty devices file and all subsequent LVM calls will fail.

Resolves: RHEL-84662