### PR TITLE
tests: Do not patch builtins.open directly

### DIFF
--- a/tests/unit_tests/devicelibs_test/lvm_test.py
+++ b/tests/unit_tests/devicelibs_test/lvm_test.py
@@ -9,32 +9,32 @@ class LVMTestCase(unittest.TestCase):
     def test_lvm_autoactivation(self):
         localconf = "global { event_activation = 0 }"
 
-        with patch("builtins.open", mock_open(read_data=localconf)):
+        with patch("blivet.devicelibs.lvm.open", mock_open(read_data=localconf)):
             # already disabled
             with self.assertRaises(RuntimeError):
                 lvm.disable_lvm_autoactivation()
 
         localconf = ""
-        with patch("builtins.open", mock_open(read_data=localconf)) as m:
+        with patch("blivet.devicelibs.lvm.open", mock_open(read_data=localconf)) as m:
             lvm.disable_lvm_autoactivation()
             m.assert_called_with("/etc/lvm/lvmlocal.conf", "a")
             handle = m()
             handle.write.assert_called_once_with("global { event_activation = 0 }")
 
         localconf = "test\ntest"
-        with patch("builtins.open", mock_open(read_data=localconf)) as m:
+        with patch("blivet.devicelibs.lvm.open", mock_open(read_data=localconf)) as m:
             # not disabled
             with self.assertRaises(RuntimeError):
                 lvm.reenable_lvm_autoactivation()
 
         localconf = "# global { event_activation = 0 }"
-        with patch("builtins.open", mock_open(read_data=localconf)) as m:
+        with patch("blivet.devicelibs.lvm.open", mock_open(read_data=localconf)) as m:
             # not disabled
             with self.assertRaises(RuntimeError):
                 lvm.reenable_lvm_autoactivation()
 
         localconf = "test\nglobal { event_activation = 0 }"
-        with patch("builtins.open", mock_open(read_data=localconf)) as m:
+        with patch("blivet.devicelibs.lvm.open", mock_open(read_data=localconf)) as m:
             lvm.reenable_lvm_autoactivation()
             m.assert_called_with("/etc/lvm/lvmlocal.conf", "w+")
             handle = m()


### PR DESCRIPTION
This causes coverity to fail, because it internally uses open() which we just mocked.

## Summary by Sourcery

Update LVM unit tests to patch the open function in the module under test instead of mocking builtins.open to avoid interfering with external tools like Coverity

Bug Fixes:
- Prevent Coverity analysis failures by limiting open() mocking to the target module namespace

Tests:
- Patch open in blivet.devicelibs.lvm rather than builtins.open across LVM tests