### PR TITLE
Try to stop stopped encrypted stratis pools before removing them

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -339,7 +339,11 @@ def stop_pool(pool_uuid):
     # repopulate the stratis info cache just to be sure all values are still valid
     stratis_info.drop_cache()
 
-    pool_info = stratis_info.pools[pool_uuid]
+    if pool_uuid in stratis_info.pools.keys():
+        pool_info = stratis_info.pools[pool_uuid]
+    else:
+        # maybe already stopped or partially constructed pool
+        pool_info = next((pool for pool in stratis_info.stopped_pools if pool.uuid == pool_uuid), None)
 
     if not pool_info:
         raise StratisError("Stratis pool %s not found" % pool_uuid)

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -275,6 +275,15 @@ class StratisPoolDevice(ContainerDevice):
             # action here will be noop and pool will be removed by removing the block devices
             log.info("Ignoring destroy action for stopped stratis pool %s", self.name)
 
+            # XXX encrypted pools can be in "partially constructed" state, we cannot detect this
+            # state using the DBus API and if we don't stop this pool (which is already marked
+            # as stopped!) we cannot remove it because there are existing private stratis DM devices
+            if self.encrypted and not self.has_key:
+                try:
+                    self._teardown()
+                except StratisError as e:
+                    log.debug("Failed to stop stratis pool %s: %s", self.name, str(e))
+
     def add_hook(self, new=True):
         super(StratisPoolDevice, self).add_hook(new=new)
         if new:

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -182,7 +182,14 @@ class StratisFormatPopulator(FormatPopulator):
                     # we cannot add a device without name
                     log.warning("Ignoring stopped stratis pool %s without name", pool_info.uuid)
                     return
-                pool_device = self._add_stopped_pool_device(pool_info)
+
+                pool_device = self._devicetree.get_device_by_uuid(pool_info.uuid)
+                if pool_device and self.device not in pool_device.parents:
+                    pool_device.parents.append(self.device)
+                    callbacks.parent_added(device=pool_device, parent=self.device)
+                    return
+                else:
+                    pool_device = self._add_stopped_pool_device(pool_info)
             else:
                 # no stopped pool info, no bd info -> nothing we can do
                 return

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -283,17 +283,23 @@ class StratisTestCase(StratisTestCaseBase):
         if stratis_version < Version("3.8.0"):
             self.skipTest("Stratis 3.8.0 or newer needed for start/stop support")
 
-        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
-        self.assertIsNotNone(disk)
-        self.storage.initialize_disk(disk)
+        disk1 = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk1)
+        self.storage.initialize_disk(disk1)
+        disk2 = self.storage.devicetree.get_device_by_path(self.vdevs[1])
+        self.assertIsNotNone(disk2)
+        self.storage.initialize_disk(disk2)
 
-        bd = self.storage.new_partition(size=blivet.size.Size("1.5 GiB"), fmt_type="stratis",
-                                        parents=[disk])
-        self.storage.create_device(bd)
+        bd1 = self.storage.new_partition(size=blivet.size.Size("1.5 GiB"), fmt_type="stratis",
+                                         parents=[disk1])
+        self.storage.create_device(bd1)
+        bd2 = self.storage.new_partition(size=blivet.size.Size("1.5 GiB"), fmt_type="stratis",
+                                         parents=[disk2])
+        self.storage.create_device(bd2)
 
         blivet.partitioning.do_partitioning(self.storage)
 
-        pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd])
+        pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd1, bd2])
         self.storage.create_device(pool)
 
         fs = self.storage.new_stratis_filesystem(name="blivetTestFS", parents=[pool],
@@ -306,6 +312,7 @@ class StratisTestCase(StratisTestCaseBase):
         pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
         self.assertIsNotNone(pool)
         self.assertTrue(pool.status)
+        self.assertEqual(len(pool.parents), 2)
 
         # try teardown and setup
         pool.teardown()
@@ -320,6 +327,7 @@ class StratisTestCase(StratisTestCaseBase):
         pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
         self.assertIsNotNone(pool)
         self.assertFalse(pool.status)
+        self.assertEqual(len(pool.parents), 2)
 
         # start the pool again to be able to remove it
         pool.setup()


### PR DESCRIPTION
Stopped pools can be in "partially constructed" state which prevents us from removing them unless we stop them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stopped encrypted Stratis pools when the encryption key isn’t available, reducing failures during teardown/removal.
  * Made stopping Stratis pools more fault-tolerant when pool status data is incomplete or only partially present.
  * Refined stopped-pool device handling to reuse an existing device by UUID when possible.
* **Tests**
  * Expanded Stratis start/stop coverage for multi-device pools and added assertions that the correct parent set is preserved across lifecycle operations and reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->