### PR TITLE
Fix getting missing libblockdev technologies with Python 3.14

### DIFF
--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -225,7 +225,7 @@ class BlockDevMethod(Method):
             try:
                 self._tech_info.check_fn(tech, mode)
             except GLib.GError as e:
-                errors.append("%s: %s" % (tech.value_name, e.message))
+                errors.append("%s" % e.message)
         return errors
 
     def availability_errors(self, resource):


### PR DESCRIPTION
Hotfix for rhbz#2371256. Technologies in libblockdev are defined as enums and we are using 'value_name' to get the technology name/ description in blivet. For some unknown reason the 'value_name' attribute from GLib.GEnumValue is not available with Python 3.14. This needs to be investigated more thoroughly, but for now we can just not include this information.

Resolves: rhbz#2371256