### PR TITLE
fcoe: Check for script existence before execution

### DIFF
--- a/blivet/fcoe.py
+++ b/blivet/fcoe.py
@@ -93,8 +93,14 @@ class FCoE(object):
         udev.settle()
 
     def _start_edd(self):
+        fcoe_edd_script_path = "/usr/libexec/fcoe/fcoe_edd.sh"
+
+        if not os.path.isfile(fcoe_edd_script_path):
+            log.debug("FCoE EDD script not found at %s, skipping.", fcoe_edd_script_path)
+            return
+
         try:
-            buf = util.capture_output(["/usr/libexec/fcoe/fcoe_edd.sh", "-i"])
+            buf = util.capture_output([fcoe_edd_script_path, "-i"])
         except OSError as e:
             log.info("Failed to read FCoE EDD info: %s", e.strerror)
             return


### PR DESCRIPTION
Address an issue where Anaconda would attempt to execute
/usr/libexec/fcoe/fcoe_edd.sh even when it was not present on the system,
leading to an error message like:
"ERROR:program:Error running /usr/libexec/fcoe/fcoe_edd.sh: No such file or directory"

This was particularly relevant on architectures (like ARM) where the fcoe-utils
package might not be installed by default, unlike x86_64.

Added a check using os.path.isfile() before attempting to run the script.

fix: ERROR:program:Error running /usr/libexec/fcoe/fcoe_edd.sh: No such file or directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced FCoE EDD processing with validation to verify script availability before execution, preventing potential errors during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->