### PR TITLE
Drop parted device cache during reset

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -89,6 +89,9 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         # initialize attributes that may later hold cached lvm info
         self.drop_device_info_cache()
 
+        # drop parted device cache
+        parted.freeAllDevices()
+
         self._cleanup = False
 
     def _add_parent_devices(self, info):


### PR DESCRIPTION
When recreating an MD RAID device with different size outside blivet, during our second device scan the parted device we get from parted reports the size of the original MD array. This causes parted to think the GPT partition table on the device has a wrong size, offers to fix it and destroying it in the process.

Resolves: rhbz#2357214