### PR TITLE
pylint: Remove suggestion-mode from pylintrc

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -40,10 +40,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=yes


### PR DESCRIPTION
This is now enabled by default and was removed from pylintrc.

## Summary by Sourcery

Enhancements:
- Remove explicit suggestion-mode setting from pylintrc now that it is enabled by default