### PR TITLE
Update properties for started stratis pools during populate

### DIFF
--- a/blivet/populator/helpers/stratis.py
+++ b/blivet/populator/helpers/stratis.py
@@ -166,6 +166,16 @@ class StratisFormatPopulator(FormatPopulator):
 
         return False
 
+    def _update_pool_info(self, pool):
+        pool_info = stratis_info.pools.get(pool.uuid)
+        if not pool_info:
+            log.warning("Failed to get information about Stratis pool %s (%s)",
+                        pool.name, pool.uuid)
+            return
+
+        pool._overprovisioning = pool_info.overprovisioning
+        pool._fs_limit = pool_info.fs_limit
+
     def _add_pool_device(self):
         bd_info = stratis_info.blockdevs.get(self.device.format.uuid)
         if not bd_info:
@@ -194,10 +204,14 @@ class StratisFormatPopulator(FormatPopulator):
                 return
 
             pool_device = self._devicetree.get_device_by_uuid(bd_info.pool_uuid)
-            if pool_device and self.device not in pool_device.parents:
-                pool_device.parents.append(self.device)
-                callbacks.parent_added(device=pool_device, parent=self.device)
-                return
+            if pool_device:
+                # update pool information for newly started pools
+                self._update_pool_info(pool_device)
+
+                if self.device not in pool_device.parents:
+                    pool_device.parents.append(self.device)
+                    callbacks.parent_added(device=pool_device, parent=self.device)
+                    return
             elif pool_device is None:
                 # started pool
                 pool_info = stratis_info.pools.get(bd_info.pool_uuid)

--- a/tests/storage_tests/devices_test/stratis_test.py
+++ b/tests/storage_tests/devices_test/stratis_test.py
@@ -375,7 +375,8 @@ class StratisTestCase(StratisTestCaseBase):
         blivet.partitioning.do_partitioning(self.storage)
 
         pool = self.storage.new_stratis_pool(name="blivetTestPool", parents=[bd],
-                                             encrypted=True, passphrase="fipsneeds8chars")
+                                             encrypted=True, passphrase="fipsneeds8chars",
+                                             overprovisioning=True)
         self.storage.create_device(pool)
 
         fs = self.storage.new_stratis_filesystem(name="blivetTestFS", parents=[pool],
@@ -414,9 +415,10 @@ class StratisTestCase(StratisTestCaseBase):
         pool.setup()
         self.assertTrue(pool.status)
 
-        # populate should add the filesystems to the devicetree
+        # populate should add the filesystems to the devicetree and update pool properties
         self.storage.devicetree.populate()
         self.assertEqual(len(pool.children), 1)
+        self.assertTrue(pool.overprovisioning)
 
         fs = self.storage.devicetree.get_device_by_name("blivetTestPool/blivetTestFS")
         self.assertIsNotNone(fs)


### PR DESCRIPTION
We can't get all information (like whether overprovisioning is enabled) for locked pools. So when the pool is unlocked and populate() is run we need to update some of the properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing Stratis pools now refresh their overprovisioning and filesystem limit settings when detected.
  * Stratis pool properties are preserved correctly after restarting and repopulating encrypted pools.

* **Tests**
  * Expanded coverage to verify filesystem discovery and overprovisioning preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->