### PR TITLE
Drop parted device cache during reset v2

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -917,3 +917,8 @@ class StorageDevice(Device):
 
         badchars = any(c in ('\x00', '/') for c in name)
         return not badchars and name != '.' and name != '..'
+
+    def drop_cache(self):
+        """ Drop cached information stored for this device and its format """
+        if self.format:
+            self.format.drop_cache()

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -78,6 +78,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
             :keyword exclusive_disks: exclusive didks
             :type exclusive_disks: list
         """
+        self._devices = []
         self.reset(ignored_disks, exclusive_disks)
 
     def reset(self, ignored_disks=None, exclusive_disks=None):
@@ -88,6 +89,10 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
             :keyword exclusive_disks: exclusive didks
             :type exclusive_disks: list
         """
+        # remove cached data for devices
+        for device in self._devices:
+            device.drop_cache()
+
         # internal data members
         self._devices = []
         self._actions = ActionList(addfunc=self._register_action,

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -735,6 +735,9 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
         data.fstype = self.type
         data.mountpoint = self.ks_mountpoint
 
+    def drop_cache(self):
+        """ Drop cached information stored for this format """
+
 
 register_device_format(DeviceFormat)
 

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -603,5 +603,11 @@ class DiskLabel(DeviceFormat):
         else:
             return 0
 
+    def drop_cache(self):
+        if self._parted_device and os.path.exists(self.device):
+            ped_device = self._parted_device.getPedDevice()
+            if ped_device:
+                ped_device.cache_remove()
+
 
 register_device_format(DiskLabel)


### PR DESCRIPTION
Parted caches information about about devices internally. The cache is based on device name so when recreating a device using the same name but different size (e.g. when removing RAID0 array and creating RAID1 array with the same name) the cached information, including device size, is used by parted. This means that during next reset() call parted will think the device is bigger and tries to fix the partition table on the array breaking it instead.

Resolves: rhbz#2357214