### PR TITLE
LUKS data and save passphrase rework for Stratis

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -48,7 +48,7 @@ from . import devicefactory
 from . import __version__
 from . import devicelibs
 from .threads import SynchronizedMeta
-from .static_data import luks_data
+from .static_data import encryption_data
 
 import logging
 log = logging.getLogger("blivet")
@@ -357,14 +357,14 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
     @property
     def encryption_passphrase(self):
-        return luks_data.encryption_passphrase
+        return encryption_data.encryption_passphrase
 
     @encryption_passphrase.setter
     def encryption_passphrase(self, value):
-        luks_data.encryption_passphrase = value
+        encryption_data.encryption_passphrase = value
 
     def save_passphrase(self, device):
-        luks_data.save_passphrase(device)
+        encryption_data.save_passphrase(device)
 
     def recursive_remove(self, device):
         """ Remove a device after removing its dependent devices.

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -37,7 +37,7 @@ from .callbacks import ResizeFormatPreData, ResizeFormatPostData
 from .callbacks import WaitForEntropyData, ReportProgressData
 from .size import Size
 from .threads import SynchronizedMeta
-from .static_data import luks_data
+from .static_data import encryption_data
 
 import logging
 log = logging.getLogger("blivet")
@@ -669,7 +669,7 @@ class ActionCreateFormat(DeviceAction):
                     log.warning("Forcing LUKS creation regardless of enough "
                                 "random data entropy (%d/%d)",
                                 get_current_entropy(), min_required_entropy)
-                    luks_data.min_entropy = 0
+                    encryption_data.min_entropy = 0
 
         self.device.setup()
         self.device.format.create(device=self.device.path,

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -40,7 +40,7 @@ from .partitioning import SameSizeSet
 from .partitioning import TotalSizeSet
 from .partitioning import do_partitioning
 from .size import Size
-from .static_data import luks_data
+from .static_data import encryption_data
 
 import gi
 gi.require_version("BlockDev", "3.0")
@@ -377,7 +377,7 @@ class DeviceFactory(object):
         self.min_luks_entropy = kwargs.get("min_luks_entropy")
 
         if self.min_luks_entropy is None:
-            self.min_luks_entropy = luks_data.min_entropy
+            self.min_luks_entropy = encryption_data.min_entropy
 
         self.luks_version = kwargs.get("luks_version") or crypto.DEFAULT_LUKS_VERSION
         self.pbkdf_args = kwargs.get("pbkdf_args", None)

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -35,7 +35,7 @@ from ..flags import flags
 from ..i18n import _, N_
 from ..tasks import availability, lukstasks
 from ..size import Size, KiB
-from ..static_data import luks_data
+from ..static_data import encryption_data
 from .. import udev
 
 import logging
@@ -176,7 +176,7 @@ class LUKS(DeviceFormat):
 
         self.min_luks_entropy = kwargs.get("min_luks_entropy")
         if self.min_luks_entropy is None:
-            self.min_luks_entropy = luks_data.min_entropy
+            self.min_luks_entropy = encryption_data.min_entropy
 
         if not self.map_name and self.exists and self.uuid:
             self.map_name = "luks-%s" % self.uuid
@@ -396,15 +396,15 @@ class LUKS(DeviceFormat):
         super(LUKS, self)._create(**kwargs)  # set up the event sync
 
         if not self.pbkdf_args and self.luks_version.startswith("luks2"):
-            if luks_data.pbkdf_args:
-                self.pbkdf_args = luks_data.pbkdf_args
+            if encryption_data.pbkdf_args:
+                self.pbkdf_args = encryption_data.pbkdf_args
             else:
                 # argon is not used with FIPS so we don't need to adjust the memory when in FIPS mode
                 if not crypto.is_fips_enabled():
                     mem_limit = crypto.calculate_luks2_max_memory()
                     if mem_limit:
                         self.pbkdf_args = LUKS2PBKDFArgs(max_memory_kb=int(mem_limit.convert_to(KiB)))
-                        luks_data.pbkdf_args = self.pbkdf_args
+                        encryption_data.pbkdf_args = self.pbkdf_args
                         log.info("PBKDF arguments for LUKS2 not specified, using defaults with memory limit %s", mem_limit)
 
         if not self.luks_sector_size and self.luks_version.startswith("luks2"):

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -31,7 +31,7 @@ from ...errors import DeviceError, LUKSError
 from ...flags import flags
 from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
-from ...static_data import luks_data
+from ...static_data import encryption_data
 
 import logging
 log = logging.getLogger("blivet")
@@ -130,12 +130,12 @@ class LUKSFormatPopulator(FormatPopulator):
 
         # look up or create the mapped device
         if not self._devicetree.get_device_by_device_id("LUKS-" + self.device.format.map_name):
-            passphrase = luks_data.luks_devs.get(self.device.format.uuid)
+            passphrase = encryption_data.luks_devs.get(self.device.format.uuid)
             if self.device.format.configured:
                 pass
             elif passphrase:
                 self.device.format.passphrase = passphrase
-            elif self.device.format.uuid in luks_data.luks_devs:
+            elif self.device.format.uuid in encryption_data.luks_devs:
                 log.info("skipping previously-skipped luks device %s",
                          self.device.name)
             elif self._devicetree._cleanup or flags.testing:
@@ -145,11 +145,11 @@ class LUKSFormatPopulator(FormatPopulator):
                     # this makes device.configured return True
                     self.device.format.passphrase = 'yabbadabbadoo'
             else:
-                # Try each known passphrase. Include luks_data.luks_devs values in case a
+                # Try each known passphrase. Include encryption_data.luks_devs values in case a
                 # passphrase has been set for a specific device without a full
                 # reset/populate, in which case the new passphrase would not be
-                # in luks_data.passphrases.
-                passphrases = luks_data.passphrases + list(luks_data.luks_devs.values())
+                # in encryption_data.passphrases.
+                passphrases = encryption_data.passphrases + list(encryption_data.luks_devs.values())
                 for passphrase in passphrases:
                     self.device.format.passphrase = passphrase
                     try:

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -33,7 +33,7 @@ from ...errors import StratisError
 from ...flags import flags
 from .formatpopulator import FormatPopulator
 
-from ...static_data import stratis_info
+from ...static_data import encryption_data, stratis_info
 
 import logging
 log = logging.getLogger("blivet")
@@ -130,6 +130,40 @@ class StratisFormatPopulator(FormatPopulator):
             self._devicetree.handle_format(udev_info, fs_device)
             fs_device.original_format = copy.deepcopy(fs_device.format)
 
+    def _unlock_locked_pool(self, pool):
+        """ Try to unlock a locked stratis pool using known passphrases. """
+        passphrase = encryption_data.stratis_devs.get(pool.uuid)
+        if passphrase:
+            # we have passphrase for this pool saved
+            pool.passphrase = passphrase
+            try:
+                pool.setup()
+            except StratisError:
+                pool.passphrase = None
+                log.warning("Failed to activate encrypted Stratis pool %s with saved passphrase",
+                            pool.name)
+                # XXX unlocking stratis pool with a wrong passphrase leaves it in inconsistent state
+                pool._teardown()
+                return False
+            else:
+                return True
+        else:
+            # no passphrase, try every other passphrase we know
+            passphrases = encryption_data.passphrases + list(encryption_data.stratis_devs.values())
+            for passphrase in passphrases:
+                pool.passphrase = passphrase
+                try:
+                    pool.setup()
+                except StratisError:
+                    pool.passphrase = None
+                    # XXX unlocking stratis pool with a wrong passphrase leaves it in inconsistent state
+                    pool._teardown()
+                else:
+                    encryption_data.save_passphrase(pool)
+                    return True
+
+        return False
+
     def _add_pool_device(self):
         bd_info = stratis_info.blockdevs.get(self.device.format.uuid)
         if not bd_info:
@@ -173,11 +207,14 @@ class StratisFormatPopulator(FormatPopulator):
                         bd_info.pool_name, bd_info.pool_uuid)
             return
 
-        if flags.auto_dev_updates and pool_device and not pool_device.status and not pool_device.encrypted:
-            try:
-                pool_device.setup()
-            except StratisError as e:
-                log.warning("Failed to activate Stratis pool %s: %s", pool_device.name, str(e))
+        if flags.auto_dev_updates and pool_device and not pool_device.status:
+            if not pool_device.encrypted:
+                try:
+                    pool_device.setup()
+                except StratisError as e:
+                    log.warning("Failed to activate Stratis pool %s: %s", pool_device.name, str(e))
+            else:
+                self._unlock_locked_pool(pool_device)
 
         # now add the filesystems
         self._add_filesystems(pool_device.uuid)

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -47,7 +47,7 @@ from ..storage_log import log_method_call
 from ..tasks import availability
 from ..threads import SynchronizedMeta
 from .helpers import get_device_helper, get_format_helper
-from ..static_data import lvs_info, pvs_info, vgs_info, luks_data, mpath_members, stratis_info
+from ..static_data import lvs_info, pvs_info, vgs_info, encryption_data, mpath_members, stratis_info
 from ..callbacks import callbacks
 
 import logging
@@ -76,11 +76,11 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             :keyword disk_images: dictionary of disk images
             :type list: dict
         """
