### PR TITLE
Fix udev race condition in DDF RAID test case

### DIFF
--- a/blivet/safe_dbus.py
+++ b/blivet/safe_dbus.py
@@ -141,7 +141,7 @@ def call_sync(service, obj_path, iface, method, args,
 
     try:
         ret = connection.call_with_unix_fd_list_sync(service, obj_path, iface, method, args,
-                                                     None, Gio.DBusCallFlags.NONE,
+                                                     None, Gio.DBusCallFlags.NONE,  # pylint: disable=no-member
                                                      timeout, fds, None)
     except GLib.GError as gerr:
         msg = "Failed to call %s method on %s with %s arguments: %s" % \

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -28,6 +28,7 @@ class BlivetLintConfig(CensorshipConfig):
             FalsePositive(r"Instance of 'GError' has no 'message' member"),  # overriding currently broken local pylint disable
             FalsePositive(r"No name '.*' in module 'libmount'"),
             FalsePositive(r"Unknown option value for 'disable', expected a valid pylint message and got 'possibly-used-before-assignment'"),
+            FalsePositive(r"No value for argument 'self' in function call"),
         ]
 
     def _files(self):

--- a/tests/storage_tests/devices_test/md_test.py
+++ b/tests/storage_tests/devices_test/md_test.py
@@ -463,8 +463,7 @@ class BIOSRAIDTestCase(StorageTestCase):
         self._create_ddf_raid()
 
         with wait_for_resync():
-            self.storage.do_it()
-        self.storage.reset()
+            self.storage.reset()
 
         # check that we can correctly detect BIOS RAID arrays
         vol0 = self.storage.devicetree.get_device_by_name("vol0")

--- a/tests/storage_tests/devices_test/md_test.py
+++ b/tests/storage_tests/devices_test/md_test.py
@@ -459,6 +459,13 @@ class BIOSRAIDTestCase(StorageTestCase):
         if ret != 0:
             raise RuntimeError("Failed to setup DDF RAID for testing")
 
+        # joys of creating devices for tests manually, we need to encourage udev
+        # a bit to actually have the correct information for reset after creating
+        # the DDF array
+        blivet.udev.trigger(action="change", path=self.vdevs[0])
+        blivet.udev.trigger(action="change", path=self.vdevs[1])
+        blivet.udev.settle()
+
     def test_ddf_raid(self):
         self._create_ddf_raid()
 


### PR DESCRIPTION
The test started randomly failing with the latest mdadm. The DDF array created for testing was always a hack so I think it is ok to encourage udev here a little, this shouldn't be a problem with a real DDF hardware.

## Summary by Sourcery

Fix udev race in DDF RAID test by triggering and settling udev events after array creation and adjusting the test flow to reset storage during the resync wait

Bug Fixes:
- Trigger and settle udev events on test devices after creating the DDF RAID to avoid stale device information
- Replace storage.do_it() with storage.reset() inside the wait_for_resync context to properly detect the resynchronized array