### PR TITLE
ci: Use the latest/rawhide Anaconda CI container instead of "main"

### DIFF
--- a/.github/workflows/anaconda_tests.yml
+++ b/.github/workflows/anaconda_tests.yml
@@ -39,7 +39,7 @@ jobs:
           # - Install dependencies for blivet.
           # - Install blivet to the container.
           # - Run Anaconda tests.
-          podman run -i --rm -v ./blivet:/blivet:z -v ./anaconda:/anaconda:z quay.io/rhinstaller/anaconda-ci:$TARGET_BRANCH sh -c " \
+          podman run -i --rm -v ./blivet:/blivet:z -v ./anaconda:/anaconda:z quay.io/rhinstaller/anaconda-ci:latest sh -c " \
               set -xe; \
               rpm -e --nodeps python3-blivet blivet-data; \
               dnf install -y python3-blockdev libblockdev-plugins-all python3-bytesize libbytesize python3-pyparted python3-libmount parted libselinux-python3; \


### PR DESCRIPTION
The "main" container is obsolete and not being updated.