### PR TITLE
Fix PV overhead calculation in LVMFactory._get_total_space

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1452,11 +1452,11 @@ class LVMFactory(DeviceFactory):
             if self.vg:
                 space += sum(p.size for p in self.vg.parents)
                 space -= self.vg.free_space
-                # we need to account for the LVM metadata being placed somewhere
-                space += self.vg.lvm_metadata_space
-                # account for unusable space in the PV (difference between PV size and its usable
-                # space), this is dues to PV metadata and data alignment to
-                space += sum(pv.size - self.vg._get_pv_usable_space(pv) for pv in self.vg.parents)
+                # account for unusable space in the PV (PV metadata and data alignment)
+                if self.vg.parents:
+                    space += sum(pv.size - self.vg._get_pv_usable_space(pv) for pv in self.vg.parents)
+                else:
+                    space += len(self.disks) * self._pe_size
             else:
                 # we need to account for the LVM metadata being placed on each disk
                 # (and thus taking up to one extent from each disk)

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1452,9 +1452,19 @@ class LVMFactory(DeviceFactory):
             if self.vg:
                 space += sum(p.size for p in self.vg.parents)
                 space -= self.vg.free_space
-                # account for unusable space in the PV (PV metadata and data alignment)
+                # Worst-case PV overhead: metadata + pe_size per PV.
+                # PE alignment losses change when manage_size_sets resizes PVs,
+                # so current overhead (already in sum - free) is not enough.
                 if self.vg.parents:
-                    space += sum(pv.size - self.vg._get_pv_usable_space(pv) for pv in self.vg.parents)
+                    worst_case_overhead = sum(
+                        self.vg._get_pv_metadata_space(pv) + self._pe_size
+                        for pv in self.vg.parents
+                    )
+                    current_overhead = sum(
+                        pv.size - self.vg._get_pv_usable_space(pv)
+                        for pv in self.vg.parents
+                    )
+                    space += max(worst_case_overhead - current_overhead, Size(0))
                 else:
                     space += len(self.disks) * self._pe_size
             else:

--- a/tests/unit_tests/devicefactory_test.py
+++ b/tests/unit_tests/devicefactory_test.py
@@ -614,6 +614,35 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         device2 = self._factory_device(device_type, **kwargs)
         self.assertEqual(device2.lvname, "name00")
 
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    @patch("blivet.formats.fs.Ext4FS.formattable", return_value=True)
+    @patch("blivet.formats.fs.XFS.formattable", return_value=True)
+    def test_lvm_shrink_pv_overhead(self, *args):  # pylint: disable=unused-argument
+        if self.device_type != devicefactory.DeviceTypes.LVM:
+            self.skipTest("only applies to plain LVM")
+
+        device_type = self.device_type
+
+        # Create a large LV filling most of the VG, then shrink it.
+        # _get_total_space must use worst-case PV overhead so that after
+        # manage_size_sets shrinks the PV partitions, the VG still has
+        # enough usable space (PE alignment losses change with PV size).
+        kwargs = {"disks": self.b.disks,
+                  "size": Size("1500 MiB"),
+                  "fstype": "ext4"}
+        device = self._factory_device(device_type, **kwargs)
+        vg = device.raw_device.container
+        self.assertGreaterEqual(vg.free_space, Size(0))
+
+        kwargs["device"] = device
+        kwargs["size"] = Size("200 MiB")
+        device = self._factory_device(device_type, **kwargs)
+        vg = device.raw_device.container
+        self.assertGreaterEqual(vg.free_space, Size(0))
 
     @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
     @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)

--- a/tests/unit_tests/devicefactory_test.py
+++ b/tests/unit_tests/devicefactory_test.py
@@ -615,6 +615,39 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         self.assertEqual(device2.lvname, "name00")
 
 
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.formattable", return_value=True)
+    @patch("blivet.formats.lvmpv.LVMPhysicalVolume.destroyable", return_value=True)
+    @patch("blivet.static_data.lvm_info.blockdev.lvm.lvs", return_value=[])
+    @patch("blivet.devices.lvm.LVMVolumeGroupDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.lvm.LVMLogicalVolumeBase.type_external_dependencies", return_value=set())
+    @patch("blivet.formats.fs.Ext4FS.formattable", return_value=True)
+    @patch("blivet.formats.mdraid.MDRaidMember.formattable", return_value=True)
+    @patch("blivet.formats.mdraid.MDRaidMember.destroyable", return_value=True)
+    @patch("blivet.devices.md.MDRaidArrayDevice.type_external_dependencies", return_value=set())
+    @patch("blivet.devices.dm.DMDevice.type_external_dependencies", return_value=set())
+    def test_lvm_on_md_pv_space(self, *args):  # pylint: disable=unused-argument
+        if self.device_type != devicefactory.DeviceTypes.LVM:
+            self.skipTest("only applies to plain LVM")
+
+        device_type = self.device_type
+
+        # Create with partition PVs, then switch to MD RAID PVs.
+        # The LV should retain its size after the switch -- _get_total_space
+        # must account for PV overhead so the MD array is large enough.
+        kwargs = {"disks": self.b.disks,
+                  "size": Size("400 MiB"),
+                  "fstype": "ext4"}
+        device = self._factory_device(device_type, **kwargs)
+        lv_size_before = device.raw_device.size
+
+        kwargs["device"] = device
+        kwargs["container_raid_level"] = "raid1"
+        device = self._factory_device(device_type, **kwargs)
+        vg = device.raw_device.container
+        self.assertGreaterEqual(vg.free_space, Size(0))
+        self.assertEqual(device.raw_device.size, lv_size_before)
+
+
 class LVMFactoryUninitializedTestCase(LVMFactoryTestCase):
     def _prepare_storage(self):
         self.b = blivet.Blivet()  # don't populate it


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LVM container-size calculation to better account for metadata and physical volume overhead, preventing potential space allocation issues in certain storage configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storaged-project/blivet/pull/1469)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->