### PR TITLE
Fix deadlock between blivet_lock and logging lock

### DIFF
--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -75,8 +75,8 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
     # deadlock when __str__ is called during logging format (which holds
     # the logging handler lock). These are safe to call without the lock
     # since they only read state and do not modify it.
-    _unsynchronized_methods = ['__str__', '_to_string', '_get_name',
-                               'type', '_get_parents', 'children']
+    _unsynchronized_methods = ['__str__', '_to_string', '_get_parents',
+                               'children']
 
     def __init__(self, name, parents=None):
         """
@@ -119,7 +119,7 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
 
     # Force str and unicode types in case type or name is unicode
     def _to_string(self):
-        s = "%s %s (%d)" % (self.type, self._get_name(), self.id)
+        s = "%s %s (%d)" % (self._type, self._name, self.id)
         return s
 
     def __str__(self):

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -71,6 +71,13 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
     _packages = []
     _external_dependencies = []
 
+    # Read-only methods/properties exempted from blivet_lock to prevent
+    # deadlock when __str__ is called during logging format (which holds
+    # the logging handler lock). These are safe to call without the lock
+    # since they only read state and do not modify it.
+    _unsynchronized_methods = ['__str__', '_to_string', '_get_name',
+                               'type', '_get_parents', 'children']
+
     def __init__(self, name, parents=None):
         """
             :param name: the device name (generally a device node's basename)
@@ -112,7 +119,7 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
 
     # Force str and unicode types in case type or name is unicode
     def _to_string(self):
-        s = "%s %s (%d)" % (self.type, self.name, self.id)
+        s = "%s %s (%d)" % (self.type, self._get_name(), self.id)
         return s
 
     def __str__(self):
@@ -155,6 +162,9 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
         self._init_parent_list()
         for parent in parents:
             self._parents.append(parent)
+
+    def _get_parents(self):
+        return self._parents[:]
 
     @property
     def children(self):

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -72,6 +72,9 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
         :class:`~.deviceaction.DeviceAction` instances can only be registered
         for leaf devices, except for resize actions.
     """
+
+    _unsynchronized_methods = ['__str__']
+
     def __init__(self, ignored_disks=None, exclusive_disks=None):
         """
             :keyword ignored_disks: ignored disks
@@ -122,7 +125,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                     s += show_subtree(child, depth + 1)
             return s
 
-        roots = [d for d in self._devices if not d.parents]
+        roots = [d for d in self._devices if not d._get_parents()]
         tree = ""
         for root in roots:
             tree += show_subtree(root, 0)


### PR DESCRIPTION
When installing openEuler via Anaconda, the process `python3 -m pyanaconda.modules.storage` can hang due to a classic lock ordering violation deadlock between two threads:

Thread 1 (D-Bus service):
  Holds blivet_lock -> waits for logging lock
  (get_device_by_name holds blivet_lock via the exclusive decorator,
  then calls log_method_call/log.debug which acquires the logging
  handler's lock)

Thread 2 (task worker):
  Holds logging lock -> waits for blivet_lock
  (device_matches calls log.debug which acquires the logging lock,
  then formats the message via msg % self.args, which triggers
  \_\_str\_\_ on a devicetree argument that internally calls run_with_lock
  to acquire blivet_lock)

The root cause is that SynchronizedMeta wraps ALL methods and properties with the exclusive decorator, including \_\_str\_\_ which is a read-only operation that does not modify any state. When the logging framework holds its lock and defers string formatting to emit time, calling \_\_str\_\_ on a DeviceTree/Device object acquires blivet_lock, creating a circular dependency with code that holds blivet_lock first and then logs.

Fix this by adding __str__ and its read-only call chain to _unsynchronized_methods for both DeviceTreeBase and Device, so that these methods do not acquire blivet_lock. This is safe because:

- All exempted methods/properties are purely read-only operations
- Write operations on properties (e.g. children, parents setters) are still called from within synchronized methods that already hold the lock
- The worst case without the lock is reading a slightly stale snapshot, which is acceptable for \_\_str\_\_ (used only for debugging/logging)

#1500 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented potential deadlocks when converting device details to strings and when rendering the device tree.
  * Improved reliability of device string details by consistently using safe access to device identity and relationship information.
  * Enhanced device tree rendering by more accurately detecting subtree roots based on current parent relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->