### PR TITLE
Remove support for pre 3.8.0 encrypted stratis pools

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -164,24 +164,10 @@ def set_key(key_desc, passphrase, key_file):
             os.close(write)
 
 
-def _unlock_pool_old(pool_uuid, method=None, desc=None, passphrase=None, keyfile=None):
-    if method == "keyring":
-        set_key(desc, passphrase, keyfile)
+def unlock_pool(pool_uuid, method=None, passphrase=None, keyfile=None):
+    if not availability.STRATIS_DBUS.available:
+        raise StratisError("Stratis DBus service not available")
 
-    try:
-        proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF)
-        (succ, err, _blockdevs) = proxy.UnlockPool(pool_uuid, method)
-    except DBusError as e:
-        raise StratisError("Failed to unlock pool: %s" % str(e))
-    else:
-        if not succ:
-            raise StratisError("Failed to unlock pool: %s" % err)
-    finally:
-        # repopulate the stratis info cache so the started pool is in correct list of pools
-        stratis_info.drop_cache()
-
-
-def _unlock_pool_new(pool_uuid, method=None, passphrase=None, keyfile=None):
     if method == "keyring":
         if passphrase:
             (read, write) = os.pipe()
@@ -214,18 +200,6 @@ def _unlock_pool_new(pool_uuid, method=None, passphrase=None, keyfile=None):
             os.close(write)
         # repopulate the stratis info cache so the started pool is in correct list of pools
         stratis_info.drop_cache()
-
-
-def unlock_pool(pool_uuid, method, desc=None, passphrase=None, keyfile=None):
-    if not availability.STRATIS_DBUS.available:
-        raise StratisError("Stratis DBus service not available")
-
-    ret = util.check_object_available(STRATIS_SERVICE, STRATIS_PATH,
-                                      iface=STRATIS_MANAGER_INTF_R8)
-    if ret:
-        return _unlock_pool_new(pool_uuid, method, passphrase, keyfile)
-    else:
-        return _unlock_pool_old(pool_uuid, method, desc, passphrase, keyfile)
 
 
 def create_pool(name, devices, encrypted, passphrase, key_file, clevis, overprovisioning):

--- a/blivet/formats/stratis.py
+++ b/blivet/formats/stratis.py
@@ -20,13 +20,9 @@
 # Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
 #
 
-import os
-
 from ..storage_log import log_method_call
 from ..i18n import N_
 from ..size import Size
-from ..errors import StratisError
-from ..devicelibs import stratis
 from . import DeviceFormat, register_device_format
 
 import logging
@@ -54,16 +50,6 @@ class StratisBlockdev(DeviceFormat):
             :type exists: bool
             :keyword pool_name: the name of the pool this block device belongs to
             :keyword pool_uuid: the UUID of the pool this block device belongs to
-            :keyword locked_pool: whether this block device belongs to a locked pool or not
-            :type locked_pool: bool
-            :keyword locked_pool_key_desc: kernel keyring description for locked pool
-            :type locked_pool_key_desc: str
-            :keyword passphrase: passphrase for the locked pool
-            :type passphrase: str
-            :keyword key_file: path to a file containing a key
-            :type key_file: str
-            :keyword locked_pool_clevis_pin: clevis PIN for locked pool (either 'tang' or 'tpm')
-            :type locked_pool_clevis_pin: str
 
             .. note::
 
@@ -78,18 +64,11 @@ class StratisBlockdev(DeviceFormat):
 
         self.pool_name = kwargs.get("pool_name")
         self.pool_uuid = kwargs.get("pool_uuid")
