### PR TITLE
Do not try to destroy "None" formats in recursive_remove

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -267,7 +267,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
             for leaf in leaves:
                 if actions:
                     if leaf.format.exists and not leaf.protected and \
-                       not leaf.format_immutable:
+                       not leaf.format_immutable and leaf.format.type:
                         self.actions.add(ActionDestroyFormat(leaf, optional=True))
 
                     self.actions.add(ActionDestroyDevice(leaf))


### PR DESCRIPTION
This just runs wipefs on empty devices needlessly. destroy_device already has the same check to skip adding the format destroy action on devices without formats.