### PR TITLE
tests: Add udev trigger call after creating MD array for tests

### DIFF
--- a/tests/storage_tests/devices_test/md_test.py
+++ b/tests/storage_tests/devices_test/md_test.py
@@ -290,6 +290,11 @@ class MDDiskTestCase(StorageTestCase):
                                         self.vdevs[0], self.vdevs[1]])
         _ret = blivet.util.run_program(["parted", "--script", "/dev/md/%s" % self.raidname,
                                         "mklabel", "gpt", "mkpart", "primary", "1MiB", "150MiB"])
+
+        # XXX udev races, sometimes we just don't get the `linux_raid_member` format on the disks
+        # in udev after creating the array above
+        _ret = blivet.util.run_program(["udevadm", "trigger", "-s", "block", "--settle"])
+
         with wait_for_resync():
             self.storage.reset()
         self.storage.reset()


### PR DESCRIPTION
When manually creating the array using mdadm sometimes one of the "legs" doesn't have the linux_raid_memeber format set in udev DB.