### PR TITLE
Ignore pylint false positive no-member in FS._format_resource

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -841,7 +841,7 @@ class FS(DeviceFormat):
     @property
     def _format_resource(self):
         if self._mkfs and hasattr(self._mkfs, "ext"):
-            return self._mkfs.ext
+            return self._mkfs.ext  # pylint: disable=no-member
         return None
 
     @property


### PR DESCRIPTION
Happens only on C9S with older pylint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality configuration with improved static-analysis handling.

---

**Note:** This release contains no user-facing changes. The update addresses internal code maintenance only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storaged-project/blivet/pull/1470)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->