### PR TITLE
Make ActionDestroyFormat optional when the device is also scheduled to be removed

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -917,7 +917,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         if device.format.exists and device.format.type and \
            not device.format_immutable:
             # schedule destruction of any formatting while we're at it
-            self.devicetree.actions.add(ActionDestroyFormat(device))
+            self.devicetree.actions.add(ActionDestroyFormat(device, optional=True))
 
         action = ActionDestroyDevice(device)
         self.devicetree.actions.add(action)

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -268,7 +268,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                 if actions:
                     if leaf.format.exists and not leaf.protected and \
                        not leaf.format_immutable:
-                        self.actions.add(ActionDestroyFormat(leaf))
+                        self.actions.add(ActionDestroyFormat(leaf, optional=True))
 
                     self.actions.add(ActionDestroyDevice(leaf))
                 else:
@@ -280,7 +280,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
         if not device.format_immutable:
             if actions:
-                self.actions.add(ActionDestroyFormat(device))
+                self.actions.add(ActionDestroyFormat(device, optional=True))
             else:
                 device.format = None
 

--- a/tests/unit_tests/devices_test/lvm_test.py
+++ b/tests/unit_tests/devices_test/lvm_test.py
@@ -1172,3 +1172,32 @@ class BlivetLVMConfigureActionsTest(BlivetLVMUnitTest):
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.b.do_it()
             lvm.vdo_enable_deduplication.assert_called_with(vg.name, vdopool.lvname)
+
+
+@patch("blivet.devices.lvm.LVMLogicalVolumeDevice._external_dependencies", new=[])
+@patch("blivet.devices.lvm.LVMLogicalVolumeBase._external_dependencies", new=[])
+@patch("blivet.devices.dm.DMDevice._external_dependencies", new=[])
+@patch("blivet.devicelibs.lvm.AUTO_ACTIVATION", False)
+class BlivetLVMOptionalDestroyTest(BlivetLVMUnitTest):
+
+    def test_optional_format_destroy(self, *args):  # pylint: disable=unused-argument
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("10 GiB"), exists=True)
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv], exists=True)
+        lv = LVMLogicalVolumeDevice("testlv", parents=[vg], exists=True, size=Size("5 GiB"),
+                                    fmt=blivet.formats.get_format("xfs", exists=True))
+
+        for dev in (pv, vg, lv):
+            self.b.devicetree._add_device(dev)
+
+        self.b.destroy_device(lv)
+        fmt_ac = self.b.devicetree.actions.find(action_type="destroy", object_type="format")
+        self.assertTrue(fmt_ac)
+        self.assertTrue(fmt_ac[0].optional)
+
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            lvm.lvactivate.side_effect = RuntimeError()
+            try:
+                self.b.do_it()
+            except RuntimeError:
+                self.fail("Optional format destroy action is not optional")


### PR DESCRIPTION
We are always trying to wipe format from devices we are going to remove, this causes issues when we for example cannot activate or assemble the device (broken thinpools, missing kernel modules...). In these cases we can ignore the failed format destroy action -- the device is going to be removed anyway so failing to remove the format is not a critical error.