### PR TITLE
Ignore missing parted disk in ActionList._post_process (#2477511)

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -251,7 +251,7 @@ class ActionList(object, metaclass=SynchronizedMeta):
         devices = devices or []
         # removal of partitions makes use of original_format, so it has to stay
         # up to date in case of multiple passes through this method
-        for disk in (d for d in devices if d.partitioned and d.format.supported):
+        for disk in (d for d in devices if d.partitioned and d.format.supported and d.format.parted_disk):
             disk.format.update_orig_parted_disk()
             disk.original_format = copy.deepcopy(disk.format)
 


### PR DESCRIPTION
We fixed one of the calls that could fail here in 240d8a3 but with a broken disk we can also crash in this call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved device handling during post-processing to prevent unnecessary operations on devices without certain format properties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storaged-project/blivet/pull/1474)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->