### PR TITLE
Do not allow grow with overprovisioning on Stratis

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -334,6 +334,9 @@ class StratisFilesystemDevice(StorageDevice):
         if not exists and size is None and not parents[0]._overprovisioning:
             raise StratisError("size must be specified for stratis filesystems on non-overprovisioned pools")
 
+        if not exists and grow and parents[0]._overprovisioning:
+            raise StratisError("cannot use grow for stratis filesystem on overprovisioned pool")
+
         if size is None:
             size = devicelibs.stratis.STRATIS_FS_SIZE
 

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -243,6 +243,21 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
 
     @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
     @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
+    def test_new_stratis_grow_overprovisioned(self, *args):  # pylint: disable=unused-argument,arguments-differ
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("10 GiB"), exists=False)
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd], overprovisioning=True)
+
+            with self.assertRaises(StratisError):
+                b.new_stratis_filesystem(name="testfs1", parents=[pool],
+                                         size=Size("1 GiB"), grow=True)
+
+    @patch("blivet.devicelibs.stratis.pool_used", return_value=Size(0))
+    @patch("blivet.devicelibs.stratis.filesystem_md_size", return_value=Size(0))
     def test_stratis_grow(self, *args):  # pylint: disable=unused-argument,arguments-differ
         b = blivet.Blivet()
         bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),


### PR DESCRIPTION
With overprovisioning enabled, requesting the filesystem size to grow automatically doesn't really makes sense, because there is no upper limit for the filesystem size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creation of grow-enabled filesystems on overprovisioned Stratis pools when available capacity is insufficient.
  * Added validation to report an error instead of allowing an invalid filesystem configuration.

* **Tests**
  * Added coverage for this constrained-capacity scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->