### PR TITLE
Make sure size for growable Stratis devices is at least 512 MiB

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -328,6 +328,11 @@ class StratisFilesystemDevice(StorageDevice):
         if size is None:
             size = devicelibs.stratis.STRATIS_FS_SIZE
 
+        if not exists and size < self._min_size and grow:
+            log.info("%s: adjusting size to %s (min size required by stratis filesystem; grow enabled)",
+                     name, self._min_size)
+            size = self._min_size
+
         # round size down to the nearest sector
         if not exists and size % LINUX_SECTOR_SIZE:
             log.info("%s: rounding size %s down to the nearest sector", name, size)

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -252,9 +252,14 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
         with patch("blivet.devicetree.DeviceTree.names", []):
             pool = b.new_stratis_pool(name="testpool", parents=[bd])
             fs1 = b.new_stratis_filesystem(name="testfs1", parents=[pool],
-                                           size=Size("1 GiB"), grow=True)
+                                           size=Size("512 MiB"), grow=True)
             fs2 = b.new_stratis_filesystem(name="testfs2", parents=[pool],
-                                           size=Size("1 GiB"), grow=True)
+                                           size=Size("1 MiB"), grow=True)
+
+        # requested size for fs2 was smaller than minimum, with grow=True, it should be
+        # automatically grown to min size (512 MiB) immediately
+        self.assertEqual(fs2.size, Size("512 MiB"))
+        self.assertEqual(fs2.req_size, Size("512 MiB"))
 
         b.create_device(pool)
         b.create_device(fs1)


### PR DESCRIPTION
We often use "--size 1 --grow" in kickstart and because min size for stratis is 512 MiB this can cause some issues with metadata size calculations which happen before the grow operation. So to fix things we'll just set the size to minimum for filesystems with req_grow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stratis filesystems created below the minimum supported size are now automatically increased to that minimum when growth is enabled.
  * Prevents undersized filesystem creation while preserving expected growth behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->