### PR TITLE
fs: Fix filesystem type for temporary mounts

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -589,7 +589,7 @@ class FS(DeviceFormat):
             else:
                 options = "ro"
             try:
-                util.mount(device=self.device, mountpoint=tmpdir, fstype=self.type,
+                util.mount(device=self.device, mountpoint=tmpdir, fstype=self.mount_type,
                            options=options)
             except FSError as e:
                 log.debug("temp mount failed: %s", e)


### PR DESCRIPTION
We need to use "mount_type" for filesystems like Stratis where the type is "stratis xfs", but mount type is "xfs".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Temporary filesystem mounts now use the correct filesystem type.
  - Improves mounting reliability for filesystems whose mount type differs from their format type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->