### PR TITLE
Read data and metadata RAID levels for existing btrfs volumes

### DIFF
--- a/blivet/devicelibs/btrfs.py
+++ b/blivet/devicelibs/btrfs.py
@@ -55,6 +55,39 @@ def is_btrfs_name_valid(name):
     return '\x00' not in name
 
 
+KNOWN_RAID_LEVELS = ("single", "dup", "raid0", "raid1", "raid10",
+                     "raid5", "raid6", "raid1c3", "raid1c4")
+
+RAID_LEVEL_MAPPING = {"raid1c3": "raid1",
+                      "raid1c4": "raid1"}
+
+
+def get_raid_levels(uuid):
+    sysfs_path = "/sys/fs/btrfs/%s/allocation" % uuid
+    data_level = None
+    metadata_level = None
+
+    for alloc_type in ("data", "metadata"):
+        type_path = os.path.join(sysfs_path, alloc_type)
+        if not os.path.isdir(type_path):
+            continue
+        try:
+            entries = os.listdir(type_path)
+        except OSError as e:
+            log.debug("failed to read %s: %s", type_path, e)
+            continue
+        for entry in entries:
+            if entry in KNOWN_RAID_LEVELS and os.path.isdir(os.path.join(type_path, entry)):
+                level = RAID_LEVEL_MAPPING.get(entry, entry)
+                if alloc_type == "data":
+                    data_level = level
+                else:
+                    metadata_level = level
+                break
+
+    return (data_level, metadata_level)
+
+
 def get_mountpoint_subvolumes(mountpoint):
     """ Get list of subvolume names on given mounted btrfs filesystem
     """

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -371,6 +371,23 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
                 return None
         return None
 
+    def _update_raid_levels(self):
+        data_level, metadata_level = btrfs.get_raid_levels(self.uuid)
+
+        if data_level and self._data_level is None:
+            try:
+                self._data_level = raid.ALL_LEVELS.raid_level(data_level)
+            except errors.RaidError:
+                log.warning("failed to set data RAID level to '%s' for %s",
+                            data_level, self.name)
+
+        if metadata_level and self._metadata_level is None:
+            try:
+                self._metadata_level = raid.ALL_LEVELS.raid_level(metadata_level)
+            except errors.RaidError:
+                log.warning("failed to set metadata RAID level to '%s' for %s",
+                            metadata_level, self.name)
+
     def _list_subvolumes(self, mountpoint, snapshots_only=False):
         subvols = []
         try:
@@ -380,6 +397,8 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
             log.debug("failed to list subvolumes: %s", e)
         else:
             self._get_default_subvolume_id(mountpoint)
+
+        self._update_raid_levels()
 
         return subvols
 

--- a/tests/storage_tests/devices_test/btrfs_test.py
+++ b/tests/storage_tests/devices_test/btrfs_test.py
@@ -117,6 +117,8 @@ class BtrfsTestCase(StorageTestCase):
         self.assertEqual(vol.format.type, "btrfs")
         self.assertEqual(vol.format.container_uuid, vol.uuid)
         self.assertEqual(len(vol.parents), 2)
+        self.assertEqual(vol.data_level, raid_level)
+        self.assertEqual(vol.metadata_level, raid_level)
 
     def test_btrfs_raid_single(self):
         self._test_btrfs_raid(blivet.devicelibs.raid.Single)

--- a/tests/unit_tests/devices_test/btrfs_test.py
+++ b/tests/unit_tests/devices_test/btrfs_test.py
@@ -6,6 +6,7 @@ import blivet
 from blivet.devices import StorageDevice
 from blivet.devices import BTRFSVolumeDevice
 from blivet.devices import BTRFSSubVolumeDevice
+from blivet.devicelibs import btrfs
 from blivet.size import Size
 from blivet.formats.fs import BTRFS
 
@@ -125,3 +126,78 @@ class BlivetNewBtrfsVolumeDeviceTest(unittest.TestCase):
                     vol.list_subvolumes()
                     blockdev.list_subvolumes.assert_not_called()
                     blockdev.get_default_subvolume_id.assert_not_called()
