### PR TITLE
Make FS temporary mounts read-only

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -583,9 +583,13 @@ class FS(DeviceFormat):
 
         else:
             tmpdir = tempfile.mkdtemp(prefix="blivet-tmp.%s" % os.path.basename(self.device))
+            if self.mountopts and "ro" not in self.mountopts:
+                options = self.mountopts + ",ro"
+            else:
+                options = "ro"
             try:
                 util.mount(device=self.device, mountpoint=tmpdir, fstype=self.type,
-                           options=self.mountopts)
+                           options=options)
             except FSError as e:
                 log.debug("temp mount failed: %s", e)
                 raise


### PR DESCRIPTION
These temporary mount operations are to gather information about the filesystem, we don't need read-write mount for these so lets be a bit safer and do a read-only mount.