### PR TITLE
Python build process modernization

### DIFF
--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -44,7 +44,7 @@ jobs:
               rpm -e --nodeps python3-blivet blivet-data; \
               dnf install -y python3-blockdev libblockdev-plugins-all python3-bytesize libbytesize python3-pyparted python3-libmount parted libselinux-python3; \
               cd /blivet; \
-              python3 ./setup.py install; \
+              pip install .; \
               cd /anaconda; \
               ./autogen.sh && ./configure; \
               make ci"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -106,6 +106,7 @@ srpm_build_deps:
  - gettext
  - python3-devel
  - python3-setuptools
+ - python3-build
 
 downstream_package_name: python-blivet
 upstream_tag_template: blivet-{version}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,7 @@ Copy the documentation from `doc/_build/html` to a temporary directory, switch t
 Fedora builds are automated using Packit. After tagging a new release Packit will open PRs against all supported versions of Fedora in Pagure. Fedora maintainer will review and merge those PRs, afterwards, Packit will do the builds and Bodhi updates as well.
 
 ## PyPI Build Procedure
-Prepare archive for PyPI: `python3 setup.py sdist bdist_wheel`
 
-Check the archive: `twine check dist/*`
-
-Upload to Test PyPI (optional): `twine upload --repository-url https://test.pypi.org/legacy/ dist/*`
-
-Upload to PyPI: `twine upload dist/*`
+```
+make release-pypi
+```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md COPYING ChangeLog Makefile python-blivet.spec release_notes.rst
 recursive-include po *.mo *.po *.pot Makefile
 recursive-include examples *.py
+recursive-include dbus *

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,20 @@ clean:
 	$(MAKE) -C po clean
 	$(PYTHON) setup.py -q clean --all
 
+install-dbus:
+	install -d $(DESTDIR)/etc/dbus-1/system.d/
+	install -m 644 dbus/blivet.conf $(DESTDIR)/etc/dbus-1/system.d/blivet.conf
+	install -d $(DESTDIR)/usr/share/dbus-1/system-services/
+	install -m 644 dbus/com.redhat.Blivet0.service $(DESTDIR)/usr/share/dbus-1/system-services/com.redhat.Blivet0.service
+	install -d $(DESTDIR)/usr/libexec/
+	install -m 755 dbus/blivetd $(DESTDIR)/usr/libexec/blivetd
+	install -d $(DESTDIR)/usr/lib/systemd/system
+	install -m 644 dbus/blivet.service $(DESTDIR)/usr/lib/systemd/system
+
 install:
 	$(PYTHON) setup.py install --root=$(DESTDIR)
 	$(MAKE) -C po install
+	$(MAKE) install-dbus
 
 ChangeLog:
 	(GIT_DIR=.git git log > .changelog.tmp && mv .changelog.tmp ChangeLog; rm -f .changelog.tmp) || (touch ChangeLog; echo 'git directory not found: installing possibly empty changelog.' >&2)

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ install-dbus:
 	install -m 644 dbus/blivet.service $(DESTDIR)/usr/lib/systemd/system
 
 install:
-	$(PYTHON) setup.py install --root=$(DESTDIR)
+	$(PYTHON) -m pip install . --root=$(DESTDIR)
 	$(MAKE) -C po install
 	$(MAKE) install-dbus
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ install-dbus:
 	install -m 644 dbus/blivet.service $(DESTDIR)/usr/lib/systemd/system
 
 install:
-	$(PYTHON) -m pip install . --root=$(DESTDIR)
+	$(PYTHON) -m pip install . --root=$(DESTDIR) --verbose --no-deps --no-build-isolation
 	$(MAKE) -C po install
 	$(MAKE) install-dbus
 

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ archive: po-pull
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(VERSION_TAG) | tar -xf -
 	cp -r po $(PKGNAME)-$(VERSION)
 	cp ChangeLog $(PKGNAME)-$(VERSION)/
