### PR TITLE
Tell LVM DBus to refresh it's internal status during reset

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -36,6 +36,7 @@ import logging
 log = logging.getLogger("blivet")
 
 from . import raid
+from .. import safe_dbus
 from ..size import Size
 from ..i18n import N_
 from ..flags import flags
@@ -338,3 +339,21 @@ def reenable_lvm_autoactivation(lvmconf=LVM_LOCAL_CONF):
 
     global AUTO_ACTIVATION
     AUTO_ACTIVATION = False
+
+
+def lvm_dbusd_refresh():
+    lvm_soname = blockdev.get_plugin_soname(blockdev.Plugin.LVM)
+    if 'dbus' not in lvm_soname:
+        return
+
+    try:
+        rc = safe_dbus.call_sync("com.redhat.lvmdbus1",
+                                 "/com/redhat/lvmdbus1/Manager",
+                                 "com.redhat.lvmdbus1.Manager",
+                                 "Refresh",
+                                 None)
+    except safe_dbus.DBusCallError as e:
+        log.error("Exception occurred when calling LVM DBusD refresh: %s", str(e))
+    else:
+        if rc[0] != 0:
+            log.error("Failed to call LVM DBusD refresh: %s", rc)

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -470,6 +470,9 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         disklib.update_volume_info()
         self.drop_device_info_cache()
 
+        # force LVM DBusD to refresh its internal state
+        lvm.lvm_dbusd_refresh()
+
         if flags.auto_dev_updates and availability.BLOCKDEV_MPATH_PLUGIN.available:
             try:
                 blockdev.mpath.set_friendly_names(flags.multipath_friendly_names)


### PR DESCRIPTION
Unfortunately some users run wipefs <disk> thinking it's enough to remove all devices on top of the disk cleanly.
In cases where the PV is not directly on the disk, LVM DBus doesn't get a udev event and doesn't remove the VG and LVs from DBus so we think these still exist.

## Summary by Sourcery

Force the LVM DBus daemon to refresh its internal state during device tree reset to ensure stale volume groups and logical volumes are cleared after direct disk operations.

Bug Fixes:
- Invoke the LVM DBus "Refresh" method during reset to remove stale VG/LV entries left by wipefs or missing udev events.

Enhancements:
- Introduce a new lvm_dbusd_refresh helper to call the DBus refresh command and handle errors.
- Integrate the lvm_dbusd_refresh call into the reset workflow in devicetree.py.