### PR TITLE
Fix populating stratis filesystems for newly unlocked pools

### DIFF
--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -235,6 +235,17 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
     def _get_device_helper(self, info):
         return get_device_helper(info)
 
+    def _get_stratis_blockdev(self, info):
+        """ Traverses from a stratis DM device to the parent blockdev """
+        while True:
+            parents = udev.device_get_parents(info)
+            if not parents:
+                return
+            fs = udev.device_get_format(parents[0])
+            if fs == "stratis":
+                return udev.device_get_name(parents[0])
+            info = parents[0]
+
     def handle_device(self, info, update_orig_fmt=False):
         """
             :param :class:`pyudev.Device` info: udev info for the device
@@ -274,13 +285,15 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                       "corresponding stratis block device", name)
 
             # XXX for newly unlocked stratis pools we need to force run handle_format
-            # on one of the parent block devices to add the pool to the tree
-            parents = udev.device_get_parents(info)
-            if parents:
-                bname = udev.device_get_name(parents[0])
-                bdev = self.get_device_by_name(bname)
-                if bdev:
-                    self.handle_format(info, bdev, force=True)
+            # on one of the parent block devices to add the filesystems to the tree
+            bname = self._get_stratis_blockdev(info)
+            if not bname:
+                log.warning("failed to find stratis block device for %s", name)
+                return
+            bdev = self.get_device_by_name(bname)
+            if bdev:
+                bdev_info = udev.get_device(bdev.sysfs_path)
+                self.handle_format(bdev_info, bdev, force=True)
             return
 
         # make sure we note the name of every device we see

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -344,7 +344,7 @@ class StratisTestCase(StratisTestCaseBase):
         self.assertIsNotNone(disk)
         self.storage.initialize_disk(disk)
 
-        bd = self.storage.new_partition(size=blivet.size.Size("1 GiB"), fmt_type="stratis",
+        bd = self.storage.new_partition(size=blivet.size.Size("1.5 GiB"), fmt_type="stratis",
                                         parents=[disk])
         self.storage.create_device(bd)
 
@@ -353,6 +353,10 @@ class StratisTestCase(StratisTestCaseBase):
         pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd],
                                              encrypted=True, passphrase="fipsneeds8chars")
         self.storage.create_device(pool)
+
+        fs = self.storage.new_stratis_filesystem(name="blivetTestFS", parents=[pool],
+                                                 size=blivet.size.Size("512 MiB"))
+        self.storage.create_device(fs)
 
         self.storage.do_it()
         self.storage.reset()
@@ -365,6 +369,13 @@ class StratisTestCase(StratisTestCaseBase):
         pool.teardown()
         self.assertFalse(pool.status)
 
+        # reset to remove the filesystems (now invisible because the pool is locked)
+        self.storage.reset()
+        pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
+        self.assertIsNotNone(pool)
+        self.assertFalse(pool.status)
+        self.assertEqual(len(pool.children), 0)
+
         # setup won't work without passphrase
         with self.assertRaisesRegex(blivet.errors.StratisError, "Passphrase or key file must be set for encrypted Stratis pool setup"):
             pool.setup()
@@ -374,10 +385,18 @@ class StratisTestCase(StratisTestCaseBase):
         with self.assertRaisesRegex(blivet.errors.StratisError, "Operation not permitted"):
             pool.setup()
 
-        # coreect passphrase
+        # correct passphrase
         pool.passphrase = "fipsneeds8chars"
         pool.setup()
         self.assertTrue(pool.status)
+
+        # populate should add the filesystems to the devicetree
+        self.storage.devicetree.populate()
+        self.assertEqual(len(pool.children), 1)
+
+        fs = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS")
+        self.assertIsNotNone(fs)
+        self.assertListEqual(pool.children, [fs])
 
         # teardown again to test reset with stopped pool
         pool.teardown()


### PR DESCRIPTION
We need to force the populator to re-scan the stratis block devices to make sure running populate() adds the filesystems for newly unlocked pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of encrypted Stratis devices during storage discovery.
  * Prevented processing when the associated Stratis block device cannot be identified.

* **Tests**
  * Added coverage confirming encrypted Stratis filesystems disappear when locked and reappear correctly after unlocking and repopulating storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->