-        self.locked_pool = kwargs.get("locked_pool")
-        self.locked_pool_key_desc = kwargs.get("locked_pool_key_desc")
-        self.locked_pool_clevis_pin = kwargs.get("locked_pool_clevis_pin")
-
-        self.__passphrase = kwargs.get("passphrase")
-        self._key_file = kwargs.get("key_file")
 
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
-        s += ("  pool_name = %(pool_name)s  pool_uuid = %(pool_uuid)s  locked_pool = %(locked_pool)s" %
-              {"pool_name": self.pool_name, "pool_uuid": self.pool_uuid,
-               "locked_pool": self.locked_pool})
+        s += ("  pool_name = %(pool_name)s  pool_uuid = %(pool_uuid)s" %
+              {"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
         return s
 
     @property
@@ -101,35 +80,6 @@ class StratisBlockdev(DeviceFormat):
         d = super(StratisBlockdev, self).dict
         d.update({"pool_name": self.pool_name, "pool_uuid": self.pool_uuid})
         return d
-
-    @property
-    def key_file(self):
-        """ Path to key file to be used in /etc/crypttab """
-        return self._key_file
-
-    def _set_passphrase(self, passphrase):
-        """ Set the passphrase used to access this device. """
-        self.__passphrase = passphrase
-
-    passphrase = property(fset=_set_passphrase)
-
-    @property
-    def has_key(self):
-        return bool((self.__passphrase not in ["", None]) or
-                    (self._key_file and os.access(self._key_file, os.R_OK)))
-
-    def unlock_pool(self):
-        if not self.locked_pool:
-            raise StratisError("This device doesn't contain a locked Stratis pool")
-
-        if not self.has_key and not self.locked_pool_clevis_pin:
-            raise StratisError("No passphrase/key file for the locked Stratis pool")
-
-        if self.has_key:
-            stratis.unlock_pool(self.pool_uuid, method="keyring", desc=self.locked_pool_key_desc,
-                                passphrase=self.__passphrase, keyfile=self.key_file)
-        else:
-            stratis.unlock_pool(self.pool_uuid, method="clevis")
 
 
 register_device_format(StratisBlockdev)

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -31,7 +31,7 @@ from ...errors import DeviceError, LUKSError
 from ...flags import flags
 from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
-from ...static_data import luks_data, stratis_info
+from ...static_data import luks_data
 
 import logging
 log = logging.getLogger("blivet")
@@ -95,27 +95,6 @@ class BITLKDevicePopulator(DevicePopulator):
 class LUKSFormatPopulator(FormatPopulator):
     priority = 100
     _type_specifier = "luks"
-
-    @classmethod
-    def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
-        if not super(LUKSFormatPopulator, cls).match(data, device):
-            return False
-
-        # locked stratis pools are managed in the StratisFormatPopulator
-        for pool in stratis_info.locked_pools:
-            if device.path in pool.devices:
-                return False
-
-        # unlocked stratis pools are also managed in the StratisFormatPopulator
-        holders = udev.device_get_holders(data)
-        if holders:
-            fs = udev.device_get_format(holders[0])
-            if fs == "stratis":
-                log.debug("ignoring LUKS format on %s, it appears to be an encrypted Stratis pool",
-                          device.name)
-                return False
-
-        return True
 
     def _get_kwargs(self):
         kwargs = super(LUKSFormatPopulator, self)._get_kwargs()

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -43,55 +43,12 @@ class StratisFormatPopulator(FormatPopulator):
     priority = 100
     _type_specifier = "stratis"
 
-    @classmethod
-    def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
-        if super(StratisFormatPopulator, cls).match(data, device):
-            return True
-
-        # encrypted pools blockdevs can have either LUKS or stratis signature
-        format_name = udev.device_get_format(data)
-        if format_name not in ("crypto_LUKS", "stratis"):
-            return False
-
-        # locked stratis pools are managed here
-        for pool in stratis_info.locked_pools:
-            if device.path in pool.devices:
-                return True
-
-        # unlocked old-style metadata encrypted pools are also managed here
-        if udev.device_get_format(data) == "crypto_LUKS":
-            holders = udev.device_get_holders(data)
-            if holders:
-                fs = udev.device_get_format(holders[0])
-                if fs == cls._type_specifier:
-                    return True
-
-        return False
-
-    def _get_blockdev_uuid(self):
-        if udev.device_get_format(self.data) == "crypto_LUKS":
-            holders = udev.device_get_holders(self.data)
-            if holders:
-                return udev.device_get_uuid(holders[0])
-
-        return udev.device_get_uuid(self.data)
-
     def _get_kwargs(self):
         kwargs = super(StratisFormatPopulator, self)._get_kwargs()
 
         name = udev.device_get_name(self.data)
-        uuid = self._get_blockdev_uuid()
+        uuid = udev.device_get_uuid(self.data)
         kwargs["uuid"] = uuid
-
-        # old-style stratis block device hosting an encrypted pool
-        kwargs["locked_pool"] = False
-        for pool in stratis_info.locked_pools:
-            if self.device.path in pool.devices:
-                kwargs["locked_pool"] = True
-                kwargs["pool_uuid"] = pool.uuid
-                kwargs["locked_pool_key_desc"] = pool.key_desc
-                kwargs["locked_pool_clevis_pin"] = pool.clevis
-                return kwargs
 
         bd_info = stratis_info.blockdevs.get(uuid)
         if bd_info:
@@ -229,8 +186,7 @@ class StratisFormatPopulator(FormatPopulator):
         log_method_call(self, pv=self.device.name)
         super(StratisFormatPopulator, self).run()
 
-        if not self.device.format.locked_pool:
-            self._add_pool_device()
+        self._add_pool_device()
 
 
 class StratisXFSFormatPopulator(FormatPopulator):

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -49,7 +49,6 @@ StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size"
 StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "used_size", "pool_name",
                                                              "pool_uuid", "object_path"])
 StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