+
+    def test_btrfs_update_raid_levels(self):
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("btrfs"),
+                           size=Size("2 GiB"), exists=True)
+
+        vol = BTRFSVolumeDevice("testvolume", parents=[bd], exists=True)
+        self.assertIsNone(vol.data_level)
+        self.assertIsNone(vol.metadata_level)
+
+        with patch("blivet.devices.btrfs.btrfs.get_raid_levels", return_value=("single", "dup")):
+            vol._update_raid_levels()
+
+        self.assertEqual(vol.data_level.name, "single")
+        self.assertEqual(vol.metadata_level.name, "dup")
+
+    def test_btrfs_update_raid_levels_raid56(self):
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("btrfs"),
+                           size=Size("2 GiB"), exists=True)
+
+        vol = BTRFSVolumeDevice("testvolume", parents=[bd], exists=True)
+
+        with patch("blivet.devices.btrfs.btrfs.get_raid_levels", return_value=("raid5", "raid6")):
+            vol._update_raid_levels()
+
+        self.assertEqual(vol.data_level.name, "raid5")
+        self.assertEqual(vol.metadata_level.name, "raid6")
+
+
+@unittest.skipUnless(not any(x.unavailable_type_dependencies() for x in DEVICE_CLASSES), "some unsupported device classes required for this test")
+class BtrfsGetRaidLevelsTest(unittest.TestCase):
+    def test_get_raid_levels(self):
+        def fake_isdir(path):
+            dirs = {"/sys/fs/btrfs/fake-uuid/allocation",
+                    "/sys/fs/btrfs/fake-uuid/allocation/data",
+                    "/sys/fs/btrfs/fake-uuid/allocation/data/raid1",
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata",
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata/dup"}
+            return path in dirs
+
+        with patch("blivet.devicelibs.btrfs.os.path.isdir", side_effect=fake_isdir):
+            with patch("blivet.devicelibs.btrfs.os.listdir") as mock_listdir:
+                mock_listdir.side_effect = lambda path: {
+                    "/sys/fs/btrfs/fake-uuid/allocation/data": ["bytes_used", "raid1", "total_bytes"],
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata": ["bytes_used", "dup", "total_bytes"],
+                }.get(path, [])
+                data_level, metadata_level = btrfs.get_raid_levels("fake-uuid")
+
+        self.assertEqual(data_level, "raid1")
+        self.assertEqual(metadata_level, "dup")
+
+    def test_get_raid_levels_raid1c(self):
+        def fake_isdir(path):
+            dirs = {"/sys/fs/btrfs/fake-uuid/allocation",
+                    "/sys/fs/btrfs/fake-uuid/allocation/data",
+                    "/sys/fs/btrfs/fake-uuid/allocation/data/raid1c3",
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata",
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata/raid1c4"}
+            return path in dirs
+
+        with patch("blivet.devicelibs.btrfs.os.path.isdir", side_effect=fake_isdir):
+            with patch("blivet.devicelibs.btrfs.os.listdir") as mock_listdir:
+                mock_listdir.side_effect = lambda path: {
+                    "/sys/fs/btrfs/fake-uuid/allocation/data": ["raid1c3", "total_bytes"],
+                    "/sys/fs/btrfs/fake-uuid/allocation/metadata": ["raid1c4", "total_bytes"],
+                }.get(path, [])
+                data_level, metadata_level = btrfs.get_raid_levels("fake-uuid")
+
+        self.assertEqual(data_level, "raid1")
+        self.assertEqual(metadata_level, "raid1")
+
+        with patch("blivet.devicelibs.btrfs.os.path.isdir", return_value=False):
+            data_level, metadata_level = btrfs.get_raid_levels("nonexistent-uuid")
+
+        self.assertIsNone(data_level)
+        self.assertIsNone(metadata_level)


### PR DESCRIPTION
Read RAID levels from sysfs /sys/fs/btrfs/<uuid>/allocation/{data,metadata}/ during subvolume listing, when the volume is known to be mounted. The kernel exposes the RAID profile as a subdirectory (e.g. single, dup, raid1). raid1c3 and raid1c4 are normalized to raid1.

Resolves: #1175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BTRFS volumes now automatically discover and report their data and metadata RAID levels during filesystem scanning.
  * Enhanced RAID configuration detection with comprehensive support for all standard BTRFS RAID levels, including proper normalization of RAID1c3 and RAID1c4 variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/storaged-project/blivet/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->