-        luks_data.reset(passphrase=None, luks_dict={})
+        encryption_data.reset(passphrase=None, luks_dict={})
         self.reset(disk_images=disk_images)
 
     def reset(self, disk_images=None):
-        luks_data.reset()
+        encryption_data.reset()
         self.disk_images = {}
         if disk_images:
             # this will overwrite self.exclusive_disks
@@ -458,7 +458,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
     def save_luks_passphrase(self, device):
         """ Save a device's LUKS passphrase in case of reset. """
         # Method is here for compatibility with blivet 1.x
-        luks_data.save_passphrase(device)
+        encryption_data.save_passphrase(device)
 
     def populate(self, cleanup_only=False):
         """ Locate all storage devices.

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -76,7 +76,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             :keyword disk_images: dictionary of disk images
             :type list: dict
         """
-        encryption_data.reset(passphrase=None, luks_dict={})
+        encryption_data.reset(passphrase=None, luks_dict={}, stratis_dict={})
         self.reset(disk_images=disk_images)
 
     def reset(self, disk_images=None):

--- a/blivet/static_data/__init__.py
+++ b/blivet/static_data/__init__.py
@@ -1,4 +1,5 @@
 from .lvm_info import lvs_info, pvs_info, vgs_info
+from .encryption_data import encryption_data
 from .luks_data import luks_data
 from .mpath_info import mpath_members
 from .stratis_info import stratis_info

