### PR TITLE
Include stratisd-dracut in packages required for stratis devices

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -48,7 +48,7 @@ class StratisPoolDevice(ContainerDevice):
 
     _type = "stratis pool"
     _resizable = False
-    _packages = ["stratisd", "stratis-cli"]
+    _packages = ["stratisd", "stratis-cli", "stratisd-dracut"]
     _dev_dir = "/dev/stratis"
     _format_immutable = True
     _external_dependencies = [availability.STRATISPREDICTUSAGE_APP, availability.STRATIS_DBUS]
@@ -280,7 +280,7 @@ class StratisFilesystemDevice(StorageDevice):
 
     _type = "stratis filesystem"
     _resizable = False
-    _packages = ["stratisd", "stratis-cli"]
+    _packages = ["stratisd", "stratis-cli", "stratisd-dracut"]
     _dev_dir = "/dev/stratis"
     _external_dependencies = [availability.STRATISPREDICTUSAGE_APP, availability.STRATIS_DBUS]
     _min_size = Size("512 MiB")


### PR DESCRIPTION
Needed for root FS on stratis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Stratis device configuration to ensure proper dracut and initramfs compatibility by including required package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->