### PR TITLE
misc: Use ansible_facts instead of deprecated top-level fact variables

### DIFF
--- a/misc/blivet-tasks.yml
+++ b/misc/blivet-tasks.yml
@@ -195,7 +195,7 @@
       - python3-pycodestyle
       - python3-yaml
       - targetcli-fb
-  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu' and test_dependencies|bool
+  when: (ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu') and test_dependencies|bool
 
 - name: Install libmount (Debian/Ubuntu)
   block:
@@ -211,4 +211,4 @@
 
 - name: Install pocketlint using pip (Debian/Ubuntu)
   pip: name=pocketlint executable=pip3 extra_args=--break-system-packages
-  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu' and test_dependencies|bool
+  when: (ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu') and test_dependencies|bool

--- a/misc/blivet-tasks.yml
+++ b/misc/blivet-tasks.yml
@@ -9,19 +9,19 @@
     name:
       - make
       - python3-ipython
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install dnf-plugins-core for dnf builddep (Fedora)
   package: name=dnf-plugins-core state=present
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install build dependencies (Fedora)
   command: "dnf -y builddep python3-blivet --nogpgcheck"
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install blivet to get all dependencies (Fedora)
   package: name=python3-blivet state=present
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install test dependencies (Fedora)
   package:
@@ -58,32 +58,32 @@
       - udftools
       - udisks2-iscsi
       - xfsprogs
-  when: ansible_distribution == 'Fedora' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'Fedora' and test_dependencies|bool
 
 ####### CentOS 9/10
 - name: Install basic build tools (CentOS)
   package: name=make state=present
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Enable EPEL repository (CentOS)
   package: name=epel-release state=present
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '9'
+  when: ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '9'
 
 - name: Install dnf-plugins-core for dnf config-manager and builddep (CentOS)
   package: name=dnf-plugins-core state=present
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Enable CRB repository (CentOS)
   command: dnf config-manager --set-enabled crb
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install build dependencies (CentOS)
   command: "dnf -y builddep python3-blivet --nogpgcheck"
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install blivet to get all dependencies (CentOS)
   package: name=python3-blivet state=present
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install test dependencies (CentOS)
   package:
@@ -114,7 +114,7 @@
       - targetcli
       - udisks2-iscsi
       - xfsprogs
-  when: ansible_distribution == 'CentOS' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and test_dependencies|bool
 
 - name: Install additional test dependencies (CentOS 9)
   package:
@@ -122,30 +122,30 @@
     name:
       - python3-coverage
       - python3-pycodestyle
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '9' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '9' and test_dependencies|bool
 
 - name: Install coverage and pycodestyle using pip (CentOS 10)
   pip:
     name: ['coverage', 'pycodestyle']
-  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '10' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '10' and test_dependencies|bool
 
 - name: Install paramiko using pip
   pip: name=paramiko executable=pip3
-  when: ansible_distribution == 'CentOS' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and test_dependencies|bool
 
 - name: Install pocketlint using pip (CentOS)
   pip: name=pocketlint executable=pip3
-  when: ansible_distribution == 'CentOS' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and test_dependencies|bool
 
 ####### Debian/Ubuntu
 - name: Update apt cache (Debian/Ubuntu)
   apt:
     update_cache: yes
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install basic build tools (Debian/Ubuntu)
   package: name=make state=present
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install dependencies (Debian/Ubuntu)
   package:
@@ -160,7 +160,7 @@
       - python3-pyudev
       - python3-parted
       - lvm2-dbusd
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install test dependencies (Debian/Ubuntu)
   package:
@@ -195,7 +195,7 @@
       - python3-pycodestyle
       - python3-yaml
       - targetcli-fb
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu' and test_dependencies|bool
 
 - name: Install libmount (Debian/Ubuntu)
   block:
@@ -207,8 +207,8 @@
 
     - name: Make and install libmount
       shell: "python3 /tmp/libmount_deb.py"
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install pocketlint using pip (Debian/Ubuntu)
   pip: name=pocketlint executable=pip3 extra_args=--break-system-packages
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu' and test_dependencies|bool


### PR DESCRIPTION
Ansible deprecated the injected top-level ansible_* fact variables (e.g. ansible_distribution) in favour of accessing them through the ansible_facts dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability when installing dependencies across Fedora, CentOS, Debian, and Ubuntu environments.
  * Improved operating system detection for more consistent setup behavior.
  * Debian and Ubuntu dependency installation now respects testing requirements consistently.
  * Preserved existing repository configuration and package installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->