### PR TITLE
Shorten the safe_device_name length to 55 characters

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1013,7 +1013,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
     def safe_device_name(self, name, device_type=None):
         """ Convert a device name to something safe and return that.
 
-            LVM limits lv names to 128 characters. I don't know the limits for
+            LVM limits vgname + lvname to 126 characters. I don't know the limits for
             the other various device types, so I'm going to pick a number so
             that we don't have to have an entire library to determine
             device name limits.
@@ -1030,7 +1030,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         else:
             allowed = "0-9a-zA-Z._-"
 
-        max_len = 96    # No, you don't need longer names than this. Really.
+        max_len = 55    # No, you don't need longer names than this. Really.
         tmp = name.strip()
 
         if "/" not in allowed:


### PR DESCRIPTION
Anaconda may use the hostname for the auto-generated vgname. However, since the hostname can exceed 55 characters, which is considered an invalid length by is_lvm_name() [1], we need to ensure that these auto-generated names are properly truncated.

[1] https://github.com/storaged-project/blivet/blob/b070f4cf918d5cb80bb4f84d1963bbdc5fbfbe3c/blivet/devicelibs/lvm.py#L273-L278

Downstream report: https://forums.almalinux.org/t/alma-linux-10-hyper-v-is-not-a-valid-name-for-this-device/6200

## Summary by Sourcery

Shorten the maximum allowed length for safe_device_name to 55 characters to prevent invalid LVM names when using long hostnames.

Bug Fixes:
- Truncate auto-generated VG names based on long hostnames to avoid exceeding LVM’s name length limits.

Enhancements:
- Reduce safe_device_name’s max_len from 96 to 55 to align with is_lvm_name() restrictions.