### PR TITLE
Add support for growing stratis filesystems

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -36,6 +36,7 @@ from ..size import Size, ROUND_DOWN
 from ..tasks import availability
 from ..util import default_namedtuple
 from .. import devicelibs
+from .. import util
 
 
 StratisClevisConfig = default_namedtuple("StratisClevisConfig", ["pin",
@@ -305,7 +306,12 @@ class StratisFilesystemDevice(StorageDevice):
     _external_dependencies = [availability.STRATISPREDICTUSAGE_APP, availability.STRATIS_DBUS]
     _min_size = Size("512 MiB")
 
-    def __init__(self, name, parents=None, size=None, uuid=None, exists=False):
+    def __init__(self, name, parents=None, size=None, uuid=None, exists=False,
+                 grow=None, maxsize=None):
+
+        self.req_grow = None
+        self.req_max_size = Size(0)
+        self.req_size = Size(0)
 
         if not exists and size is None and not parents[0]._overprovisioning:
             raise StratisError("size must be specified for stratis filesystems on non-overprovisioned pools")
@@ -323,6 +329,11 @@ class StratisFilesystemDevice(StorageDevice):
 
         super(StratisFilesystemDevice, self).__init__(name=name, size=size, uuid=uuid,
                                                       parents=parents, exists=exists)
+
+        if not self.exists:
+            self.req_grow = grow
+            self.req_max_size = Size(util.numeric_type(maxsize))
+            self.req_size = self._size
 
     def _get_name(self):
         """ This device's name. """
@@ -366,7 +377,7 @@ class StratisFilesystemDevice(StorageDevice):
         if not isinstance(newsize, Size):
             raise ValueError("new size must of type Size")
 
-        if not self.exists:
+        if not self.exists and not self.req_grow:
             if self.pool.overprovisioning:
                 md_size = devicelibs.stratis.filesystem_md_size(newsize)
                 if md_size > self.pool.free_space:

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -33,6 +33,7 @@ import _ped
 from .errors import DeviceError, PartitioningError, AlignmentError
 from .flags import flags
 from .devices import Device, PartitionDevice, device_path_to_name
+from .devices.lib import LINUX_SECTOR_SIZE
 from .size import Size
 from .i18n import _, N_
 from .util import compare
@@ -1158,6 +1159,27 @@ class LVRequest(Request):
         return reserve
 
 
+class StratisRequest(Request):
+
+    def __init__(self, fs):
+        """
+            :param fs: the stratis filesystem being requested
+            :type fs: :class:`~.devices.StratisFilesystemDevice`
+        """
+        super(StratisRequest, self).__init__(fs)
+        self.base = int(fs.size / LINUX_SECTOR_SIZE)
+
+        if fs.req_grow:
+            limits = [int(l / LINUX_SECTOR_SIZE) for l in
+                      (fs.req_max_size, fs.format.max_size) if l > Size(0)]
+
+            if limits:
+                max_sectors = min(limits)
+                self.max_growth = max_sectors - self.base
+                if self.max_growth <= 0:
+                    self.done = True
+
+
 class Chunk(object):
 
     """ A free region from which devices will be allocated """
@@ -1569,6 +1591,41 @@ class ThinPoolChunk(VGChunk):
         self.path = pool.path
         usable_extents = (pool.size / pool.vg.pe_size)
         super(VGChunk, self).__init__(usable_extents, requests=requests)  # pylint: disable=bad-super-call
+
+
+class StratisPoolChunk(Chunk):
+
+    """ A free region in a Stratis pool from which filesystems will be allocated """
+
+    def __init__(self, pool, requests=None):
+        """
+            :param pool: the stratis pool whose free space this chunk represents
+            :type pool: :class:`~.devices.StratisPoolDevice`
+            :keyword requests: list of requests to add initially
+            :type requests: list of :class:`StratisRequest`
+        """
+        self.pool = pool
+        self.path = pool.path
+        usable_size = pool._physical_size - pool._pool_metadata_size
+        usable_sectors = int(usable_size / LINUX_SECTOR_SIZE)
+        super(StratisPoolChunk, self).__init__(usable_sectors, requests=requests)
+
+    def add_request(self, req):
+        """ Add a request to this chunk.
+
+            :param req: the request to add
+            :type req: :class:`StratisRequest`
+        """
+        if not isinstance(req, StratisRequest):
+            raise ValueError(_("StratisPoolChunk requests must be of type StratisRequest"))
+
+        super(StratisPoolChunk, self).add_request(req)
+
+    def length_to_size(self, length):
+        return Size(length * LINUX_SECTOR_SIZE)
+
+    def size_to_length(self, size):
+        return int(size / LINUX_SECTOR_SIZE)
 
 
 def get_disk_chunks(disk, partitions, free):
@@ -2095,3 +2152,27 @@ def grow_lvm(storage):
             thin_chunk = ThinPoolChunk(pool, requests)
             thin_chunk.grow_requests()
             _apply_chunk_growth(thin_chunk)
+
+
+def grow_stratis(storage):
+    """ Grow Stratis filesystems according to the pool sizes. """
+    for pool in storage.stratis_pools:
+        if not pool.filesystems:
+            continue
+
+        total_free = pool.free_space
+        if total_free < 0:
+            # by now we have allocated the stratis block devices so if there isn't enough
+            # space in the pool we have a real problem
+            raise PartitioningError(_("not enough space for Stratis requests"))
+        elif not total_free:
+            log.debug("pool %s has no free space", pool.name)
+            continue
+
+        log.debug("pool %s: %s free ; filesystems: %s", pool.name, total_free,
+                  [fs.fsname for fs in pool.filesystems])
+
+        chunk = StratisPoolChunk(pool,
+                                 requests=[StratisRequest(fs) for fs in pool.filesystems])
+        chunk.grow_requests()
+        _apply_chunk_growth(chunk)

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -462,6 +462,109 @@ class StratisTestCaseClevis(StratisTestCaseBase):
         self.assertIsNone(pool._clevis.tang_thumbprint)
 
 
+class StratisGrowTestCase(StratisTestCaseBase):
+
+    _num_disks = 1
+    _disk_size = 5 * 1024**3
+
+    def test_stratis_grow(self):
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.storage.initialize_disk(disk)
+
+        bd = self.storage.new_partition(size=blivet.size.Size("4.5 GiB"), fmt_type="stratis",
+                                        parents=[disk])
+        self.storage.create_device(bd)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd])
+        self.storage.create_device(pool)
+
+        pool_free = pool.free_space
+
+        fs1 = self.storage.new_stratis_filesystem(name="blivetTestFS1", parents=[pool],
+                                                  size=blivet.size.Size("512 MiB"), grow=True)
+        self.storage.create_device(fs1)
+        fs2 = self.storage.new_stratis_filesystem(name="blivetTestFS2", parents=[pool],
+                                                  size=blivet.size.Size("512 MiB"), grow=True)
+        self.storage.create_device(fs2)
+
+        blivet.partitioning.grow_stratis(self.storage)
+
+        # both should grow equally to fill pool
+        self.assertAlmostEqual(fs1.size, fs2.size, delta=blivet.size.Size("1 MiB"))
+        self.assertAlmostEqual(fs1.size + fs2.size, pool_free, delta=blivet.size.Size("1 MiB"))
+        self.assertGreater(fs1.size, blivet.size.Size("512 MiB"))
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        fs1 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS1")
+        self.assertIsNotNone(fs1)
+        self.assertAlmostEqual(fs1.size, blivet.size.Size("1.9 GiB"), delta=blivet.size.Size("100 MiB"))
+
+        fs2 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS2")
+        self.assertIsNotNone(fs2)
+        self.assertAlmostEqual(fs2.size, blivet.size.Size("1.9 GiB"), delta=blivet.size.Size("100 MiB"))
+
+        pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
+        self.assertIsNotNone(pool)
+        self.assertAlmostEqual(pool.free_space, blivet.size.Size(0), delta=blivet.size.Size("10 MiB"))
+
+    def test_stratis_grow_maxsize(self):
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.storage.initialize_disk(disk)
+
+        bd = self.storage.new_partition(size=blivet.size.Size("4.5 GiB"), fmt_type="stratis",
+                                        parents=[disk])
+        self.storage.create_device(bd)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd])
+        self.storage.create_device(pool)
+
+        pool_free = pool.free_space
+
+        fs1 = self.storage.new_stratis_filesystem(name="blivetTestFS1", parents=[pool],
+                                                  size=blivet.size.Size("512 MiB"), grow=True)
+        self.storage.create_device(fs1)
+        fs2 = self.storage.new_stratis_filesystem(name="blivetTestFS2", parents=[pool],
+                                                  size=blivet.size.Size("512 MiB"), grow=True,
+                                                  maxsize=blivet.size.Size("550 MiB"))
+        self.storage.create_device(fs2)
+
+        blivet.partitioning.grow_stratis(self.storage)
+
+        # fs2 should be capped at maxsize
+        self.assertAlmostEqual(fs2.size, blivet.size.Size("550 MiB"), delta=blivet.size.Size("1 MiB"))
+        # fs1 gets the rest
+        self.assertAlmostEqual(fs1.size, pool_free - fs2.size, delta=blivet.size.Size("1 MiB"))
+        self.assertGreater(fs1.size, fs2.size)
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        fs1 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS1")
+        self.assertIsNotNone(fs1)
+        stratis_version = self._get_stratis_version()
+        if stratis_version <= Version("3.7.0"):
+            # older versions of stratis have smaller metadata
+            self.assertAlmostEqual(fs1.size, blivet.size.Size("3.44 GiB"), delta=blivet.size.Size("10 MiB"))
+        else:
+            self.assertAlmostEqual(fs1.size, blivet.size.Size("3.24 GiB"), delta=blivet.size.Size("10 MiB"))
+
+        fs2 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS2")
+        self.assertIsNotNone(fs2)
+        self.assertAlmostEqual(fs2.size, blivet.size.Size("550 MiB"), delta=blivet.size.Size("1 MiB"))
+
+        pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
+        self.assertIsNotNone(pool)
+        self.assertAlmostEqual(pool.free_space, blivet.size.Size(0), delta=blivet.size.Size("10 MiB"))
+
+
 class StratisDeviceFactoryTestCase(StratisTestCaseBase):
 
     _num_disks = 2

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, PropertyMock
 
 import blivet
