### PR TITLE
CONTRIBUTING: Update directions for updating documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Generate documentation for the new release
 ```
 make -C doc html
 ```
-Copy the documentation from `doc/_build/html` to a temporary directory, switch to the `gh-pages`, copy the documentation back and commit and push the changes.
+Copy the documentation from `doc/_build/html` to the `blivet` folder in the [Storaged project website repository](https://github.com/storaged-project/storaged-project.github.io) and commit and push the changes.
 
 ### Fedora Build Procedure
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Revise documentation publishing steps to point contributors to the storaged-project.github.io repository and blivet folder instead of using the gh-pages branch directly.