### PR TITLE
Add a pre-wipe fixup function for LVM logical volumes

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -766,6 +766,9 @@ class ActionDestroyFormat(DeviceAction):
             if hasattr(self.device, 'set_rw'):
                 self.device.set_rw()
 
+            if hasattr(self.device, 'pre_format_destroy'):
+                self.device.pre_format_destroy()
+
             self.format.destroy()
             udev.settle()
             if isinstance(self.device, PartitionDevice) and self.device.disklabel_supported:


### PR DESCRIPTION
LVs scheduled to be removed are always activated to remove the format during installation. If there is a read-only LV with the skip activation flag with MD metadata this means after activating the LV to remove the format the MD array is auto-assembled by udev preventing us from removing it. For this special case, we simply stop the array before removing the format.

## Summary by Sourcery

Ensure LVM logical volumes with the skip activation flag and MD metadata are properly deactivated before format removal by introducing a pre-wipe cleanup hook and integrating it into the device destruction workflow.

New Features:
- Add pre_format_destroy() to LVM logical volumes to detect and deactivate MD arrays on volumes with skip activation before wiping
- Invoke pre_format_destroy() in deviceaction.execute() prior to format destruction