+import blivet.partitioning
 
 from blivet.devices import StorageDevice
 from blivet.devices import StratisPoolDevice
@@ -215,3 +216,76 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
         fs = StratisFilesystemDevice("testfs", parents=[pool], size=Size("1 GiB") + Size(1))
         # size should be rounded down to 1 GiB
         self.assertEqual(fs.size, Size("1 GiB"))
+
+    @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
+    @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
+    def test_new_stratis_grow(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("10 GiB"), exists=False)
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd])
+            fs1 = b.new_stratis_filesystem(name="testfs1", parents=[pool],
+                                           size=Size("1 GiB"), grow=True)
+            fs2 = b.new_stratis_filesystem(name="testfs2", parents=[pool],
+                                           size=Size("1 GiB"), grow=True,
+                                           maxsize=Size("5 GiB"))
+
+        self.assertTrue(fs1.req_grow)
+        self.assertEqual(fs1.req_size, Size("1 GiB"))
+        self.assertEqual(fs1.req_max_size, Size(0))
+
+        self.assertTrue(fs2.req_grow)
+        self.assertEqual(fs2.req_size, Size("1 GiB"))
+        self.assertEqual(fs2.req_max_size, Size("5 GiB"))
+
+    @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
+    @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
+    def test_stratis_grow(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("10 GiB"), exists=False)
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd])
+            fs1 = b.new_stratis_filesystem(name="testfs1", parents=[pool],
+                                           size=Size("1 GiB"), grow=True)
+            fs2 = b.new_stratis_filesystem(name="testfs2", parents=[pool],
+                                           size=Size("1 GiB"), grow=True)
+
+        b.create_device(pool)
+        b.create_device(fs1)
+        b.create_device(fs2)
+
+        blivet.partitioning.grow_stratis(b)
+
+        self.assertEqual(fs1.size, Size("5 GiB"))
+        self.assertEqual(fs2.size, Size("5 GiB"))
+
+    @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
+    @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
+    def test_stratis_grow_maxsize(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("10 GiB"), exists=False)
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd])
+            fs1 = b.new_stratis_filesystem(name="testfs1", parents=[pool],
+                                           size=Size("1 GiB"), grow=True)
+            fs2 = b.new_stratis_filesystem(name="testfs2", parents=[pool],
+                                           size=Size("1 GiB"), grow=True,
+                                           maxsize=Size("3 GiB"))
+
+        b.create_device(pool)
+        b.create_device(fs1)
+        b.create_device(fs2)
+
+        blivet.partitioning.grow_stratis(b)
+
+        self.assertEqual(fs1.size, Size("7 GiB"))
+        self.assertEqual(fs2.size, Size("3 GiB"))

