### PR TITLE
Allow running tests on Debian

### DIFF
--- a/misc/blivet-tasks.yml
+++ b/misc/blivet-tasks.yml
@@ -169,6 +169,7 @@
       - automake
       - autopoint
       - bison
+      - flex
       - git
       - libtool
       - pkg-config

--- a/tests/storage_tests/devices_test/partition_test.py
+++ b/tests/storage_tests/devices_test/partition_test.py
@@ -544,7 +544,7 @@ class PartitionTestCase(StorageTestCase):
         self.storage.reset()
 
         # create MD RAID with metadata 1.0 on the first partition
-        ret = blivet.util.run_program(["mdadm", "--create", "blivetMDTest", "--level=linear",
+        ret = blivet.util.run_program(["mdadm", "--create", "blivetMDTest", "--level=raid0",
                                        "--metadata=1.0", "--raid-devices=1", "--force", part1.path])
         self.assertEqual(ret, 0, "Failed to create RAID array for partition wipe test")
         ret = blivet.util.run_program(["mdadm", "--stop", "/dev/md/blivetMDTest"])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted test setup to use a RAID 0 configuration for the partition-wipe metadata check.

* **Chores**
  * Added the flex package to the Debian/Ubuntu test dependency installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storaged-project/blivet/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->