### PR TITLE
Make sure size for VGs without PVs is Size not int

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -582,6 +582,8 @@ class LVMVolumeGroupDevice(ContainerDevice):
     def size(self):
         """ The size of this VG """
         # TODO: just ask lvm if isModified returns False
+        if not self.pvs:
+            return Size(0)
         return sum(self._get_pv_usable_space(pv) for pv in self.pvs)
 
     @property

--- a/tests/unit_tests/devices_test/lvm_test.py
+++ b/tests/unit_tests/devices_test/lvm_test.py
@@ -508,6 +508,11 @@ class LVMDeviceTest(unittest.TestCase):
                                exists=False)
         self.assertFalse(vg.is_empty)
 
+    def test_vg_size_zero(self):
+        vg = LVMVolumeGroupDevice("testvg", parents=[])
+        self.assertEqual(vg.size, Size(0))
+        self.assertEqual(vg.extents, 0)
+
     def test_lvm_vdo_pool(self):
         pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
                            size=Size("1 GiB"), exists=True)


### PR DESCRIPTION
This doesn't really happen outside test scenarios, but size should always be instance of blivet.size.Size and not integer which we get from sum of an empty list which can lead to errors like "TypeError: unsupported operand type(s) for /: 'int' and 'Size'"

## Summary by Sourcery

Return a Size instance for empty LVM volume groups to avoid type errors, and add a test to confirm correct size and extents.

Enhancements:
- Ensure LVM volume groups without physical volumes return a Size(0) for size instead of an integer.

Tests:
- Add unit test verifying that an empty volume group reports size as Size(0) and has zero extents.