### PR TITLE
Do not set XBOOTLDR GUID for /boot partition (#2406974)

### DIFF
--- a/blivet/devicelibs/gpt.py
+++ b/blivet/devicelibs/gpt.py
@@ -238,7 +238,6 @@ def gpt_part_uuid_for_mountpoint(path, arch=None):
 
         "/efi": GPT_VOL_ESP,
         "/boot/efi": GPT_VOL_ESP,
-        "/boot": GPT_VOL_XBOOTLDR,
         "/home": GPT_VOL_HOME,
         "/var": GPT_VOL_VAR,
         "/srv": GPT_VOL_SRV,


### PR DESCRIPTION
XBOOTLDR or Extended Boot Loader Partition needs to be formatted to VFAT and placed on the same disk as EFI boot partition. This is not something we support and we cannot set this GUID by default. See https://uapi-group.org/specifications/specs/boot_loader_specification/ for more information.

## Summary by Sourcery

Bug Fixes:
- Remove the default GPT_VOL_XBOOTLDR mapping for the /boot mount point