### PR TITLE
Do not try to get used size for stratis filesystems in stopped pools

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -372,7 +372,7 @@ class StratisFilesystemDevice(StorageDevice):
     @property
     def used_size(self):
         """ Size used by this filesystem in the pool """
-        if not self.exists:
+        if not self.exists or not self.pool.status:
             return devicelibs.stratis.filesystem_md_size(self.size)
         else:
             fs_info = stratis_info.get_filesystem_info(self.pool.name, self.fsname)


### PR DESCRIPTION
We don't have data for stopped pools so we can't get filesystem (used) size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem size reporting when a Stratis pool is unavailable or not running.
  * Preserved accurate used-size reporting when the pool and filesystem are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->