--- a/blivet/static_data/encryption_data.py
+++ b/blivet/static_data/encryption_data.py
@@ -1,0 +1,107 @@
+# encryption_data.py
+# Backend code for populating a DeviceTree.
+#
+# Copyright (C) 2009-2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): Jan Pokorny <japokorn@redhat.com>
+#
+
+
+class Encryption_Data(object):
+    """ Class to be used as a singleton.
+        Maintains the encryption data.
+    """
+
+    def __init__(self):
+        # new passphrase; used while working with new device
+        self.__encryption_passphrase = None
+        # minimum entropy in bits required for LUKS format creation
+        self.__min_entropy = 0
+        # list of known passphrases
+        self.__passphrases = []
+        # dict of luks devices {device: passphrase}
+        self.__luks_devs = {}
+        # default pbkdf parameters for LUKS2 format creation
+        self._pbkdf_args = None
+
+    @property
+    def encryption_passphrase(self):
+        return self.__encryption_passphrase
+
+    @encryption_passphrase.setter
+    def encryption_passphrase(self, value):
+        self.__encryption_passphrase = value
+
+    @property
+    def min_entropy(self):
+        return self.__min_entropy
+
+    @min_entropy.setter
+    def min_entropy(self, value):
+        if value < 0:
+            msg = "Invalid value for minimum required entropy: %s" % value
+            raise ValueError(msg)
+        self.__min_entropy = value
+
+    @property
+    def luks_devs(self):
+        return self.__luks_devs
+
+    @luks_devs.setter
+    def luks_devs(self, value):
+        self.__luks_devs = value
+
+    @property
+    def pbkdf_args(self):
+        return self._pbkdf_args
+
+    @pbkdf_args.setter
+    def pbkdf_args(self, value):
+        self._pbkdf_args = value
+
+    def clear_passphrases(self):
+        self.__passphrases = []
+
+    def add_passphrase(self, passphrase):
+        if passphrase:
+            self.__passphrases.append(passphrase)
+
+    def add_passphrases(self, passphrases):
+        self.__passphrases.extend(passphrases)
+
+    def save_passphrase(self, device):
+        """ Save a device's LUKS passphrase in case of reset. """
+        pctx = device.format.contexts.get_context("passphrase")
+        passphrase = pctx and pctx._passphrase
+        if passphrase:
+            encryption_data.luks_devs[device.format.uuid] = passphrase
+            self.add_passphrase(passphrase)
+
+    def reset(self, passphrase=None, luks_dict=None):
+        self.clear_passphrases()
+        self.add_passphrase(passphrase)
+        self.luks_devs = {}
+        if luks_dict and isinstance(luks_dict, dict):
+            self.luks_devs = luks_dict
+            self.add_passphrases([p for p in self.luks_devs.values() if p])
+
+    @property
+    def passphrases(self):
+        return self.__passphrases
+
+
+encryption_data = Encryption_Data()