-StratisLockedPoolInfo = namedtuple("StratisLockedPoolInfo", ["uuid", "key_desc", "clevis", "devices"])
 StratisStoppedPoolInfo = namedtuple("StratisStoppedPoolInfo", ["uuid", "name", "devices", "encrypted"])
 
 
@@ -149,37 +148,6 @@ class StratisInfo(object):
                                        pool_name=pool_name, pool_uuid=pool_info.uuid,
                                        object_path=blockdev_path)
 
-    def _get_locked_pools_info(self):
-        locked_pools = []
-
-        try:
-            proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF)
-            pools_info = proxy.LockedPools
-        except DBusError as e:
-            log.error("Failed to get list of locked Stratis pools: %s", str(e))
-            return locked_pools
-
-        for pool_uuid in pools_info.keys():
-            valid, (_err, description) = pools_info[pool_uuid]["key_description"]
-            if not valid:
-                log.info("Locked Stratis pool %s doesn't have a valid key description: %s", pool_uuid, description)
-                description = None
-            valid, (clevis_set, (pin, _options)) = pools_info[pool_uuid]["clevis_info"]
-            if not valid:
-                log.info("Locked Stratis pool %s doesn't have a valid clevis info", pool_uuid)
-                clevis = None
-            elif not clevis_set:
-                clevis = None
-            else:
-                clevis = pin
-            info = StratisLockedPoolInfo(uuid=pool_uuid,
-                                         key_desc=description,
-                                         clevis=clevis,
-                                         devices=[d["devnode"] for d in pools_info[pool_uuid]["devs"]])
-            locked_pools.append(info)
-
-        return locked_pools
-
     def _get_stopped_pools_info(self):
         stopped_pools = []
 
@@ -231,7 +199,6 @@ class StratisInfo(object):
         self._info_cache["pools"] = dict()
         self._info_cache["blockdevs"] = dict()
         self._info_cache["filesystems"] = dict()
-        self._info_cache["locked_pools"] = []
         self._info_cache["stopped_pools"] = []
 
         try:
@@ -263,7 +230,6 @@ class StratisInfo(object):
                 if bd_info:
                     self._info_cache["blockdevs"][bd_info.uuid] = bd_info
 
-        self._info_cache["locked_pools"] = self._get_locked_pools_info()
         self._info_cache["stopped_pools"] = self._get_stopped_pools_info()
 
     @property
@@ -286,13 +252,6 @@ class StratisInfo(object):
             self._get_stratis_info()
 
         return self._info_cache["blockdevs"]
-
-    @property
-    def locked_pools(self):
-        if self._info_cache is None:
-            self._get_stratis_info()
-
-        return self._info_cache["locked_pools"]
 
     @property
     def stopped_pools(self):

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -22,7 +22,9 @@
 import abc
 import shutil
 
-from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH
+from packaging.version import Version
+
+from ..devicelibs.stratis import STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF
 from .. import util
 
 import gi
@@ -298,13 +300,15 @@ class DBusMethod(Method):
 
     """ Methods for when application is actually a DBus service. """
 
-    def __init__(self, dbus_name, dbus_path):
+    def __init__(self, dbus_name, dbus_path, version_intf=None, version=None):
         """ Initializer.
 
             :param :class:`AppVersionInfo` version_info:
         """
         self.dbus_name = dbus_name
         self.dbus_path = dbus_path
+        self.version_intf = version_intf
+        self.version = version
         self._availability_errors = None
 
     def _service_available(self):
@@ -333,6 +337,13 @@ class DBusMethod(Method):
             else:
                 if not self._service_available():
                     return ["DBus service %s not available" % resource.name]
+        if self.version:
+            try:
+                proxy = util.SystemBus.get_proxy(self.dbus_name, self.dbus_path, self.version_intf)
+                if Version(str(proxy.Version)) < Version(self.version):
+                    return ["DBus service %s not available in required version" % resource.name]
+            except util.DBusError:
+                return ["Failed to get version for DBus service %s" % resource.name]
         return []
 
 
@@ -643,5 +654,5 @@ MULTIPATH_APP = application("multipath")
 STRATISPREDICTUSAGE_APP = application("stratis-predict-usage")
 
 # dbus services
