### PR TITLE
Set FSTAB_PATH to /etc/fstab

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -54,10 +54,8 @@ import logging
 log = logging.getLogger("blivet")
 
 
-# Default path to fstab file. Left empty to prevent blivet from using
-# fstab functionality by default.
-# TODO Change to "/etc/fstab" at next major version
-FSTAB_PATH = ""
+# Default path to fstab file.
+FSTAB_PATH = "/etc/fstab"
 
 
 class Blivet(object, metaclass=SynchronizedMeta):


### PR DESCRIPTION
This fixes a regression where FSTabManager was initialized with an empty src_file, causing rescue mode to fail to mount /boot and /boot/efi partitions.

The empty FSTAB_PATH was introduced when fstab handling moved from anaconda to blivet in PR #6160 [1].

[1] https://github.com/rhinstaller/anaconda/pull/6160

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2402976

## Summary by Sourcery

Bug Fixes:
- Restore default fstab path to '/etc/fstab' to fix rescue mode mounting of /boot and /boot/efi partitions