### PR TITLE
Fix expected exception type when activating devices in populor

### DIFF
--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -175,7 +175,7 @@ class LUKSFormatPopulator(FormatPopulator):
                     self.device.format.passphrase = passphrase
                     try:
                         self.device.format.setup()
-                    except blockdev.BlockDevError:
+                    except LUKSError:
                         self.device.format.passphrase = None
                     else:
                         break

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -29,7 +29,7 @@ from ...callbacks import callbacks
 from ... import udev
 from ...devicelibs import lvm
 from ...devices.lvm import LVMVolumeGroupDevice, LVMLogicalVolumeDevice, LVMInternalLVtype
-from ...errors import DeviceTreeError, DuplicateVGError
+from ...errors import DeviceTreeError, DuplicateVGError, LVMError
 from ...flags import flags
 from ...size import Size
 from ...storage_log import log_method_call
@@ -295,7 +295,7 @@ class LVMFormatPopulator(FormatPopulator):
                 if flags.auto_dev_updates:
                     try:
                         lv_device.setup()
-                    except blockdev.LVMError:
+                    except LVMError:
                         log.warning("failed to activate lv %s", lv_device.name)
                         lv_device.controllable = False
 


### PR DESCRIPTION
We are no longer raising libblockdev exceptions in our public API calls (see #1014) so when calling setup() ourselves we need to catch our exceptions instead of libblockdev ones as well.

Resolves: rhbz#2362743