### PR TITLE
Fix various bugs found during code review

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -192,6 +192,7 @@ class KeyslotContext(object):
             return True
         if self.is_keyfile:
             return os.access(self._key_file, os.R_OK)
+        return False
 
     @property
     def is_passphrase(self):

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -328,7 +328,7 @@ def reenable_lvm_autoactivation(lvmconf=LVM_LOCAL_CONF):
     with open(lvmconf, "r") as f:
         lines = f.readlines()
 
-    if "global { event_activation = 0 }" not in lines:
+    if not any(line.strip("\n") == "global { event_activation = 0 }" for line in lines):
         raise RuntimeError("LVM auto-activation is not configured in %s" % lvmconf)
 
     with open(lvmconf, "w+") as f:

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1195,7 +1195,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
 
         if old_name == new_name:
             raise ValueError("device is already named '%s'" % old_name)
-        if not lvm.is_lvm_name_valid(self.name):
+        if not lvm.is_lvm_name_valid(new_name):
             raise ValueError("'%s' is not a valid name for %s" % (new_name, self.type))
 
         if not dry_run:

--- a/blivet/formats/prepboot.py
+++ b/blivet/formats/prepboot.py
@@ -71,6 +71,7 @@ class PPCPRePBoot(DeviceFormat):
                 any previously set value of this instance's "device" attribute.
         """
         super(PPCPRePBoot, self)._create(**kwargs)
+        fd = None
         try:
             fd = os.open(self.device, os.O_RDWR)
             length = os.lseek(fd, 0, os.SEEK_END)
@@ -87,7 +88,7 @@ class PPCPRePBoot(DeviceFormat):
         except OSError as e:
             log.error("error zeroing out %s: %s", self.device, e)
         finally:
-            if fd:
+            if fd is not None:
                 os.close(fd)
 
     @property

--- a/tests/unit_tests/populator_test.py
+++ b/tests/unit_tests/populator_test.py
@@ -208,12 +208,12 @@ class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
         device_is_loop = args[0]
         loop_info = args[7]
         data = {'SYS_PATH': 'dummy'}
-        loop_info.return_value = Mock(baking_file="foobar")
+        loop_info.return_value = Mock(backing_file="foobar")
         self.assertEqual(get_device_helper(data), self.helper_class)
 
-        loop_info.return_value = Mock(baking_file=None)
+        loop_info.return_value = Mock(backing_file=None)
         self.assertEqual(get_device_helper(data), self.helper_class)
-        loop_info.return_value = Mock(baking_file="foobar")
+        loop_info.return_value = Mock(backing_file="foobar")
 
         # verify that setting one of the required True return values to False prevents success
         device_is_loop.return_value = False


### PR DESCRIPTION
## Summary

- **LVM rename validation**: `_rename` was validating `self.name` (old name) instead of `new_name`, allowing invalid names to pass validation
- **PReP boot fd handling**: uninitialized `fd` variable caused `NameError` in the `finally` block when `os.open()` failed, masking the original `OSError`
- **LVM autoactivation**: `reenable_lvm_autoactivation` string comparison always failed because `readlines()` preserves trailing newlines but the check didn't account for them
- **crypto KeyslotContext.valid**: property could implicitly return `None` instead of `False` when neither passphrase nor keyfile condition matched
- **populator test typo**: mock attribute `baking_file` didn't match production code's `backing_file`, so the `None` backing file path was never actually tested

## Test plan

- [ ] `make ci` passes
- [ ] Verify LVM rename rejects invalid new names
- [ ] Verify `reenable_lvm_autoactivation` finds the config line correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cryptographic key validation to consistently handle invalid passphrases and missing keyfiles.
  * Enhanced LVM auto-activation detection with more precise configuration line matching.
  * Fixed LVM logical volume rename operation to properly validate proposed names.
  * Strengthened boot format creation with improved file descriptor handling to prevent initialization errors.

* **Tests**
  * Corrected test mock data to properly reflect expected structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->