### PR TITLE
[WIP] ci: Stop skipping RAID tests on RHEL/CentOS 9

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -24,8 +24,3 @@
 
 ---
 
-- test: storage_tests.devices_test.md_test.(MDTestCase|MDLUKSTestCase|MDDiskTestCase)
-  skip_on:
-    - distro: "centos"
-      version: "9"
-      reason: "MD tests are randomly failing on RHEL/CentOS 9"


### PR DESCRIPTION
We did quite a lot of changes to the tests and locally these seem to run fine, so let's try in our CI.