### PR TITLE
iscsi: Fix calling initiator methods without argument

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -155,7 +155,7 @@ class iSCSI(object):
 
         if flags.ibft:
             try:
-                initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")[0]
+                initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")
                 self._initiator = initiatorname
             except Exception as e:  # pylint: disable=broad-except
                 log.info("failed to get initiator name from iscsi firmware: %s", str(e))


### PR DESCRIPTION
If arguments are not specified we default to None and trying to expand it results in TypeError.

Resolves: RHEL-145882