--- a/blivet/static_data/encryption_data.py
+++ b/blivet/static_data/encryption_data.py
@@ -101,8 +101,8 @@ class Encryption_Data(object):
             encryption_data.stratis_devs[device.uuid] = passphrase
         else:
             pctx = device.format.contexts.get_context("passphrase")
-            encryption_data.luks_devs[device.format.uuid] = passphrase
             passphrase = pctx and pctx._passphrase
+            encryption_data.luks_devs[device.format.uuid] = passphrase
         if passphrase:
             self.add_passphrase(passphrase)
 

--- a/blivet/static_data/encryption_data.py
+++ b/blivet/static_data/encryption_data.py
@@ -35,6 +35,8 @@ class Encryption_Data(object):
         self.__passphrases = []
         # dict of luks devices {device: passphrase}
         self.__luks_devs = {}
+        # dict of stratis devices {pool: passphrase}
+        self.__stratis_devs = {}
         # default pbkdf parameters for LUKS2 format creation
         self._pbkdf_args = None
 
@@ -66,6 +68,14 @@ class Encryption_Data(object):
         self.__luks_devs = value
 
     @property
+    def stratis_devs(self):
+        return self.__stratis_devs
+
+    @stratis_devs.setter
+    def stratis_devs(self, value):
+        self.__stratis_devs = value
+
+    @property
     def pbkdf_args(self):
         return self._pbkdf_args
 
@@ -84,20 +94,29 @@ class Encryption_Data(object):
         self.__passphrases.extend(passphrases)
 
     def save_passphrase(self, device):
-        """ Save a device's LUKS passphrase in case of reset. """
-        pctx = device.format.contexts.get_context("passphrase")
-        passphrase = pctx and pctx._passphrase
-        if passphrase:
+        """ Save a device's encryption passphrase in case of reset. """
+        passphrase = None
+        if device.type == "stratis pool":
+            passphrase = device._StratisPoolDevice__passphrase
+            encryption_data.stratis_devs[device.uuid] = passphrase
+        else:
+            pctx = device.format.contexts.get_context("passphrase")
             encryption_data.luks_devs[device.format.uuid] = passphrase
+            passphrase = pctx and pctx._passphrase
+        if passphrase:
             self.add_passphrase(passphrase)
 
-    def reset(self, passphrase=None, luks_dict=None):
+    def reset(self, passphrase=None, luks_dict=None, stratis_dict=None):
         self.clear_passphrases()
         self.add_passphrase(passphrase)
         self.luks_devs = {}
+        self.stratis_devs = {}
         if luks_dict and isinstance(luks_dict, dict):
             self.luks_devs = luks_dict
             self.add_passphrases([p for p in self.luks_devs.values() if p])
+        if stratis_dict and isinstance(stratis_dict, dict):
+            self.stratis_devs = stratis_dict
+            self.add_passphrases([p for p in self.stratis_devs.values() if p])
 
     @property
     def passphrases(self):

--- a/blivet/static_data/luks_data.py
+++ b/blivet/static_data/luks_data.py
@@ -1,5 +1,5 @@
 # luks_data.py
-# Backend code for populating a DeviceTree.
+# Backward compatibility shim -- the canonical module is encryption_data.py.
 #
 # Copyright (C) 2009-2016  Red Hat, Inc.
 #
@@ -20,88 +20,5 @@
 # Red Hat Author(s): Jan Pokorny <japokorn@redhat.com>
 #
 
