### PR TITLE
Tell LVM DBus to refresh it's internal status during reset

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -453,6 +453,9 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         disklib.update_volume_info()
         self.drop_device_info_cache()
 
+        # force LVM DBusD to refresh its internal state
+        lvm.lvm_dbusd_refresh()
+
         if flags.auto_dev_updates and availability.BLOCKDEV_MPATH_PLUGIN.available:
             blockdev.mpath.set_friendly_names(flags.multipath_friendly_names)
 


### PR DESCRIPTION
Unfortunately some users run wipefs <disk> thinking it's enough to remove all devices on top of the disk cleanly.
In cases where the PV is not directly on the disk, LVM DBus doesn't get a udev event and doesn't remove the VG and LVs from DBus so we think these still exist.

Resolves: RHEL-93967