### PR TITLE
Add support for creating stratis filesystems with size limit

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -37,6 +37,7 @@ from .. import util
 STRATIS_SERVICE = "org.storage.stratis3"
 STRATIS_PATH = "/org/storage/stratis3"
 STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool.r1"
+STRATIS_POOL_INTF_R6 = STRATIS_SERVICE + ".pool.r6"
 STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem.r0"
 STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev.r0"
 STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r0"
@@ -249,7 +250,7 @@ def create_pool(name, devices, encrypted, passphrase, key_file, clevis, overprov
     stratis_info.drop_cache()
 
 
-def create_filesystem(name, pool_uuid, fs_size=None):
+def create_filesystem(name, pool_uuid, fs_size=None, size_limit=None):
     if not availability.STRATIS_DBUS.available:
         raise StratisError("Stratis DBus service not available")
 
@@ -265,9 +266,14 @@ def create_filesystem(name, pool_uuid, fs_size=None):
     else:
         size_opt = (False, "")
 
+    if size_limit:
+        limit_opt = (True, str(size_limit.get_bytes()))
+    else:
+        limit_opt = (False, "")
+
     try:
-        proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, pool_info.object_path, STRATIS_POOL_INTF)
-        ((succ, _paths), rc, err) = proxy.CreateFilesystems([(name, size_opt), ],
+        proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, pool_info.object_path, STRATIS_POOL_INTF_R6)
+        ((succ, _paths), rc, err) = proxy.CreateFilesystems([(name, size_opt, limit_opt), ],
                                                             timeout=STRATIS_CALL_TIMEOUT)
     except DBusError as e:
         raise StratisError("Failed to create stratis filesystem on '%s': %s" % (pool_info.name, str(e)))

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -316,11 +316,12 @@ class StratisFilesystemDevice(StorageDevice):
     _min_size = Size("512 MiB")
 
     def __init__(self, name, parents=None, size=None, uuid=None, exists=False,
-                 grow=None, maxsize=None):
+                 grow=None, maxsize=None, size_limit=None):
 
         self.req_grow = None
         self.req_max_size = Size(0)
         self.req_size = Size(0)
+        self.size_limit = size_limit
 
         if not exists and size is None and not parents[0]._overprovisioning:
             raise StratisError("size must be specified for stratis filesystems on non-overprovisioned pools")
@@ -343,6 +344,10 @@ class StratisFilesystemDevice(StorageDevice):
             self.req_grow = grow
             self.req_max_size = Size(util.numeric_type(maxsize))
             self.req_size = self._size
+
+        if not exists and size_limit and self.pool and \
+           any(fs for fs in self.pool.filesystems if fs.size_limit and fs is not self):
+            raise StratisError("only one filesystem in pool can have size limit set")
 
     def _get_name(self):
         """ This device's name. """
@@ -403,7 +408,7 @@ class StratisFilesystemDevice(StorageDevice):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
         devicelibs.stratis.create_filesystem(name=self.fsname, pool_uuid=self.pool.uuid,
-                                             fs_size=self.size)
+                                             fs_size=self.size, size_limit=self.size_limit)
 
     def _post_create(self):
         super(StratisFilesystemDevice, self)._post_create()

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -119,6 +119,7 @@ class StratisFormatPopulator(FormatPopulator):
 
             fs_device = StratisFilesystemDevice(fs_info.name, parents=[pool_device],
                                                 uuid=fs_info.uuid, size=STRATIS_FS_SIZE,
+                                                size_limit=fs_info.size_limit,
                                                 exists=True)
             self._devicetree._add_device(fs_device)
 

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -38,7 +38,7 @@ log = logging.getLogger("blivet")
 STRATIS_SERVICE = "org.storage.stratis3"
 STRATIS_PATH = "/org/storage/stratis3"
 STRATIS_POOL_INTF = STRATIS_SERVICE + ".pool.r1"
-STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem.r0"
+STRATIS_FILESYSTEM_INTF = STRATIS_SERVICE + ".filesystem.r6"
 STRATIS_BLOCKDEV_INTF = STRATIS_SERVICE + ".blockdev.r0"
 STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r0"
 STRATIS_MANAGER_INTF_R8 = STRATIS_SERVICE + ".Manager.r8"
@@ -46,8 +46,8 @@ STRATIS_MANAGER_INTF_R8 = STRATIS_SERVICE + ".Manager.r8"
 
 StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "physical_used", "object_path",
                                                  "encrypted", "clevis", "overprovisioning"])
-StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "used_size", "pool_name",
-                                                             "pool_uuid", "object_path"])
+StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "used_size", "size_limit",
+                                                             "pool_name", "pool_uuid", "object_path"])
 StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
 StratisStoppedPoolInfo = namedtuple("StratisStoppedPoolInfo", ["uuid", "name", "devices", "encrypted"])
 
@@ -120,8 +120,15 @@ class StratisInfo(object):
                         properties["Name"], used_size)
             used_size = 0
 
+        valid, size_limit = properties.get("SizeLimit",
+                                           (False, "SizeLimit not available"))
+        if not valid:
+            log.warning("Failed to get Stratis filesystem size limit for %s: %s",
+                        properties["Name"], size_limit)
+            size_limit = 0
+
         return StratisFilesystemInfo(name=properties["Name"], uuid=properties["Uuid"],
-                                     used_size=Size(used_size),
+                                     used_size=Size(used_size), size_limit=Size(size_limit),
                                      pool_name=pool_info.name, pool_uuid=pool_info.uuid,
                                      object_path=filesystem_path)
 

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -55,7 +55,8 @@ class StratisTestCase(StratisTestCaseBase):
         self.storage.create_device(pool)
 
         fs = self.storage.new_stratis_filesystem(name="blivetTestFS", parents=[pool],
-                                                 size=blivet.size.Size("512 MiB"))
+                                                 size=blivet.size.Size("512 MiB"),
+                                                 size_limit=blivet.size.Size("1 GiB"))
         self.storage.create_device(fs)
 
         self.storage.do_it()
@@ -88,6 +89,7 @@ class StratisTestCase(StratisTestCaseBase):
         self.assertEqual(fs.pool, pool)
         self.assertEqual(len(fs.parents), 1)
         self.assertEqual(fs.parents[0], pool)
+        self.assertEqual(fs.size_limit, Size("1 GiB"))
 
         # now try again but use entire free space in the pool
         self.storage.destroy_device(fs)

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -76,7 +76,7 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                     fs.create()
                     stratis_dbus.create_filesystem.assert_called_with(name="testfs",
                                                                       pool_uuid="c4fc9ebe-e173-4cab-8d81-cc6abddbe02d",
-                                                                      fs_size=Size("1 GiB"))
+                                                                      fs_size=Size("1 GiB"), size_limit=None)
 
     def test_new_encrypted_stratis(self):
         b = blivet.Blivet()
@@ -185,7 +185,7 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                     fs.create()
                     stratis_dbus.create_filesystem.assert_called_with(name="testfs",
                                                                       pool_uuid="c4fc9ebe-e173-4cab-8d81-cc6abddbe02d",
-                                                                      fs_size=Size("1 TiB"))
+                                                                      fs_size=Size("1 TiB"), size_limit=None)
 
     def test_device_id(self):
         bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-filesystem size limit support for Stratis filesystems.
  - Stratis now retrieves and reports filesystem size limits.
  - Filesystems can be created with or without an explicit size limit.
  - Enforces at most one size-limited filesystem per pool.
- **Bug Fixes**
  - When size-limit information is unavailable, a safe default is used.
- **Tests**
  - Updated Stratis tests to cover creating and validating size-limited filesystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->