### PR TITLE
Allow using uninitialized disks in device factory

### DIFF
--- a/tests/unit_tests/devicefactory_test.py
+++ b/tests/unit_tests/devicefactory_test.py
@@ -60,7 +60,9 @@ class DeviceFactoryTestCase(unittest.TestCase):
     def setUp(self, *args):  # pylint: disable=unused-argument,arguments-differ
         if self.device_type is None:
             raise unittest.SkipTest("abstract base class")
+        self._prepare_storage()
 
+    def _prepare_storage(self):
         self.b = blivet.Blivet()  # don't populate it
         self.disk_files = [create_sparse_tempfile("factorytest", self._disk_size),
                            create_sparse_tempfile("factorytest", self._disk_size)]
@@ -360,6 +362,18 @@ class PartitionFactoryTestCase(DeviceFactoryTestCase):
         return delta
 
 
+class PartitionFactoryUnitializedTestCase(PartitionFactoryTestCase):
+    def _prepare_storage(self):
+        self.b = blivet.Blivet()  # don't populate it
+        self.disk_files = [create_sparse_tempfile("factorytest", self._disk_size),
+                           create_sparse_tempfile("factorytest", self._disk_size)]
+        for filename in self.disk_files:
+            disk = DiskFile(filename)
+            self.b.devicetree._add_device(disk)
+
+        self.addCleanup(self._clean_up_disk_files)
+
+
 class LVMFactoryTestCase(DeviceFactoryTestCase):
     device_class = LVMLogicalVolumeDevice
     device_type = devicefactory.DeviceTypes.LVM
@@ -599,6 +613,18 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         # second device with same name should be automatically renamed
         device2 = self._factory_device(device_type, **kwargs)
         self.assertEqual(device2.lvname, "name00")
+
+
+class LVMFactoryUninitializedTestCase(LVMFactoryTestCase):
+    def _prepare_storage(self):
+        self.b = blivet.Blivet()  # don't populate it
+        self.disk_files = [create_sparse_tempfile("factorytest", self._disk_size),
+                           create_sparse_tempfile("factorytest", self._disk_size)]
+        for filename in self.disk_files:
+            disk = DiskFile(filename)
+            self.b.devicetree._add_device(disk)
+
+        self.addCleanup(self._clean_up_disk_files)
 
 
 class LVMThinPFactoryTestCase(LVMFactoryTestCase):


### PR DESCRIPTION
Fixes: #725
Fixes: #1030

## Summary by Sourcery

Enable the device factory to accept uninitialized disks by auto-initializing them on demand, centralize disk filtering logic in a new helper method, and add corresponding tests for uninitialized disk scenarios

New Features:
- Allow uninitialized disks to be auto-initialized and used by the device factory

Enhancements:
- Add _filter_disks helper to centralize disk filtering and optional initialization
- Refactor disk selection in both _configure and configure methods to use the new filtering utility

Tests:
- Introduce PartitionFactoryUninitializedTestCase and LVMFactoryUninitializedTestCase to cover scenarios with uninitialized disks
- Refactor DeviceFactoryTestCase to use a new _prepare_storage helper for disk setup