### PR TITLE
Fix ksdata for oveprovisioned stratis pools

### DIFF
--- a/blivet/devices/stratis.py
+++ b/blivet/devices/stratis.py
@@ -322,7 +322,7 @@ class StratisPoolDevice(ContainerDevice):
         data.blockdevs = ["stratis.%d" % p.id for p in self.parents]
         data.preexist = self.exists
         data.encrypted = self.encrypted
-        data.overprovision = self.overprovisioning
+        data.overprovisioning = self.overprovisioning
 
     def dracut_setup_args(self):
         return set(["stratis.rootfs.pool_uuid=%s" % self.uuid])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Stratis storage configuration export to preserve the overprovisioning setting in the expected field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->