### PR TITLE
Fix resolve_device for non-existing btrfs subvolumes

### DIFF
--- a/tests/storage_tests/fstab_test.py
+++ b/tests/storage_tests/fstab_test.py
@@ -243,6 +243,11 @@ class FstabTestCase(StorageTestCase):
             self.assertIsNotNone(dev)
             self.assertEqual(dev, sub)
 
+            # non-existing subvolume, should not return the volume
+            dev = fstab.find_device(devicetree=self.storage.devicetree, spec="UUID=%s" % vol.uuid,
+                                    mntopts=["subvol=non-existing"])
+            self.assertIsNone(dev)
+
     def test_swap_creation(self):
         # test swap creation for presence of FSTabOptions object
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])

--- a/tests/unit_tests/devicetree_test.py
+++ b/tests/unit_tests/devicetree_test.py
@@ -110,6 +110,13 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertEqual(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=%s" % sub1.name), sub1)
         self.assertEqual(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=%s" % sub2.name), sub2)
 
+        # try to resolve non-existing subvolume (should return None)
+        self.assertIsNone(dt.resolve_device("UUID=%s" % btrfs_uuid, subvolspec="non-existing"))
+        self.assertIsNone(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=non-existing"))
+
+        # resolve with some unrelated options given (no subvol or subvolid)
+        self.assertEqual(dt.resolve_device(vol.name, options="nofail,ro"), vol)
+
     def test_device_name(self):
         # check that devicetree.names property contains all device's names
 


### PR DESCRIPTION
We don't want to return the parent volume when a non-existing subvolume is specified in subvolspec or options.

Fixes: #1134