### PR TITLE
Do not try to get physical size for stopped stratis pools

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -103,7 +103,7 @@ class StratisPoolDevice(ContainerDevice):
 
     @property
     def _physical_size(self):
-        if self.exists:
+        if self.exists and self.status:
             pool_info = stratis_info.get_pool_info(self.name)
             if not pool_info:
                 raise DeviceError("Failed to get information about pool %s" % self.name)


### PR DESCRIPTION
We can't get this for stopped pools from the DBus API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stratis pool size handling when a pool exists but is not in a healthy/active state.
  * The app now falls back to the pool’s known size instead of trying to read metadata that may not be available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->