### PR TITLE
Fix getting filesystem size from udev

### DIFF
--- a/blivet/tasks/fssize.py
+++ b/blivet/tasks/fssize.py
@@ -58,11 +58,12 @@ class FSSize(fstask.FSTask, metaclass=abc.ABCMeta):
         if not udev_info:
             raise FSError("Failed to obtain udev information for device %s" % self.fs.device)
 
-        fs_size = udev.device_get_format_size(udev_info)
-        if not fs_size:
+        last_block = udev.device_get_format_lastblock(udev_info)
+        block_size = udev.device_get_format_blocksize(udev_info)
+        if not last_block or not block_size:
             raise FSError("Failed to obtain filesystem size for %s from udev" % self.fs.device)
 
-        return Size(fs_size)
+        return Size(int(last_block) * int(block_size))
 
     def do_task(self):  # pylint: disable=arguments-differ
         """ Returns the size of the filesystem.

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -285,6 +285,11 @@ def device_get_format_size(udev_info):
     return udev_info.get("ID_FS_SIZE")
 
 
+def device_get_format_lastblock(udev_info):
+    """ Report a device's format last block as reported by udev. """
+    return udev_info.get("ID_FS_LASTBLOCK")
+
+
 def device_get_format_blocksize(udev_info):
     """ Report a device's format block size as reported by udev. """
     return udev_info.get("ID_FS_BLOCKSIZE")


### PR DESCRIPTION
We cannot use ID_FS_SIZE, for some filesystems (like XFS) this doesn't include the filesystem metadata.

See also https://github.com/storaged-project/udisks/pull/1115