--- a/tests/unit_tests/partitioning_test.py
+++ b/tests/unit_tests/partitioning_test.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import parted
 
@@ -10,11 +10,15 @@ from blivet.partitioning import Request
 from blivet.partitioning import Chunk
 from blivet.partitioning import LVRequest
 from blivet.partitioning import VGChunk
+from blivet.partitioning import StratisRequest
+from blivet.partitioning import StratisPoolChunk
 
 from blivet.devices import StorageDevice
 from blivet.devices import LVMVolumeGroupDevice
 from blivet.devices import LVMLogicalVolumeDevice
 from blivet.devices import DiskDevice
+from blivet.devices import StratisPoolDevice
+from blivet.devices import StratisFilesystemDevice
 from blivet.devices.lvm import LVMCacheRequest
 
 from blivet.formats import get_format
@@ -379,3 +383,57 @@ class DiskTagsTestCase(unittest.TestCase):
         self.assertEqual(resolve_disk_tags(disks, ["0", "2"]), [disks[0], disks[2]])
         self.assertEqual(resolve_disk_tags(disks, ["local"]), disks)
         self.assertEqual(resolve_disk_tags(disks, ["canteloupe"]), [])
+
+
+STRATIS_DEVICE_CLASSES = [
+    StratisPoolDevice,
+    StratisFilesystemDevice,
+    StorageDevice
+]
+
+
+@unittest.skipUnless(not any(x.unavailable_type_dependencies() for x in STRATIS_DEVICE_CLASSES),
+                     "some unsupported device classes required for this test")
+class StratisPartitioningTestCase(unittest.TestCase):
+
+    @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
+    @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
+    def test_stratis_pool_chunk(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        bd = StorageDevice("bd1", fmt=get_format("stratis"),
+                           size=Size("10 GiB"), exists=True)
+        pool = StratisPoolDevice("testpool", parents=[bd])
+
+        fs1 = StratisFilesystemDevice("testfs1", parents=[pool],
+                                      size=Size("1 GiB"), grow=True)
+        fs2 = StratisFilesystemDevice("testfs2", parents=[pool],
+                                      size=Size("1 GiB"), grow=True)
+        fs3 = StratisFilesystemDevice("testfs3", parents=[pool],
+                                      size=Size("1 GiB"), grow=True,
+                                      maxsize=Size("3 GiB"))
+
+        req1 = StratisRequest(fs1)
+        req2 = StratisRequest(fs2)
+        req3 = StratisRequest(fs3)
+        chunk = StratisPoolChunk(pool, requests=[req1, req2, req3])
+
+        self.assertEqual(chunk.length, int(Size("10 GiB") / 512))
+        self.assertEqual(chunk.pool, int(Size("7 GiB") / 512))
+        self.assertEqual(chunk.base, 3 * int(Size("1 GiB") / 512))
+
+        self.assertEqual(chunk.length_to_size(2), Size(1024))
+        self.assertEqual(chunk.size_to_length(Size(1024)), 2)
+        self.assertTrue(chunk.has_growable)
+
+        self.assertEqual(chunk.remaining, 3)
+        self.assertFalse(chunk.done)
+
+        chunk.grow_requests()
+
+        self.assertTrue(chunk.done)
+        self.assertEqual(chunk.remaining, 2)
+
+        # fs3 is capped at maxsize=3 GiB (growth of 2 GiB)
+        self.assertEqual(req3.growth, int(Size("2 GiB") / 512))
+        # remaining 5 GiB split equally between fs1 and fs2 (2.5 GiB each)
+        self.assertEqual(req1.growth, int(Size("2.5 GiB") / 512))
+        self.assertEqual(req2.growth, int(Size("2.5 GiB") / 512))


### PR DESCRIPTION
Same as for LVM and LVs. Introduces a new "grow_stratis" function similar to "grow_lvm".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stratis filesystem auto-growth using available pool free space.
  * Growth is balanced across multiple grow-enabled filesystems.
  * Introduced per-filesystem grow controls, including optional maximum-size caps.
* **Bug Fixes**
  * Improved handling of pool free-space validation during requested growth workflows.
* **Tests**
  * Added/expanded unit and integration tests covering balanced growth, maxsize capping, and size persistence across apply/reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->