### PR TITLE
Fix crash on systems with broken stratis pools

### DIFF
--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -176,6 +176,11 @@ class StratisFormatPopulator(FormatPopulator):
             # possibly stopped pool
             pool_info = next((pool_info for pool_info in stratis_info.stopped_pools if self.device.path in pool_info.devices), None)
             if pool_info:
+                if not pool_info.name:
+                    # no name -> probably broken or partially constructed pool
+                    # we cannot add a device without name
+                    log.warning("Ignoring stopped stratis pool %s without name", pool_info.uuid)
+                    return
                 pool_device = self._add_stopped_pool_device(pool_info)
             else:
                 # no stopped pool info, no bd info -> nothing we can do

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -211,8 +211,14 @@ class StratisInfo(object):
                 else:
                     encrypted = bool(feats["encryption"])
 
+            if "name" in pools_info[pool_uuid].keys():
+                pool_name = pools_info[pool_uuid]["name"].get_string()
+            else:
+                log.warning("Stopped Stratis pool %s does not have name", pool_uuid)
+                pool_name = None
+
             info = StratisStoppedPoolInfo(uuid=pool_uuid,
-                                          name=pools_info[pool_uuid]["name"].get_string(),
+                                          name=pool_name,
                                           devices=[d["devnode"] for d in pools_info[pool_uuid]["devs"]],
                                           encrypted=encrypted)
             stopped_pools.append(info)


### PR DESCRIPTION
A broken or partially created stratis pool can be reported as stopped without a name. In this case we fail to gather the info about it and crash. We can't work with devices without a name so we need to completely ignore these pools.

Related: https://github.com/stratis-storage/project/issues/861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and robustness when processing stopped storage pools: the system now detects missing pool names, logs warnings, and skips creating or registering pool devices when required metadata is absent, preventing invalid configurations and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->