### PR TITLE
tests: Skip test_detect_virt on systems without running DBus

### DIFF
--- a/tests/unit_tests/util_test.py
+++ b/tests/unit_tests/util_test.py
@@ -40,6 +40,7 @@ class MiscTest(unittest.TestCase):
         # real deduplication
         self.assertEqual([1, 2, 3, 4, 5, 6], util.dedup_list([1, 2, 3, 4, 2, 2, 2, 1, 3, 5, 3, 6, 6, 2, 3, 1, 5]))
 
+    @unittest.skipIf(not os.path.exists("/run/dbus/system_bus_socket"), "system bus socket does not exist")
     def test_detect_virt(self):
         in_virt = not util.run_program(["systemd-detect-virt", "--vm"])
         self.assertEqual(util.detect_virt(), in_virt)


### PR DESCRIPTION
This will allow to run unit tests in %check during RPM build in Koji.

## Summary by Sourcery

Tests:
- Add a skip condition to test_detect_virt if /run/dbus/system_bus_socket does not exist