### PR TITLE
iscsi: Fix calling initiator methods without argument

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -155,7 +155,7 @@ class iSCSI(object):
 
         if flags.ibft:
             try:
-                initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")[0]
+                initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")
                 self._initiator = initiatorname
             except Exception as e:  # pylint: disable=broad-except
                 log.info("failed to get initiator name from iscsi firmware: %s", str(e))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed iSCSI initiator name retrieval when IBFT (iSCSI Boot Firmware Table) is enabled to properly handle the returned value.
* Improved iSCSI initiator method invocation to correctly handle optional arguments, ensuring more reliable operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->