### PR TITLE
spec: Bump required version of libblockdev to 3.4.0

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -22,7 +22,7 @@ Patch0: 0001-remove-btrfs-plugin.patch
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 3.3.0
+%global libblockdevver 3.4.0
 %global libbytesizever 0.3
 %global pyudevver 0.18
 %global s390utilscorever 2.31.0


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update libblockdev requirement from 3.3.0 to 3.4.0 in python-blivet.spec