### PR TITLE
Fix handling devices with "no" parents in udev

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -513,7 +513,11 @@ def device_get_parents(info):
 
     parents = list()
     for name in names:
-        parents.append(get_device(device_node="/dev/" + name))
+        parent = get_device(device_node="/dev/" + name)
+        if not parent:
+            log.warning("Failed to get udev info for %s, ignoring", name)
+        else:
+            parents.append(parent)
 
     return parents
 


### PR DESCRIPTION
Another attempt to make blivet.reset() more stable and not crash when encountering broken devices. This is triggered by lingering MD device after removing it's parent devices. The MD device itself will be "broken" and unusable in blivet, but at least the reset/ populate call won't end with an error.