### PR TITLE
Fix checking for success when starting encrypted stratis pools

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -199,8 +199,11 @@ def _unlock_pool_new(pool_uuid, method=None, passphrase=None, keyfile=None):
     try:
         proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF_R8,
                                          client=GLibClientUnix)
-        (succ, err, _blockdevs) = proxy.StartPool(pool_uuid, "uuid", (True, (False, 0)), key_arg,
-                                                  timeout=STRATIS_CALL_TIMEOUT)
+        ((succ, (_pool, _bd, _fs)), _code, err) = proxy.StartPool(pool_uuid,
+                                                                  "uuid",
+                                                                  (True, (False, 0)),
+                                                                  key_arg,
+                                                                  timeout=STRATIS_CALL_TIMEOUT)
     except DBusError as e:
         raise StratisError("Failed to unlock pool: %s" % str(e))
     else:

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -377,6 +377,12 @@ class StratisTestCase(StratisTestCaseBase):
         with self.assertRaisesRegex(blivet.errors.StratisError, "Passphrase or key file must be set for encrypted Stratis pool setup"):
             pool.setup()
 
+        # wrong passphrase
+        pool.passphrase = "wrongpassphrase"
+        with self.assertRaisesRegex(blivet.errors.StratisError, "Operation not permitted"):
+            pool.setup()
+
+        # coreect passphrase
         pool.passphrase = "fipsneeds8chars"
         pool.setup()
         self.assertTrue(pool.status)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when starting Stratis pools through newer system interfaces.
  - Incorrect passphrases for encrypted Stratis pools are now handled consistently, with a clear “Operation not permitted” error.
  - Correct passphrases continue to unlock and start encrypted pools successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->