-	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) -m build --sdist --outdir .. )
+	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) -m build --sdist --outdir .. --no-isolation )
 	rm -rf $(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 	@make tests-archive
@@ -153,7 +153,7 @@ tests-archive:
 
 local: po-pull
 	@make -B ChangeLog
-	$(PYTHON) -m build --sdist --outdir .
+	$(PYTHON) -m build --sdist --outdir . --no-isolation
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ HEAD tests/ | gzip -9 > $(PKGNAME)-$(VERSION)-tests.tar.gz
 	@echo "The test archive is in $(PKGNAME)-$(VERSION)-tests.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 PYTHON=python3
-PKG_INSTALL?=dnf
 
 L10N_REPOSITORY=git@github.com:storaged-project/blivet-weblate.git
 L10N_BRANCH=master
@@ -9,13 +8,10 @@ SPECFILE=python-blivet.spec
 VERSION=$(shell $(PYTHON) setup.py --version)
 RPMVERSION=$(shell rpmspec -q --queryformat "%{version}\n" $(SPECFILE) | head -1)
 RPMRELEASE=$(shell rpmspec --undefine '%dist' -q --queryformat "%{release}\n" $(SPECFILE) | head -1)
-RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 RELEASE_TAG=$(PKGNAME)-$(RPMVERSION)-$(RPMRELEASE)
 VERSION_TAG=$(PKGNAME)-$(VERSION)
 
 COVERAGE=$(PYTHON) -m coverage
-
-MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)
 
 all:
 	$(MAKE) -C po
@@ -168,22 +164,6 @@ rpmlog:
 
 bumpver: po-pull
 	( scripts/makebumpver -n $(PKGNAME) -v $(VERSION) -r $(RPMRELEASE) ) || exit 1 ;
-
-scratch:
-	@rm -f ChangeLog
-	@make ChangeLog
-	@rm -rf $(PKGNAME)-$(VERSION).tar.gz
-	@rm -rf /tmp/$(PKGNAME)-$(VERSION) /tmp/$(PKGNAME)
-	@dir=$$PWD; cp -a $$dir /tmp/$(PKGNAME)-$(VERSION)
-	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) setup.py -q sdist
-	@cp /tmp/$(PKGNAME)-$(VERSION)/dist/$(PKGNAME)-$(VERSION).tar.gz .
-	@rm -rf /tmp/$(PKGNAME)-$(VERSION)
-	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
-
-rc-release: scratch-bumpver scratch
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(SPECFILE) --sources . --resultdir $(PWD) || exit 1
-	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD)  || exit 1
 
 srpm: local
 	rpmbuild -bs --nodeps $(SPECFILE) --define "_sourcedir `pwd`"

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ archive: po-pull
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ $(VERSION_TAG) | tar -xf -
 	cp -r po $(PKGNAME)-$(VERSION)
 	cp ChangeLog $(PKGNAME)-$(VERSION)/
