### PR TITLE
tests: Make sure iscsi-init.service is started for iSCSI tests

### DIFF
--- a/misc/blivet-tasks.yml
+++ b/misc/blivet-tasks.yml
@@ -51,6 +51,7 @@
       - stratisd
       - stratis-cli
       - libblockdev-tools
+      - udisks2-iscsi
   when: ansible_distribution == 'Fedora' and test_dependencies|bool
 
 ####### CentOS 9/10
@@ -99,6 +100,7 @@
       - stratisd
       - stratis-cli
       - libblockdev-tools
+      - udisks2-iscsi
   when: ansible_distribution == 'CentOS' and test_dependencies|bool
 
 - name: Install additional test dependencies (CentOS 9)

--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -25,5 +25,5 @@ prepare:
 execute:
     how: tmt
     script:
-      - sudo python3 tests/run_tests.py -l
+      - sudo python3 tests/run_tests.py -l -j
       - tmt-file-submit -l /tmp/blivet.log

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -228,9 +228,15 @@ if __name__ == '__main__':
     argparser.add_argument("-d", "--log-dir", dest="logdir",
                            help="directory for saving the logs (defaults to /tmp)",
                            action="store")
+    argparser.add_argument("-j", "--jenkins", dest="jenkins",
+                           help="run also tests that should run only in a CI environment",
+                           action="store_true")
     args = argparser.parse_args()
 
     testdir = os.path.abspath(os.path.dirname(__file__))
+
+    if args.jenkins:
+        os.environ["JENKINS_HOME"] = testdir  # pylint: disable=environment-modify
 
     import blivet
     print("Running tests with Blivet %s from %s" % (blivet.__version__,

--- a/tests/storage_tests/iscsi_test.py
+++ b/tests/storage_tests/iscsi_test.py
@@ -112,6 +112,8 @@ class ISCSITestCase(unittest.TestCase):
         except RuntimeError as e:
             raise RuntimeError("Failed to setup targetcli device for testing: %s" % e)
 
+        subprocess.call(["systemctl", "start", "iscsi-init.service"], stdout=subprocess.DEVNULL)
+
     def _force_logout(self):
         subprocess.call(["iscsiadm", "--mode", "node", "--logout", "--name", self.dev], stdout=subprocess.DEVNULL)
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for CI-specific tests and improve iSCSI test setup

New Features:
- Add --jenkins flag to include CI-only tests and set JENKINS_HOME environment variable

Enhancements:
- Start iscsi-init.service in iSCSI tests to ensure correct initialization
- Add udisks2-iscsi package to test dependency installation for Fedora and CentOS