### PR TITLE
devicetree: match btrfs subvol mount options with or without a leading slash

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -787,7 +787,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
                 if attr and val:
                     for subvol in volume.subvolumes:
-                        if getattr(subvol, attr, None) == val:
+                        if getattr(subvol, attr, None) == val.lstrip("/"):
                             device = subvol
                             break
                     else:

--- a/tests/unit_tests/devicetree_test.py
+++ b/tests/unit_tests/devicetree_test.py
@@ -109,6 +109,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         # resolve by UUID with options
         self.assertEqual(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=%s" % sub1.name), sub1)
         self.assertEqual(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=%s" % sub2.name), sub2)
+        self.assertEqual(dt.resolve_device("UUID=%s" % btrfs_uuid, options="subvol=/%s" % sub1.name), sub1)
 
         # try to resolve non-existing subvolume (should return None)
         self.assertIsNone(dt.resolve_device("UUID=%s" % btrfs_uuid, subvolspec="non-existing"))


### PR DESCRIPTION
The subvol= fstab mount option names a path relative to the top-level subvolume (see btrfs(5)). Existing systems may use subvol=/@ while blockdev reports the subvolume as @. Strip the leading slash from the fstab value when comparing to the device name, as MountsCache does for mountinfo paths.

https: //btrfs.readthedocs.io/en/latest/btrfs-man5.html#mount-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Btrfs subvolume device resolution to properly handle mount options with path-based values by normalizing path representations and correctly stripping leading slashes before matching.

* **Tests**
  * Expanded test coverage to verify Btrfs subvolume device resolution by UUID works correctly with both absolute path-style and simple name-style formats in mount options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->