-	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) setup.py -q sdist --dist-dir .. --mode release )
+	( cd $(PKGNAME)-$(VERSION) && $(PYTHON) -m build --sdist --outdir .. )
 	rm -rf $(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 	@make tests-archive
@@ -146,7 +146,7 @@ tests-archive:
 
 local: po-pull
 	@make -B ChangeLog
-	$(PYTHON) setup.py -q sdist --dist-dir . --mode normal
+	$(PYTHON) -m build --sdist --outdir .
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 	git archive --format=tar --prefix=$(PKGNAME)-$(VERSION)/ HEAD tests/ | gzip -9 > $(PKGNAME)-$(VERSION)-tests.tar.gz
 	@echo "The test archive is in $(PKGNAME)-$(VERSION)-tests.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,18 @@ rpm: local
 	rpmbuild -bb --nodeps $(SPECFILE) --define "_sourcedir `pwd`"
 	rm -f $(PKGNAME)-$(VERSION).tar.gz $(PKGNAME)-$(VERSION)-tests.tar.gz
 
+release-pypi:
+	if ! $(PYTHON) -m build --sdist --wheel; then \
+		echo ""; \
+		echo Distribution package build failed! Please verify that you have \'python3-build\' and \'python3-setuptools\' installed. >&2; \
+		exit 1; \
+	fi
+	if ! $(PYTHON) -m twine upload dist/*; then \
+		echo ""; \
+		echo Package upload failed! Make sure the \'twine tool\' is installed and you are registered >&2; \
+		exit 1; \
+	fi
+
 ci: check coverage
 
 .PHONY: check clean pylint pep8 install tag archive local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,32 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "blivet"
+version = "3.12.1"
+description = "Python module for system storage configuration"
+readme = "README.md"
+license = {file = "COPYING"}
+dependencies = ["pyudev"]
+maintainers = [
+  {name = "Vojtech Trefny", email = "vtrefny@redhat.com"}
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+  "Operating System :: POSIX :: Linux",
+  "Topic :: System :: Operating System"
+]
+
+[project.urls]
+issues = "https://github.com/storaged-project/blivet/issues"
+source = "https://github.com/storaged-project/blivet"
+releasenotes = "https://github.com/storaged-project/blivet/blob/main/release_notes.rst"
+documentation = "https://storaged.org/blivet/"
+
+[tool.setuptools]
+packages = ["blivet", "blivet.dbus", "blivet.devices", "blivet.devicelibs", "blivet.events",
+            "blivet.formats", "blivet.populator", "blivet.static_data", "blivet.tasks",
+            "blivet.populator.helpers"]

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -51,7 +51,6 @@ Summary: A python3 package for examining and modifying storage configuration.
 
 BuildRequires: gettext
 BuildRequires: python3-devel
-BuildRequires: python3-setuptools
 
 # For tests
 BuildRequires: python3-pyudev >= %{pyudevver}
@@ -105,6 +104,9 @@ configuration.
 %prep
 %autosetup -n %{realname}-%{realversion} -N
 %autosetup -n %{realname}-%{realversion} -b1 -p1
+
+%generate_buildrequires
+%pyproject_buildrequires
 
 %build
 make

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -186,7 +186,7 @@ def main():
         sys.exit(1)
 
     # Files to replace version strings in
-    version_files = [(os.path.realpath(cwd+"/setup.py"), "version='%s'"),
+    version_files = [(os.path.realpath(cwd+"/pyproject.toml"), "version = \"%s\""),
                      (os.path.realpath(cwd+"/blivet/__init__.py"), "__version__ = '%s'"),
                      (os.path.realpath(cwd+"/doc/conf.py"), "version = '%s'")]
 

--- a/setup.py
+++ b/setup.py
@@ -41,36 +41,6 @@ def findall(dirname=os.curdir):
 
 setuptools.findall = findall
 
-# Extend the sdist command
-class blivet_sdist(sdist):
-    user_options = sdist.user_options + [('mode=', None, "specify mode for sdist; one of 'release', 'normal'"),]
-
-    def initialize_options(self):
-        sdist.initialize_options(self)
-        self.mode = None  # pylint: disable=attribute-defined-outside-init
-
-    def finalize_options(self):
-        sdist.finalize_options(self)
-        if self.mode not in (None, 'release', 'normal'):
-            raise AttributeError('Unknown mode %s' % self.mode)
-
-    def run(self):
-        # Build the .mo files
-        subprocess.check_call(['make', '-C', 'po'])
-
-        # Run the parent command
-        sdist.run(self)
-
-    def make_release_tree(self, base_dir, files):
-        # Run the parent command first
-        sdist.make_release_tree(self, base_dir, files)
-
-        if self.mode == "release":
-            # Run translation-canary in release mode to remove any bad translations
-            sys.path.append('translation-canary')
-            from translation_canary.translated import testSourceTree  # pylint: disable=import-error
-            testSourceTree(base_dir, releaseMode=True)
-
 
 data_files = [
     ('/etc/dbus-1/system.d', ['dbus/blivet.conf']),
@@ -86,7 +56,6 @@ with open("README.md", "r") as f:
 
 setup(name='blivet',
       version='3.12.1',
-      cmdclass={"sdist": blivet_sdist},
       description='Python module for system storage configuration',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,6 @@
 #!/usr/bin/python3
 
-import setuptools
 from setuptools import setup
-from setuptools.command.sdist import sdist
-import subprocess
-import sys
-import os
-
-# this is copied straight from distutils.filelist.findall , but with os.stat()
-# replaced with os.lstat(), so S_ISLNK() can actually tell us something.
-
-
-def findall(dirname=os.curdir):
-    from stat import ST_MODE, S_ISREG, S_ISDIR, S_ISLNK
-
-    file_list = []
-    stack = [dirname]
-    pop = stack.pop
-    push = stack.append
-
-    while stack:
-        dirname = pop()
-        names = os.listdir(dirname)
-
-        for name in names:
-            if dirname != os.curdir:        # avoid the dreaded "./" syndrome
-                fullname = os.path.join(dirname, name)
-            else:
-                fullname = name
-
-            # Avoid excess stat calls -- just one will do, thank you!
-            stat = os.lstat(fullname)
-            mode = stat[ST_MODE]
-            if S_ISREG(mode):
-                file_list.append(fullname)
-            elif S_ISDIR(mode) and not S_ISLNK(mode):
-                push(fullname)
-
-    return file_list
-
-setuptools.findall = findall
 
 
 with open("README.md", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,3 @@
-#!/usr/bin/python3
-
 from setuptools import setup
 
-
-with open("README.md", "r") as f:
-    long_description = f.read()
-
-
-setup(name='blivet',
-      version='3.12.1',
-      description='Python module for system storage configuration',
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      author='David Lehman', author_email='dlehman@redhat.com',
-      url='http://github.com/storaged-project/blivet',
-      packages=['blivet', 'blivet.dbus', 'blivet.devices', 'blivet.devicelibs', 'blivet.events', 'blivet.formats', 'blivet.populator', 'blivet.static_data', 'blivet.tasks', 'blivet.populator.helpers'],
-      install_requires=['pyudev'],
-      classifiers=["Development Status :: 5 - Production/Stable",
-                   "Intended Audience :: Developers",
-                   "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-                   "Programming Language :: Python :: 3",
-                   "Operating System :: POSIX :: Linux"],
-      project_urls={"Bug Reports": "https://github.com/storaged-project/blivet/issues",
-                    "Source": "https://github.com/storaged-project/blivet",
-                    "Changelog": "https://github.com/storaged-project/blivet/blob/main/release_notes.rst",
-                    "Documentation": "https://storaged.org/blivet/"}
-     )
+setup()

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,6 @@ def findall(dirname=os.curdir):
 setuptools.findall = findall
 
 
-data_files = [
-    ('/etc/dbus-1/system.d', ['dbus/blivet.conf']),
-    ('/usr/share/dbus-1/system-services', ['dbus/com.redhat.Blivet0.service']),
-    ('/usr/libexec', ['dbus/blivetd']),
-    ('/usr/lib/systemd/system', ['dbus/blivet.service'])
-]
-
-
 with open("README.md", "r") as f:
     long_description = f.read()
 
@@ -61,7 +53,6 @@ setup(name='blivet',
       long_description_content_type="text/markdown",
       author='David Lehman', author_email='dlehman@redhat.com',
       url='http://github.com/storaged-project/blivet',
-      data_files=data_files,
       packages=['blivet', 'blivet.dbus', 'blivet.devices', 'blivet.devicelibs', 'blivet.events', 'blivet.formats', 'blivet.populator', 'blivet.static_data', 'blivet.tasks', 'blivet.populator.helpers'],
       install_requires=['pyudev'],
       classifiers=["Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Some `setup.py` commands are deprecated and will be removed soon, namely `install` and `sdist` which we are using in our Makefile. This PR also changes other things to move towards a more modern setuptools-based build system configuration which includes moving project definitions to the `pyproject.toml` file.

## Summary by Sourcery

Modernize the Python build process by adopting a PEP 517/518 workflow with setuptools and pyproject.toml, simplifying setup.py, and updating packaging scripts to use standard build tools.

Enhancements:
- Move project metadata and build-system configuration into pyproject.toml under a PEP 517/518 layout
- Simplify setup.py to a single setup() call and remove custom sdist logic and findall workaround

Build:
- Update Makefile to install via pip and build source distributions using python -m build, and add an install-dbus target
- Revise RPM spec and packit configuration to generate PEP 517 build requirements and remove direct setuptools dependency