### PR TITLE
Add support for setting fslimit when creating stratis pools

### DIFF
--- a/blivet/devicelibs/stratis.py
+++ b/blivet/devicelibs/stratis.py
@@ -44,6 +44,7 @@ STRATIS_MANAGER_INTF = STRATIS_SERVICE + ".Manager.r0"
 STRATIS_MANAGER_INTF_R8 = STRATIS_SERVICE + ".Manager.r8"
 
 STRATIS_FS_SIZE = Size("1 TiB")
+STRATIS_FS_LIMIT_DEFAULT = 100
 
 STRATIS_CALL_TIMEOUT = 120 * 1000  # 120 s (used by stratis-cli by default) in ms
 
@@ -203,7 +204,8 @@ def unlock_pool(pool_uuid, method=None, passphrase=None, keyfile=None):
         stratis_info.drop_cache()
 
 
-def create_pool(name, devices, encrypted, passphrase, key_file, clevis, overprovisioning):
+def create_pool(name, devices, encrypted, passphrase, key_file, clevis, overprovisioning,
+                fs_limit=STRATIS_FS_LIMIT_DEFAULT):
     if not availability.STRATIS_DBUS.available:
         raise StratisError("Stratis DBus service not available")
 
@@ -245,6 +247,14 @@ def create_pool(name, devices, encrypted, passphrase, key_file, clevis, overprov
         proxy.Overprovisioning = overprovisioning  # pylint: disable=assigning-non-slot
     except DBusError as e:
         raise StratisError("Failed to enable overprovisioning on stratis pool: %s" % str(e))
+
+    if fs_limit and fs_limit != STRATIS_FS_LIMIT_DEFAULT:
+        try:
+            proxy = util.SystemBus.get_proxy(STRATIS_SERVICE, pool_path,
+                                             STRATIS_POOL_INTF)
+            proxy.FsLimit = fs_limit  # pylint: disable=assigning-non-slot
+        except DBusError as e:
+            raise StratisError("Failed to set filesystem limit on stratis pool: %s" % str(e))
 
     # repopulate the stratis info cache so the new pool will be added
     stratis_info.drop_cache()

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -66,12 +66,15 @@ class StratisPoolDevice(ContainerDevice):
             :type: StratisClevisConfig
             :keyword overprovisioning: whether overprovisioning is enabled for this pool or not
             :type overprovisioning: bool
+            :keyword fs_limit: maximum number of filesystems allowed in this pool
+            :type fs_limit: int
         """
         self._encrypted = kwargs.pop("encrypted", False)
         self.__passphrase = kwargs.pop("passphrase", None)
         self._key_file = kwargs.pop("key_file", None)
         self._clevis = kwargs.pop("clevis", None)
         self._overprovisioning = kwargs.pop("overprovisioning", False)
+        self._fs_limit = kwargs.pop("fs_limit", devicelibs.stratis.STRATIS_FS_LIMIT_DEFAULT)
 
         super(StratisPoolDevice, self).__init__(*args, **kwargs)
 
@@ -152,6 +155,17 @@ class StratisPoolDevice(ContainerDevice):
         self._overprovisioning = enabled
 
     @property
+    def fs_limit(self):
+        """ Maximum number of filesystems allowed in this pool """
+        return self._fs_limit
+
+    @fs_limit.setter
+    def fs_limit(self, new_limit):
+        if self.exists:
+            raise StratisError("Cannot set filesystem limit for existing Stratis pool %s" % self.name)
+        self._fs_limit = new_limit
+
+    @property
     def encrypted(self):
         """ True if this device is encrypted. """
         return self._encrypted
@@ -212,7 +226,8 @@ class StratisPoolDevice(ContainerDevice):
                                        passphrase=self.__passphrase,
                                        key_file=self._key_file,
                                        clevis=self._clevis,
-                                       overprovisioning=self._overprovisioning)
+                                       overprovisioning=self._overprovisioning,
+                                       fs_limit=self._fs_limit)
 
     def _post_create(self):
         self.exists = True

--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -151,7 +151,7 @@ class StratisPoolDevice(ContainerDevice):
     @overprovisioning.setter
     def overprovisioning(self, enabled):
         if self.exists:
-            raise StratisError("Cannot set %s overprovisioning for existing Stratis pool %s" % ("enable" if enabled else "disable", self.name))
+            raise StratisError("Cannot %s overprovisioning for existing Stratis pool %s" % ("enable" if enabled else "disable", self.name))
         self._overprovisioning = enabled
 
     @property

--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -97,7 +97,8 @@ class StratisFormatPopulator(FormatPopulator):
                                         exists=True,
                                         encrypted=pool_info.encrypted,
                                         clevis=clevis_info,
-                                        overprovisioning=pool_info.overprovisioning)
+                                        overprovisioning=pool_info.overprovisioning,
+                                        fs_limit=pool_info.fs_limit)
         self._devicetree._add_device(pool_device)
         return pool_device
 

--- a/blivet/static_data/stratis_info.py
+++ b/blivet/static_data/stratis_info.py
@@ -45,7 +45,7 @@ STRATIS_MANAGER_INTF_R8 = STRATIS_SERVICE + ".Manager.r8"
 
 
 StratisPoolInfo = namedtuple("StratisPoolInfo", ["name", "uuid", "physical_size", "physical_used", "object_path",
-                                                 "encrypted", "clevis", "overprovisioning"])
+                                                 "encrypted", "clevis", "overprovisioning", "fs_limit"])
 StratisFilesystemInfo = namedtuple("StratisFilesystemInfo", ["name", "uuid", "used_size", "size_limit",
                                                              "pool_name", "pool_uuid", "object_path"])
 StratisBlockdevInfo = namedtuple("StratisBlockdevInfo", ["path", "uuid", "pool_name", "pool_uuid", "object_path"])
@@ -101,7 +101,8 @@ class StratisInfo(object):
         return StratisPoolInfo(name=properties["Name"], uuid=properties["Uuid"],
                                physical_size=Size(pool_size), physical_used=Size(pool_used),
                                object_path=pool_path, encrypted=properties["Encrypted"],
-                               clevis=clevis, overprovisioning=properties["Overprovisioning"])
+                               clevis=clevis, overprovisioning=properties["Overprovisioning"],
+                               fs_limit=properties.get("FsLimit", 0))
 
     def _get_filesystem_info(self, filesystem_path):
         properties = _get_all_properties(filesystem_path, STRATIS_FILESYSTEM_INTF)

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -80,6 +80,7 @@ class StratisTestCase(StratisTestCaseBase):
         self.assertEqual(len(pool.parents), 1)
         self.assertEqual(pool.parents[0], bd)
         self.assertEqual(pool.overprovisioning, False)
+        self.assertEqual(pool.fs_limit, 100)
 
         fs = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS")
         self.assertIsNotNone(fs)
@@ -227,6 +228,27 @@ class StratisTestCase(StratisTestCaseBase):
         self.assertIsNotNone(fs)
         self.assertIsInstance(fs, blivet.devices.StratisFilesystemDevice)
         self.assertAlmostEqual(fs.size, blivet.size.Size("2 GiB"), delta=blivet.size.Size("10 MiB"))
+
+    def test_stratis_fs_limit(self):
+        disk = self.storage.devicetree.get_device_by_path(self.vdevs[0])
+        self.assertIsNotNone(disk)
+        self.storage.initialize_disk(disk)
+
+        bd = self.storage.new_partition(size=blivet.size.Size("1.5 GiB"), fmt_type="stratis",
+                                        parents=[disk])
+        self.storage.create_device(bd)
+
+        blivet.partitioning.do_partitioning(self.storage)
+
+        pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd], fs_limit=110)
+        self.storage.create_device(pool)
+
+        self.storage.do_it()
+        self.storage.reset()
+
+        pool = self.storage.devicetree.get_device_by_name("blivetTestPool")
+        self.assertIsNotNone(pool)
+        self.assertEqual(pool.fs_limit, 110)
 
     def test_stratis_add_device(self):
         disk1 = self.storage.devicetree.get_device_by_path(self.vdevs[0])

--- a/tests/unit_tests/devices_test/stratis_test.py
+++ b/tests/unit_tests/devices_test/stratis_test.py
@@ -65,7 +65,8 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 passphrase=None,
                                                                 key_file=None,
                                                                 clevis=None,
-                                                                overprovisioning=False)
+                                                                overprovisioning=False,
+                                                                fs_limit=100)
 
         # we would get this from pool._post_create
         pool.uuid = "c4fc9ebe-e173-4cab-8d81-cc6abddbe02d"
@@ -104,7 +105,8 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 passphrase="secret",
                                                                 key_file=None,
                                                                 clevis=None,
-                                                                overprovisioning=False)
+                                                                overprovisioning=False,
+                                                                fs_limit=100)
 
     def test_new_encrypted_stratis_clevis(self):
         b = blivet.Blivet()
@@ -133,7 +135,8 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 passphrase="secret",
                                                                 key_file=None,
                                                                 clevis=clevis,
-                                                                overprovisioning=False)
+                                                                overprovisioning=False,
+                                                                fs_limit=100)
 
     def test_new_stratis_no_size(self):
         b = blivet.Blivet()
@@ -174,7 +177,8 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                                                                 passphrase=None,
                                                                 key_file=None,
                                                                 clevis=None,
-                                                                overprovisioning=True)
+                                                                overprovisioning=True,
+                                                                fs_limit=100)
 
         # we would get this from pool._post_create
         pool.uuid = "c4fc9ebe-e173-4cab-8d81-cc6abddbe02d"
@@ -186,6 +190,33 @@ class BlivetNewStratisDeviceTest(unittest.TestCase):
                     stratis_dbus.create_filesystem.assert_called_with(name="testfs",
                                                                       pool_uuid="c4fc9ebe-e173-4cab-8d81-cc6abddbe02d",
                                                                       fs_size=Size("1 TiB"), size_limit=None)
+
+    def test_new_stratis_fs_limit(self):
+        b = blivet.Blivet()
+        bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),
+                           size=Size("2 GiB"), exists=False)
+
+        b.devicetree._add_device(bd)
+
+        with patch("blivet.devicetree.DeviceTree.names", []):
+            pool = b.new_stratis_pool(name="testpool", parents=[bd], fs_limit=200)
+        self.assertEqual(pool.name, "testpool")
+        self.assertEqual(pool.fs_limit, 200)
+
+        b.create_device(pool)
+
+        with patch("blivet.devicelibs.stratis") as stratis_dbus:
+            with patch.object(pool, "_pre_create"):
+                with patch.object(pool, "_post_create"):
+                    pool.create()
+                    stratis_dbus.create_pool.assert_called_with(name='testpool',
+                                                                devices=['/dev/bd1'],
+                                                                encrypted=False,
+                                                                passphrase=None,
+                                                                key_file=None,
+                                                                clevis=None,
+                                                                overprovisioning=False,
+                                                                fs_limit=200)
 
     def test_device_id(self):
         bd = StorageDevice("bd1", fmt=blivet.formats.get_format("stratis"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a filesystem limit when creating Stratis pools.
  * Stratis pool information now displays the configured filesystem limit.
  * Existing pools retain the default limit of 100 unless a custom value is specified.

* **Bug Fixes**
  * Errors encountered while applying a custom filesystem limit are now reported clearly.

* **Tests**
  * Added coverage for default and custom filesystem limits, including persistence and creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->