-
-class LUKS_Data(object):
-    """ Class to be used as a singleton.
-        Maintains the LUKS data.
-    """
-
-    def __init__(self):
-        # new passphrase; used while working with new device
-        self.__encryption_passphrase = None
-        # minimum entropy in bits required for LUKS format creation
-        self.__min_entropy = 0
-        # list of known passphrases
-        self.__passphrases = []
-        # dict of luks devices {device: passphrase}
-        self.__luks_devs = {}
-        # default pbkdf parameters for LUKS2 format creation
-        self._pbkdf_args = None
-
-    @property
-    def encryption_passphrase(self):
-        return self.__encryption_passphrase
-
-    @encryption_passphrase.setter
-    def encryption_passphrase(self, value):
-        self.__encryption_passphrase = value
-
-    @property
-    def min_entropy(self):
-        return self.__min_entropy
-
-    @min_entropy.setter
-    def min_entropy(self, value):
-        if value < 0:
-            msg = "Invalid value for minimum required entropy: %s" % value
-            raise ValueError(msg)
-        self.__min_entropy = value
-
-    @property
-    def luks_devs(self):
-        return self.__luks_devs
-
-    @luks_devs.setter
-    def luks_devs(self, value):
-        self.__luks_devs = value
-
-    @property
-    def pbkdf_args(self):
-        return self._pbkdf_args
-
-    @pbkdf_args.setter
-    def pbkdf_args(self, value):
-        self._pbkdf_args = value
-
-    def clear_passphrases(self):
-        self.__passphrases = []
-
-    def add_passphrase(self, passphrase):
-        if passphrase:
-            self.__passphrases.append(passphrase)
-
-    def add_passphrases(self, passphrases):
-        self.__passphrases.extend(passphrases)
-
-    def save_passphrase(self, device):
-        """ Save a device's LUKS passphrase in case of reset. """
-        pctx = device.format.contexts.get_context("passphrase")
-        passphrase = pctx and pctx._passphrase
-        if passphrase:
-            luks_data.luks_devs[device.format.uuid] = passphrase
-            self.add_passphrase(passphrase)
-
-    def reset(self, passphrase=None, luks_dict=None):
-        self.clear_passphrases()
-        self.add_passphrase(passphrase)
-        self.luks_devs = {}
-        if luks_dict and isinstance(luks_dict, dict):
-            self.luks_devs = luks_dict
-            self.add_passphrases([p for p in self.luks_devs.values() if p])
-
-    @property
-    def passphrases(self):
-        return self.__passphrases
-
-
-luks_data = LUKS_Data()
+from .encryption_data import Encryption_Data as LUKS_Data  # pylint: disable=unused-import
+from .encryption_data import encryption_data as luks_data  # pylint: disable=unused-import

--- a/tests/storage_tests/formats_test/luks_test.py
+++ b/tests/storage_tests/formats_test/luks_test.py
@@ -297,7 +297,7 @@ class LUKSResetTestCase(StorageTestCase):
         self.storage.format_device(disk, fmt)
         self.storage.do_it()
 
-        blivet.static_data.luks_data.save_passphrase(disk)
+        blivet.static_data.encryption_data.save_passphrase(disk)
         self.storage.devicetree.populate()
 
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
@@ -306,7 +306,7 @@ class LUKSResetTestCase(StorageTestCase):
 
         # remove passphrase and try to save it (should not fail)
         disk.format.passphrase = None
-        blivet.static_data.luks_data.save_passphrase(disk)
+        blivet.static_data.encryption_data.save_passphrase(disk)
 
     def test_label_subsystem(self):
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])

--- a/tests/unit_tests/formats_tests/luks_test.py
+++ b/tests/unit_tests/formats_tests/luks_test.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 
 from blivet.formats.luks import LUKS
 from blivet.size import Size
-from blivet.static_data import luks_data
+from blivet.static_data import encryption_data
 from blivet import blockdev
 
 
 class LUKSNodevTestCase(unittest.TestCase):
     def setUp(self):
-        luks_data.pbkdf_args = None
+        encryption_data.pbkdf_args = None
 
     def test_create_discard_option(self):
         # flags.discard_new=False --> no discard


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized encryption settings and passphrase management using shared encryption data.
  * Improved automatic unlocking of encrypted Stratis pools by trying saved and known passphrases, and saving the successful one.
  * Persisted LUKS2 PBKDF defaults (including memory limits) for smoother future LUKS device creation.

* **Bug Fixes**
  * Improved consistency of passphrase saving/loading across LUKS and Stratis flows.
  * Ensured entropy override uses the centralized minimum-entropy value during forced LUKS creation.
  * Kept backward compatibility via a legacy LUKS data shim.

* **Tests**
  * Updated LUKS tests to validate the new encryption data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->