### PR TITLE
LUKS label and subsystem support

### DIFF
--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -405,10 +405,14 @@ class LUKS(DeviceFormat):
                                              iterations=self.pbkdf_args.iterations,
                                              time_ms=self.pbkdf_args.time_ms)
             extra = blockdev.CryptoLUKSExtra(pbkdf=pbkdf,
-                                             sector_size=self.luks_sector_size)
+                                             sector_size=self.luks_sector_size,
+                                             label=self.label,
+                                             subsystem=self.subsystem)
         else:
-            if self.luks_sector_size:
-                extra = blockdev.CryptoLUKSExtra(sector_size=self.luks_sector_size)
+            if self.luks_sector_size or self.label or self.subsystem:
+                extra = blockdev.CryptoLUKSExtra(sector_size=self.luks_sector_size,
+                                                 label=self.label,
+                                                 subsystem=self.subsystem)
             else:
                 extra = None
 

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -317,3 +317,12 @@ class LUKSResetTestCase(StorageTestCase):
         self.assertEqual(disk.format.type, "luks")
         self.assertEqual(disk.format.label, "label")
         self.assertEqual(disk.format.subsystem, "subsystem")
+
+        disk.format.label = "new_label"
+        disk.format.write_label()
+
+        self.storage.reset()
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.assertEqual(disk.format.type, "luks")
+        self.assertEqual(disk.format.label, "new_label")

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -303,3 +303,17 @@ class LUKSResetTestCase(StorageTestCase):
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
         self.assertIsNotNone(disk)
         self.assertTrue(disk.format.has_key)
+
+    def test_label_subsystem(self):
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+
+        fmt = LUKS(passphrase="password", label="label", subsystem="subsystem")
+        self.storage.format_device(disk, fmt)
+        self.storage.do_it()
+
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.assertEqual(disk.format.type, "luks")
+        self.assertEqual(disk.format.label, "label")
+        self.assertEqual(disk.format.subsystem, "subsystem")


### PR DESCRIPTION
## Summary by Sourcery

Add support for specifying and updating LUKS2 volume labels and subsystems

New Features:
- Allow specifying label and subsystem when creating LUKS2 containers
- Introduce write_label method to set or update labels on existing LUKS2 devices

Enhancements:
- Include label and subsystem in CryptoLUKSExtra during format creation
- Add labeling and relabels properties to gate LUKS2-only labeling operations
- Implement label_format_ok to enforce maximum label length

Tests:
- Add test for LUKS2 label and subsystem creation and subsequent label update