### PR TITLE
Remove Python 2 compatibility code

### DIFF
--- a/blivet/arch.py
+++ b/blivet/arch.py
@@ -25,12 +25,6 @@
 #            Dennis Gilmore <dgilmore@ausil.us>
 #            David Marlin <dmarlin@redhat.com>
 #
-# The absolute_import is needed so that we can
-# import the "platform" module from the Python
-# standard library but not the local blivet module
-# that is also called "platform".
-from __future__ import absolute_import
-
 import os
 
 from .storage_log import log_exception_info

--- a/misc/files/libmount_deb.py
+++ b/misc/files/libmount_deb.py
@@ -1,10 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Debian based distributions do not have python3-libmount (and never will). This does manual
 # installation of it.
 # Requires autopoint and bison packages to work.
-
-from __future__ import print_function
 
 import os
 import re

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from __future__ import print_function
-
 import argparse
 import csv
 import os

--- a/tests/unit_tests/size_test.py
+++ b/tests/unit_tests/size_test.py
@@ -21,9 +21,6 @@
 #
 # Red Hat Author(s): David Cantrell <dcantrell@redhat.com>
 
-# we need integer division to work the same with both Python 2 and 3
-from __future__ import division
-
 import locale
 import os
 import pickle


### PR DESCRIPTION
Remove all remaining Python 2 compatibility imports and shebangs:
- Remove __future__ imports (print_function, absolute_import, division)
- Update shebang in libmount_deb.py from python to python3
- Remove obsolete Python 2/3 compatibility comments

These are no longer needed as blivet is Python 3 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Python 2 compatibility imports and code across the project to streamline the codebase for Python 3-only environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->