### PR TITLE
Always return Size instance when calculating stratis pool size

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -93,7 +93,7 @@ class StratisPoolDevice(ContainerDevice):
     def size(self):
         """ The size of this pool """
         # sum up the sizes of the block devices
-        return sum(parent.size for parent in self.parents)
+        return sum((parent.size for parent in self.parents), Size(0))
 
     @property
     def status(self):


### PR DESCRIPTION
For empty lists sum returns 0 (int), we need to make sure to always return Size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool size calculations so totals are computed more reliably across all size values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->