### PR TITLE
Fstab fixes for Anaconda rescue mode

### DIFF
--- a/blivet/fstab.py
+++ b/blivet/fstab.py
@@ -560,7 +560,7 @@ class FSTabManager(object):
         if hasattr(device.format, "mountpoint"):
             device.format.mountpoint = _file
 
-        device.format.options = _mntopts
+        device.format.options = _mntopts_str
 
         return device
 

--- a/tests/storage_tests/fstab_test.py
+++ b/tests/storage_tests/fstab_test.py
@@ -127,6 +127,7 @@ class FstabTestCase(StorageTestCase):
             self.assertIsNotNone(dev)
             self.assertEqual(dev, lv)
             self.assertEqual(dev.format.mountpoint, "/mnt/test2")
+            self.assertEqual(dev.format.options, "optionA,optionB")
 
             # remove the device
             dev = self.storage.devicetree.get_device_by_name("blivetTestVG-blivetTestLVMine")
@@ -261,6 +262,7 @@ class FstabTestCase(StorageTestCase):
             self.assertIsNotNone(dev)
             self.assertEqual(dev, sub)
             self.assertEqual(dev.format.mountpoint, "/home")
+            self.assertEqual(dev.format.options, "subvol=blivetTestSubVol1")
 
             # non-existing subvolume, should not return the volume
             dev = fstab.find_device(devicetree=self.storage.devicetree, spec="UUID=%s" % vol.uuid,


### PR DESCRIPTION
## Summary by Sourcery

Fix fstab.get_device to respect entry defaults for filesystem type and mountpoint/options parameters, and add tests to verify spec- and entry-based device resolution including mountpoint and option handling.

Bug Fixes:
- Use entry.vfstype and entry.file as defaults when spec, file, or vfstype arguments are omitted
- Ensure get_format is called with the correct filesystem type and mountpoint and options are assigned properly

Enhancements:
- Consolidate internal variables (_spec, _mntopts, _vfstype, _file) for clarity

Tests:
- Add tests for retrieving devices by spec and by entry and asserting mountpoint and options for LVM and Btrfs entries