### PR TITLE
Fix error messages when adding a device to stratis pool

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -308,10 +308,10 @@ def add_device(pool_uuid, device):
         proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, pool_info.object_path, STRATIS_POOL_INTF)
         ((succ, _paths), rc, err) = proxy.AddDataDevs([device], timeout=STRATIS_CALL_TIMEOUT)
     except DBusError as e:
-        raise StratisError("Failed to create stratis filesystem on '%s': %s" % (pool_info.name, str(e)))
+        raise StratisError("Failed to add device '%s' to stratis pool '%s': %s" % (device, pool_info.name, str(e)))
     else:
         if not succ:
-            raise StratisError("Failed to create stratis filesystem on '%s': %s (%d)" % (pool_info.name, err, rc))
+            raise StratisError("Failed to add device '%s' to stratis pool '%s': %s (%d)" % (device, pool_info.name, err, rc))
 
     # repopulate the stratis info cache so the new filesystem will be added
     stratis_info.drop_cache()

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -197,7 +197,7 @@ class StratisInfo(object):
             proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF_R8)
             pools_info = proxy.StoppedPools
         except DBusError as e:
-            log.error("Failed to get list of locked Stratis pools: %s", str(e))
+            log.error("Failed to get list of stopped Stratis pools: %s", str(e))
             return stopped_pools
 
         for pool_uuid in pools_info.keys():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when adding a device to a Stratis pool, making failures clearer by including the device, pool, and underlying error details.
  * Corrected logging for Stratis pool lookups so errors now accurately refer to stopped pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->