-STRATIS_SERVICE_METHOD = DBusMethod(STRATIS_SERVICE, STRATIS_PATH)
+STRATIS_SERVICE_METHOD = DBusMethod(STRATIS_SERVICE, STRATIS_PATH, STRATIS_MANAGER_INTF, "3.8.0")
 STRATIS_DBUS = dbus_service("stratisd", STRATIS_SERVICE_METHOD)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python module for system storage configuration"
 readme = "README.md"
 license = {file = "COPYING"}
 requires-python = ">=3.9"
-dependencies = ["pyudev", "dasbus"]
+dependencies = ["pyudev", "dasbus", "packaging"]
 maintainers = [
   {name = "Vojtech Trefny", email = "vtrefny@redhat.com"}
 ]

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -2,7 +2,6 @@ import tempfile
 import unittest
 
 from ..storagetestcase import StorageTestCase
-from packaging.version import Version
 
 import blivet
 
@@ -24,10 +23,6 @@ class StratisTestCaseBase(StorageTestCase):
         super().setUp()
 
         self._blivet_setup()
-
-    def _get_stratis_version(self):
-        out = blivet.util.capture_output(["stratis", "--version"])
-        return Version(out)
 
     def _clean_up(self):
         self.storage.reset()
@@ -275,14 +270,6 @@ class StratisTestCase(StratisTestCaseBase):
         self.assertEqual(bd2.format.pool_uuid, pool.uuid)
 
     def test_stratis_pool_start_stop(self):
-        try:
-            stratis_version = self._get_stratis_version()
-        except (FileNotFoundError, OSError):
-            self.skipTest("stratis CLI not available")
-
-        if stratis_version < Version("3.8.0"):
-            self.skipTest("Stratis 3.8.0 or newer needed for start/stop support")
-
         disk1 = self.storage.devicetree.get_device_by_path(self.vdevs[0])
         self.assertIsNotNone(disk1)
         self.storage.initialize_disk(disk1)
@@ -353,9 +340,6 @@ class StratisTestCase(StratisTestCaseBase):
         pool.setup()
 
     def test_stratis_pool_start_stop_encrypted(self):
-        if self._get_stratis_version() < Version("3.8.0"):
-            self.skipTest("Stratis 3.8.0 or newer needed for start/stop support")
-
         disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
         self.assertIsNotNone(disk)
         self.storage.initialize_disk(disk)
@@ -563,12 +547,7 @@ class StratisGrowTestCase(StratisTestCaseBase):
 
         fs1 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS1")
         self.assertIsNotNone(fs1)
-        stratis_version = self._get_stratis_version()
-        if stratis_version <= Version("3.7.0"):
-            # older versions of stratis have smaller metadata
-            self.assertAlmostEqual(fs1.size, blivet.size.Size("3.44 GiB"), delta=blivet.size.Size("10 MiB"))
-        else:
-            self.assertAlmostEqual(fs1.size, blivet.size.Size("3.24 GiB"), delta=blivet.size.Size("10 MiB"))
+        self.assertAlmostEqual(fs1.size, blivet.size.Size("3.24 GiB"), delta=blivet.size.Size("10 MiB"))
 
         fs2 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS2")
         self.assertIsNotNone(fs2)
@@ -657,13 +636,7 @@ class StratisDeviceFactoryTestCase(StratisTestCaseBase):
         fs1 = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS1")
         self.assertIsNotNone(fs1)
         self.assertEqual(fs1.pool, pool)
-
-        stratis_version = self._get_stratis_version()
-        if stratis_version <= Version("3.7.0"):
-            # older versions of stratis have smaller metadata for encrypted pools
-            self.assertAlmostEqual(fs1.size, Size("9.5 GiB"), delta=Size("100 MiB"))
-        else:
-            self.assertAlmostEqual(fs1.size, Size("9 GiB"), delta=Size("100 MiB"))
+        self.assertAlmostEqual(fs1.size, Size("9 GiB"), delta=Size("100 MiB"))
 
     def test_factory_grow(self):
         disk1 = self.storage.devicetree.get_device_by_path(self.vdevs[0])


### PR DESCRIPTION
The Stratis medata v2 brough a big change for encrypted pools (LUKS format no longer being public) and supporting both old-style and new-style pools brings too many complications. We are not aiming to support old versions of stratis with new blivet so there is no reason to keep the old code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Stratis pool unlocking via the current DBus interface.
  * Added Stratis service version validation to ensure a supported DBus manager version is available.

* **Changes**
  * Removed legacy locked-pool and unlock-credential APIs, including related Stratis block device key-management capabilities.
  * Updated Stratis device discovery/population to treat pool devices consistently (including encrypted pools) without locked-pool-specific handling.

* **Bug Fixes**
  * Improved unlock failure reporting and post-unlock state refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->